### PR TITLE
BUG: Avoid error "include path too long: depth=1024"

### DIFF
--- a/include/MinimalPathExtractionExport.h
+++ b/include/MinimalPathExtractionExport.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #include "itkConfigure.h"
 // Workaround for ITKTubeTK Python package builds
 #if !defined(ITK_BUILD_SHARED_LIBS) && !defined(MinimalPathExtraction_EXPORT)


### PR DESCRIPTION
This file was being included multiple times during wrapping and
causing an error.   Added pragma to limit it to a single include.