### PR TITLE
BUG: Specify ITK_DIR for SlicerExecutionModel in Linux and MacOS github workflows

### DIFF
--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -254,7 +254,8 @@ jobs:
         ln -s $(pwd)/ITKMinimalPathExtraction/ITKPythonPackage .
         ln -s $(pwd)/ITKMinimalPathExtraction/tools .
 
-        export ITK_DIR="${PWD}/ITK-build"
+        #  Can build SEM using any version of python wrapping
+        export ITK_DIR="/work/ITKPythonPackage/ITK-cp36-cp36m-manylinux2014_x64/"
         git clone https://github.com/Slicer/SlicerExecutionModel
         mkdir SlicerExecutionModel-build
         pushd SlicerExecutionModel-build
@@ -320,7 +321,8 @@ jobs:
         popd
         cp ITKMinimalPathExtraction/include/* include/
 
-        export ITK_DIR="${PWD}/ITK-build"
+        #  Can build SEM using any version of python wrapping
+        export ITK_DIR="/Users/svc-dashboard/D/P/ITKPythonPackage/ITK-3.6-macosx_x86_64/"
         git clone https://github.com/Slicer/SlicerExecutionModel
         mkdir SlicerExecutionModel-build
         pushd SlicerExecutionModel-build

--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -3,9 +3,9 @@ name: Build, test, package
 on: [push,pull_request]
 
 env:
-  ITKMinimalPathExtraction-git-tag: v1.1.2
-  itk-git-tag: "v5.2.0"
+  ITKMinimalPathExtraction-git-tag: v1.2.0
   vtk-git-tag: "1681cee3489800373c2e183af2d3ca8552e05940"
+  itk-git-tag: v5.2.0
 
 jobs:
   build-test-cxx:
@@ -29,12 +29,12 @@ jobs:
             cmake-build-type: "Release"
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
 
-    - name: Set up Python 3.7
-      uses: actions/setup-python@v1
+    - name: Set up Python 3.8
+      uses: actions/setup-python@v2
       with:
-        python-version: 3.7
+        python-version: 3.8
 
     - name: Set up OpenGL
       if: matrix.os == 'ubuntu-18.04'
@@ -195,13 +195,13 @@ jobs:
       shell: cmd
 
   build-linux-python-packages:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     strategy:
       max-parallel: 1
       matrix:
         python-version: [36, 37, 38, 39]
         include:
-          - itk-python-git-tag: "v5.2.0"
+          - itk-python-git-tag: "v5.2.0.post2"
             c-compiler: "gcc"
             cxx-compiler: "g++"
             cmake-build-type: "Release"
@@ -274,6 +274,7 @@ jobs:
       matrix:
         include:
           - itk-python-git-tag: "v5.2.0"
+          - itk-python-git-tag: "v5.2.0.post2"
             c-compiler: "clang"
             cxx-compiler: "clang++"
             cmake-build-type: "Release"
@@ -341,7 +342,7 @@ jobs:
       matrix:
         python-version-minor: [6, 7, 8, 9]
         include:
-          - itk-python-git-tag: "v5.2.0"
+          - itk-python-git-tag: "v5.2.0.post2"
             c-compiler: "cl.exe"
             cxx-compiler: "cl.exe"
             cmake-build-type: "Release"

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setup(
     keywords='ITK InsightToolkit',
     url=r'https://itk.org/',
     install_requires=[
-        r'itk>=5.2.0',
-        r'itk-minimalpathextraction>=1.1.2'
+        r'itk>=5.2.0.post2',
+        r'itk-minimalpathextraction>=1.2.0'
     ]
     )


### PR DESCRIPTION
SlicerExecutionModel requires ITK_DIR to be set as an environment variable.   This merge fixes those paths on Linux and MacOS