### PR TITLE
ENH: Use evolutionary optimizer registration, even with initialization

### DIFF
--- a/src/Registration/itkImageToImageRegistrationHelper.hxx
+++ b/src/Registration/itkImageToImageRegistrationHelper.hxx
@@ -748,7 +748,7 @@ ImageToImageRegistrationHelper<TImage>
     typename RigidRegistrationMethodType::Pointer regRigid;
     regRigid = RigidRegistrationMethodType::New();
     regRigid->SetRandomNumberSeed( m_RandomNumberSeed );
-    if( m_EnableInitialRegistration || !m_UseEvolutionaryOptimization )
+    if( !m_UseEvolutionaryOptimization )
       {
       regRigid->SetUseEvolutionaryOptimization( false );
       }


### PR DESCRIPTION
Even if a registration initialization is provided, use the evolutionary
optimizer prior to gradient optimizer.