### PR TITLE
COMP: Add cmake_minimum_required to top level CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,8 @@
 # limitations under the License.
 #
 ##############################################################################
+cmake_minimum_required(VERSION 3.10.2)
+
 if(NOT ITK_SOURCE_DIR)
   include(itk-module-init.cmake)
 endif()


### PR DESCRIPTION
My review was wrong in #48 -- we do need `cmake_minimum_required` when building the modules as a separate project :man_shrugging: .

This should fix the Linux Python wrapping build.

Using version 3.10.2 because this is the current version required by ITK for compatibility with Linux distributions.