### PR TITLE
BUG: CastSpatialObject filter moved to ITK, so remove install cmd

### DIFF
--- a/TubeTKLib/Filtering/CMakeLists.txt
+++ b/TubeTKLib/Filtering/CMakeLists.txt
@@ -28,7 +28,6 @@ set( TubeTKLib_Base_Filtering_H_Files
   itktubeAnisotropicEdgeEnhancementDiffusionImageFilter.h
   itktubeAnisotropicHybridDiffusionImageFilter.h
   itktubeBinaryThinningImageFilter3D.h
-  itktubeCastSpatialObjectFilter.h
   itktubeComputeTubeFlyThroughImageFilter.h
   itktubeComputeTubeMeasuresFilter.h
   itktubeContrastCostFunction.h


### PR DESCRIPTION
File is no longer part of ITKTubeTK, so we shouldn't list it.