### PR TITLE
ENH: Extended SeedMask capabilities to performed ordered extraction

### DIFF
--- a/include/tubeSegmentTubes.h
+++ b/include/tubeSegmentTubes.h
@@ -139,8 +139,22 @@ public:
 
   tubeWrapSetObjectMacro( SeedMask, TubeMaskImageType, Filter );
   tubeWrapGetConstObjectMacro( SeedMask, TubeMaskImageType, Filter );
+
   tubeWrapSetObjectMacro( SeedRadiusMask, ImageType, Filter );
   tubeWrapGetConstObjectMacro( SeedRadiusMask, ImageType, Filter );
+
+  tubeWrapSetMacro( UseSeedMaskAsProbabilities, bool, Filter );
+  tubeWrapGetMacro( UseSeedMaskAsProbabilities, bool, Filter );
+
+  tubeWrapSetMacro( SeedExtractionMinimumSuccessRatio, double, Filter );
+  tubeWrapGetMacro( SeedExtractionMinimumSuccessRatio, double, Filter );
+
+  tubeWrapSetMacro( SeedExtractionMinimumProbability, double, Filter );
+  tubeWrapGetMacro( SeedExtractionMinimumProbability, double, Filter );
+
+  tubeWrapSetMacro( SeedMaskMaximumNumberOfPoints, unsigned int, Filter );
+  tubeWrapGetMacro( SeedMaskMaximumNumberOfPoints, unsigned int, Filter );
+
   tubeWrapSetMacro( SeedMaskStride, int, Filter );
   tubeWrapGetMacro( SeedMaskStride, int, Filter );
 

--- a/src/Segmentation/itktubeTubeExtractor.h
+++ b/src/Segmentation/itktubeTubeExtractor.h
@@ -189,6 +189,11 @@ public:
    * Get the radius extractor */
   RadiusExtractorType * GetRadiusExtractor( void );
 
+  /** Set final ridge scale and radius values to the values specified rather
+   *   than optimize. */
+  itkSetMacro( OptimizeRadius, bool );
+  itkGetMacro( OptimizeRadius, bool );
+
 
   /***********/
   /***********/
@@ -213,9 +218,25 @@ public:
   itkSetConstObjectMacro( SeedMask, TubeMaskImageType );
   itkGetConstObjectMacro( SeedMask, TubeMaskImageType );
 
-  /** Set Seed Scale Image */
+  /** Set initial ridge scale and initial radius estimate based on these
+   *    the values in this image */
   itkSetConstObjectMacro( SeedRadiusMask, ImageType );
   itkGetConstObjectMacro( SeedRadiusMask, ImageType );
+
+  /** SeedMask is interpreted as ordered values for initiating 
+   *    seed extractions */
+  itkSetMacro( UseSeedMaskAsProbabilities, bool );
+  itkGetMacro( UseSeedMaskAsProbabilities, bool );
+
+  itkSetMacro( SeedExtractionMinimumSuccessRatio, double );
+  itkGetMacro( SeedExtractionMinimumSuccessRatio, double );
+
+  itkSetMacro( SeedExtractionMinimumProbability, double );
+  itkGetMacro( SeedExtractionMinimumProbability, double );
+
+  /** Set Seed Mask Stride */
+  itkSetMacro( SeedMaskMaximumNumberOfPoints, unsigned int );
+  itkGetMacro( SeedMaskMaximumNumberOfPoints, unsigned int );
 
   /** Set Seed Mask Stride */
   itkSetMacro( SeedMaskStride, int );
@@ -321,8 +342,14 @@ private:
   RadiusListType                      m_SeedRadiiInObjectSpaceList;
 
   typename TubeMaskImageType::ConstPointer m_SeedMask;
+  bool                                     m_UseSeedMaskAsProbabilities;
+  unsigned int                             m_SeedMaskMaximumNumberOfPoints;
+  double                                   m_SeedExtractionMinimumSuccessRatio;
+  double                                   m_SeedExtractionMinimumProbability;
   typename ImageType::ConstPointer         m_SeedRadiusMask;
   int                                      m_SeedMaskStride;
+
+  bool                                     m_OptimizeRadius;
 
 
 

--- a/src/Segmentation/itktubeTubeExtractor.hxx
+++ b/src/Segmentation/itktubeTubeExtractor.hxx
@@ -532,7 +532,7 @@ TubeExtractor<TInputImage>
             this->ExtractTubeInObjectSpace( pnt, count, verbose );
           if( !xTube.IsNull() )
             {
-            m_RidgeExtractor->DeleteTube<TubeMaskImageType>( xTube, tmpSeedMask );
+            m_RidgeExtractor->DeleteTube< typename TubeExtractor<TInputImage>::TubeMaskImageType >( xTube, tmpSeedMask );
             successRatio = (successRatio*9 + 1)/10;
             std::cout << "   Ridge size = " << xTube->GetNumberOfPoints()
               << std::endl;

--- a/src/Segmentation/itktubeTubeExtractor.hxx
+++ b/src/Segmentation/itktubeTubeExtractor.hxx
@@ -501,10 +501,10 @@ TubeExtractor<TInputImage>
     if( m_UseSeedMaskAsProbabilities )
       {
       typedef itk::ImageDuplicator<TubeMaskImageType> DuplicatorType;
-      DuplicatorType::Pointer duplicator = DuplicatorType::New();
+      typename DuplicatorType::Pointer duplicator = DuplicatorType::New();
       duplicator->SetInputImage(m_SeedMask);
       duplicator->Update();
-      TubeMaskImageType::Pointer tmpSeedMask = duplicator->GetOutput();
+      typename TubeMaskImageType::Pointer tmpSeedMask = duplicator->GetOutput();
       
       typedef itk::MinimumMaximumImageCalculator<TubeMaskImageType> MinMaxCalcType;
       typename MinMaxCalcType::Pointer maxCalc = MinMaxCalcType::New();

--- a/src/Segmentation/itktubeTubeExtractor.hxx
+++ b/src/Segmentation/itktubeTubeExtractor.hxx
@@ -532,7 +532,7 @@ TubeExtractor<TInputImage>
             this->ExtractTubeInObjectSpace( pnt, count, verbose );
           if( !xTube.IsNull() )
             {
-            m_RidgeExtractor->DeleteTube< typename TubeExtractor<TInputImage>::TubeMaskImageType >( xTube, tmpSeedMask );
+            m_RidgeExtractor->DeleteTube( xTube, tmpSeedMask.GetPointer() );
             successRatio = (successRatio*9 + 1)/10;
             std::cout << "   Ridge size = " << xTube->GetNumberOfPoints()
               << std::endl;


### PR DESCRIPTION
If a seedmask is treated "as probabilities" then the most probable vessels will be extracted first.   Stops after specified maximum number of extractions, when extraction failure rate gets too high, or when available maximum probability is too low.