### PR TITLE
ENH: Remove cmake_minimum_requirements since ITK defines them.

### DIFF
--- a/CMake/FindNumPy.cmake
+++ b/CMake/FindNumPy.cmake
@@ -3,8 +3,6 @@
 # PYTHON_NUMPY_FOUND
 # will be set by this script
 
-cmake_minimum_required( VERSION 2.6 )
-
 if( NOT PYTHON_EXECUTABLE )
   if( NumPy_FIND_QUIETLY )
     find_package( PythonInterp QUIET )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,8 +19,6 @@
 # limitations under the License.
 #
 ##############################################################################
-cmake_minimum_required(VERSION 3.13.2)
-
 if(NOT ITK_SOURCE_DIR)
   include(itk-module-init.cmake)
 endif()


### PR DESCRIPTION
Removing these redundant min req specifications reduces warnings
rom CMake.