### PR TITLE
BUG: Searching for path for ITK_DIR for linux wheel building

### DIFF
--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -247,6 +247,7 @@ jobs:
         ln -s $(pwd)/ITKMinimalPathExtraction/tools .
 
     - name: 'Git-Configure-Build SEM'
+      shell: bash
       run: |
         cat > git-configure-build-sem.sh << EOF
         #!/bin/sh
@@ -285,6 +286,7 @@ jobs:
         /tmp/dockcross-manylinux-x64 -a "-v $PWD/ITKPythonPackage:/ITKPythonPackage" ./git-configure-build-sem.sh cp${{ matrix.python-version }}-cp${{ matrix.python-version }}
 
     - name: 'Git-Configure-Build VTK'
+      shell: bash
       run: |
         cat > git-configure-build-vtk.sh << EOF
         #!/bin/sh

--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -255,7 +255,7 @@ jobs:
         ln -s $(pwd)/ITKMinimalPathExtraction/tools .
 
         #  Can build SEM using any version of python wrapping
-        export ITK_DIR="/work/ITKPythonPackage/ITK-cp36-cp36m-manylinux2014_x64/"
+        export ITK_DIR=$(pwd)/ITKPythonPackage/ITK-cp36-cp36m-manylinux2014_x64
         git clone https://github.com/Slicer/SlicerExecutionModel
         mkdir SlicerExecutionModel-build
         pushd SlicerExecutionModel-build

--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -251,8 +251,11 @@ jobs:
         cat > git-configure-build-sem.sh << EOF
         #!/bin/sh
 
+        echo "1 = ${1}"
+        echo "2 = ${2}"
         export version=${1:-cp38-cp38}
         export ARCH=${2:-x64}
+        echo "version = ${version}"
         # remove trailing m
         export version=${version:0:9}
         echo "version = ${version}"
@@ -260,8 +263,8 @@ jobs:
         echo "itk_build_dir = ${itk_build_dir}"
         echo "Dir /work = "
         ls /work
-        echo "Dir /work/ITKPythonPackage = "
-        ls /work/ITKPythonPackage
+        echo "Dir /ITKPythonPackage = "
+        ls /ITKPythonPackage
         ln -fs /ITKPythonPackage/ITK-${version}*-manylinux2014_${ARCH} $itk_build_dir
 
         if [[ ! -d ${itk_build_dir} ]]; then

--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -251,11 +251,12 @@ jobs:
         cat > git-configure-build-sem.sh << EOF
         #!/bin/sh
 
-        version=${1:-cp38-cp38}
-        ARCH=${2:-x64}
+        export version=${1:-cp38-cp38}
+        export ARCH=${2:-x64}
 
-        version=${version:0:9}
-        itk_build_dir=/work/$(basename /ITKPythonPackage/ITK-${version}*-manylinux2014_${ARCH})
+        # remove trailing m
+        export version=${version:0:9}
+        export itk_build_dir=/work/$(basename /ITKPythonPackage/ITK-${version}*-manylinux2014_${ARCH})
         ln -fs /ITKPythonPackage/ITK-${version}*-manylinux2014_${ARCH} $itk_build_dir
 
         if [[ ! -d ${itk_build_dir} ]]; then

--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -233,16 +233,8 @@ jobs:
         curl -L https://raw.githubusercontent.com/InsightSoftwareConsortium/ITKPythonPackage/master/scripts/dockcross-manylinux-download-cache-and-build-module-wheels.sh -O
         chmod u+x dockcross-manylinux-download-cache-and-build-module-wheels.sh
 
-        git clone https://github.com/Kitware/VTK
-        pushd VTK
-        git checkout ${{env.vtk-git-tag}}
-        popd
-        mkdir VTK-build
-        pushd VTK-build
-        cmake -DCMAKE_C_COMPILER:FILEPATH="${{ matrix.c-compiler }}" -DBUILD_TESTING:BOOL=OFF -DBUILD_SHARED_LIBS:BOOL=OFF -DCMAKE_CXX_COMPILER="${{ matrix.cxx-compiler }}" -DCMAKE_BUILD_TYPE:STRING=${{ matrix.cmake-build-type }} -GNinja ../VTK
-        ninja
-        popd
-
+    - name: 'Build MinimalPathExtraction'
+      run: |
         export ITK_PACKAGE_VERSION=${{ matrix.itk-python-git-tag }}
         git clone https://github.com/InsightSoftwareConsortium/ITKMinimalPathExtraction
         mv ./dockcross-manylinux-download-cache-and-build-module-wheels.sh ./ITKMinimalPathExtraction
@@ -254,15 +246,63 @@ jobs:
         ln -s $(pwd)/ITKMinimalPathExtraction/ITKPythonPackage .
         ln -s $(pwd)/ITKMinimalPathExtraction/tools .
 
-        #  Can build SEM using any version of python wrapping
-        export ITK_DIR=$(pwd)/ITKPythonPackage/ITK-cp36-cp36m-manylinux2014_x64
-        git clone https://github.com/Slicer/SlicerExecutionModel
-        mkdir SlicerExecutionModel-build
-        pushd SlicerExecutionModel-build
-        cmake -DCMAKE_C_COMPILER:FILEPATH="${{ matrix.c-compiler }}" -DCMAKE_CXX_COMPILER="${{ matrix.cxx-compiler }}" -DCMAKE_BUILD_TYPE:STRING=${{ matrix.cmake-build-type }} -GNinja ../SlicerExecutionModel
-        ninja
-        popd
-        ./ITKPythonPackage/scripts/dockcross-manylinux-build-module-wheels.sh cp${{ matrix.python-version }}
+    - name: 'Git-Configure-Build SEM'
+      run: |
+        cat > git-configure-build-sem.sh << EOF
+          #!/bin/sh
+
+          version=${1:-cp38-cp38}
+          ARCH=${2:-x64}
+
+          version=${version:0:9}
+          itk_build_dir=/work/$(basename /ITKPythonPackage/ITK-${version}*-manylinux2014_${ARCH})
+          ln -fs /ITKPythonPackage/ITK-${version}*-manylinux2014_${ARCH} $itk_build_dir
+
+          if [[ ! -d ${itk_build_dir} ]]; then
+            echo 'ITK build tree not available!' 1>&2
+            exit 1
+          fi
+
+          git clone https://github.com/Slicer/SlicerExecutionModel
+          mkdir -p SlicerExecutionModel-build
+          cd SlicerExecutionModel-build
+          cmake \
+            -DCMAKE_BUILD_TYPE:STRING=Release \
+            -DITK_DIR:PATH=${itk_build_dir} \
+            -GNinja \
+            ../SlicerExecutionModel
+          ninja
+          EOF
+        chmod +x ./git-configure-build-sem.sh
+        # /tmp/dockcross-manylinux-x64 is created by the run of ./dockcross-manylinux-download-cache-and-build-module-wheels.sh
+        /tmp/dockcross-manylinux-x64 -a "-v $PWD/ITKPythonPackage:/ITKPythonPackage" ./git-configure-build-sem.sh
+
+    - name: 'Git-Configure-Build VTK'
+      run: |
+        cat > git-configure-build-vtk.sh << EOF
+          #!/bin/sh
+
+          git clone https://github.com/Kitware/VTK.git
+          cd VTK
+          git checkout ${{ env.vtk-git-tag }}
+          cd ..
+          mkdir -p VTK-build
+          cd VTK-build
+          cmake -DCMAKE_C_COMPILER:FILEPATH="${{ matrix.c-compiler }}" \
+                -DBUILD_TESTING:BOOL=OFF \
+                -DBUILD_SHARED_LIBS:BOOL=OFF \
+                -DCMAKE_CXX_COMPILER="${{ matrix.cxx-compiler }}" \
+                -DCMAKE_BUILD_TYPE:STRING=${{ matrix.cmake-build-type }} \
+                -GNinja \
+                ../VTK
+          ninja
+          EOF
+        chmod +x ./git-configure-build-vtk.sh
+        /tmp/dockcross-manylinux-x64 -a "-v $PWD/ITKPythonPackage:/ITKPythonPackage" ./git-configure-build-vtk.sh
+
+    - name: Build TubeTK package
+      run: |
+      ./ITKPythonPackage/scripts/dockcross-manylinux-build-module-wheels.sh cp${{ matrix.python-version }}
 
     - name: Publish Python package as GitHub Artifact
       uses: actions/upload-artifact@v1

--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -251,7 +251,7 @@ jobs:
       run: |
         cat > git-configure-build-sem.sh << EOF
         #!/bin/sh
-        ln -sf /work/ITK-cp36-cp36m-manlinux2014_x64 /ITKPythonPackage/ITK-cp36-cp36m-manylinux2014_x64
+        ln -sf /work/ITK-cp36-cp36m-manylinux2014_x64 /ITKPythonPackage/ITK-cp36-cp36m-manylinux2014_x64
         export ITK_DIR="/work/ITK-cp36-cp36m-manylinux2014_x64"
         git clone https://github.com/Slicer/SlicerExecutionModel
         mkdir -p SlicerExecutionModel-build

--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -251,12 +251,15 @@ jobs:
       run: |
         cat > git-configure-build-sem.sh << EOF
         #!/bin/sh
-        ln -sf /work/ITK-cp36-cp36m-manylinux2014_x64 /ITKPythonPackage/ITK-cp36-cp36m-manylinux2014_x64
+        ln -s -f -T /ITKPythonPackage/ITK-cp36-cp36m-manylinux2014_x64 /work/ITK-cp36-cp36m-manylinux2014_x64
         export ITK_DIR="/work/ITK-cp36-cp36m-manylinux2014_x64"
+        echo "itk_dir = ${ITK_DIR}"
+        ls -la /work
         git clone https://github.com/Slicer/SlicerExecutionModel
         mkdir -p SlicerExecutionModel-build
         cd SlicerExecutionModel-build
         cmake -DCMAKE_BUILD_TYPE:STRING=Release \
+          -DITK_DIR=/work/ITK-cp36-cp36m-manylinux2014_x64 \
           -GNinja \
           ../SlicerExecutionModel
         ninja

--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -252,27 +252,10 @@ jobs:
         cat > git-configure-build-sem.sh << EOF
         #!/bin/sh
 
-        echo "1 = ${1}"
-        echo "2 = ${2}"
-        export version=${1:-cp38-cp38}
-        export ARCH=${2:-x64}
-        echo "version = ${version}"
-        # remove trailing m
-        export version=${version:0:9}
-        echo "version = ${version}"
-        itk_build_dir=/work/$(basename /ITKPythonPackage/ITK-${version}*-manylinux2014_${ARCH})
-        echo "itk_build_dir = ${itk_build_dir}"
-        echo "Dir /work = "
-        ls /work
-        echo "Dir /ITKPythonPackage = "
-        ls /ITKPythonPackage
-        ln -fs /ITKPythonPackage/ITK-${version}*-manylinux2014_${ARCH} $itk_build_dir
-
-        if [[ ! -d ${itk_build_dir} ]]; then
-          echo 'ITK build tree not available!' 1>&2
-          exit 1
-        fi
-
+        export itk_build_dir=/work/ITKPythonPackage/ITK-cp36-cp36m-manylinux2014_x64
+        ln -fs /ITKPythonPackage/ITK-cp36-cp36m-manylinux2014_x64 ${itk_build_dir}
+        echo "ITK = ${itk_build_dir}"
+        ls ${itk_build_dir}
         git clone https://github.com/Slicer/SlicerExecutionModel
         mkdir -p SlicerExecutionModel-build
         cd SlicerExecutionModel-build
@@ -283,7 +266,7 @@ jobs:
         ninja
         EOF
         chmod +x ./git-configure-build-sem.sh
-        /tmp/dockcross-manylinux-x64 -a "-v $PWD/ITKPythonPackage:/ITKPythonPackage" ./git-configure-build-sem.sh cp${{ matrix.python-version }}-cp${{ matrix.python-version }}
+        /tmp/dockcross-manylinux-x64 -a "-v $PWD/ITKPythonPackage:/ITKPythonPackage" ./git-configure-build-sem.sh
 
     - name: 'Git-Configure-Build VTK'
       shell: bash
@@ -307,7 +290,7 @@ jobs:
         ninja
         EOF
         chmod +x ./git-configure-build-vtk.sh
-        /tmp/dockcross-manylinux-x64 -a "-v $PWD/ITKPythonPackage:/ITKPythonPackage" ./git-configure-build-vtk.sh cp${{ matrix.python-version }}-cp${{ matrix.python-version }}
+        /tmp/dockcross-manylinux-x64 -a "-v $PWD/ITKPythonPackage:/ITKPythonPackage" ./git-configure-build-vtk.sh
 
     - name: 'Build 🐍 Python 📦 package TubeTK'
       run: |

--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -251,15 +251,17 @@ jobs:
         cat > git-configure-build-sem.sh << EOF
         #!/bin/sh
 
-        version=${1:-cp38-cp38}
-        ARCH=${2:-x64}
+        export version=${1:-cp38-cp38}
+        export ARCH=${2:-x64}
         # remove trailing m
-        version=${version:0:9}
+        export version=${version:0:9}
         echo "version = ${version}"
         itk_build_dir=/work/$(basename /ITKPythonPackage/ITK-${version}*-manylinux2014_${ARCH})
         echo "itk_build_dir = ${itk_build_dir}"
         echo "Dir /work = "
         ls /work
+        echo "Dir /work/ITKPythonPackage = "
+        ls /work/ITKPythonPackage
         ln -fs /ITKPythonPackage/ITK-${version}*-manylinux2014_${ARCH} $itk_build_dir
 
         if [[ ! -d ${itk_build_dir} ]]; then

--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -251,11 +251,11 @@ jobs:
       run: |
         cat > git-configure-build-sem.sh << EOF
         #!/bin/sh
-
+        ln -sf /work/ITK-cp36-cp36m-manlinux2014_x64 /ITKPythonPackage/ITK-cp36-cp36m-manylinux2014_x64
+        export ITK_DIR="/work/ITK-cp36-cp36m-manylinux2014_x64"
         git clone https://github.com/Slicer/SlicerExecutionModel
         mkdir -p SlicerExecutionModel-build
         cd SlicerExecutionModel-build
-        export ITK_DIR="/ITKPythonPackage/ITK-cp36-cp36m-manylinux2014_x64"
         cmake -DCMAKE_BUILD_TYPE:STRING=Release \
           -GNinja \
           ../SlicerExecutionModel

--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -252,15 +252,10 @@ jobs:
         cat > git-configure-build-sem.sh << EOF
         #!/bin/sh
 
-        echo "Dir /ITKPythonPackage"
-        ls /ITKPythonPackage
-        echo "Dir /work"
-        ls /work
-        ln -fs /ITKPythonPackage/ITK-cp36-cp36m-manylinux2014_x64 /work/ITKPythonPackage/ITK-cp36-cp36m-manylinux2014_x64
         git clone https://github.com/Slicer/SlicerExecutionModel
         mkdir -p SlicerExecutionModel-build
         cd SlicerExecutionModel-build
-        export ITK_DIR="/work/ITKPythonPackage/ITK-cp36-cp36m-manylinux2014_x64"
+        export ITK_DIR="/ITKPythonPackage/ITK-cp36-cp36m-manylinux2014_x64"
         cmake -DCMAKE_BUILD_TYPE:STRING=Release \
           -GNinja \
           ../SlicerExecutionModel

--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -237,14 +237,14 @@ jobs:
       run: |
         export ITK_PACKAGE_VERSION=${{ matrix.itk-python-git-tag }}
         git clone https://github.com/InsightSoftwareConsortium/ITKMinimalPathExtraction
-        mv ./dockcross-manylinux-download-cache-and-build-module-wheels.sh ./ITKMinimalPathExtraction
+        cp ./dockcross-manylinux-download-cache-and-build-module-wheels.sh ./ITKMinimalPathExtraction
         pushd ITKMinimalPathExtraction
         git checkout ${{env.ITKMinimalPathExtraction-git-tag}}
         ./dockcross-manylinux-download-cache-and-build-module-wheels.sh cp${{ matrix.python-version }}
         popd
         cp ITKMinimalPathExtraction/include/* include/
-        ln -s $(pwd)/ITKMinimalPathExtraction/ITKPythonPackage .
-        ln -s $(pwd)/ITKMinimalPathExtraction/tools .
+        mv ./ITKMinimalPathExtraction/ITKPythonPackage .
+        mv ./ITKMinimalPathExtraction/tools .
 
     - name: 'Git-Configure-Build SEM'
       shell: bash
@@ -294,6 +294,7 @@ jobs:
 
     - name: 'Build 🐍 Python 📦 package TubeTK'
       run: |
+        export ITK_PACKAGE_VERSION=${{ matrix.itk-python-git-tag }}
         ./ITKPythonPackage/scripts/dockcross-manylinux-build-module-wheels.sh cp${{ matrix.python-version }}
 
     - name: Publish Python package as GitHub Artifact

--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -258,6 +258,7 @@ jobs:
         echo "version = ${version}"
         itk_build_dir=/work/$(basename /ITKPythonPackage/ITK-${version}*-manylinux2014_${ARCH})
         echo "itk_build_dir = ${itk_build_dir}"
+        echo "Dir /work = "
         ls /work
         ln -fs /ITKPythonPackage/ITK-${version}*-manylinux2014_${ARCH} $itk_build_dir
 

--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -252,6 +252,7 @@ jobs:
         cat > git-configure-build-sem.sh << EOF
         #!/bin/sh
         ln -s -f -T /ITKPythonPackage/ITK-cp36-cp36m-manylinux2014_x64 /work/ITK-cp36-cp36m-manylinux2014_x64
+        ln -s -f -T /ITKPythonPackage/ITK-source /work/ITK-source
         export ITK_DIR="/work/ITK-cp36-cp36m-manylinux2014_x64"
         echo "itk_dir = ${ITK_DIR}"
         ls -la /work

--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -251,12 +251,14 @@ jobs:
         cat > git-configure-build-sem.sh << EOF
         #!/bin/sh
 
-        export version=${1:-cp38-cp38}
-        export ARCH=${2:-x64}
-
+        version=${1:-cp38-cp38}
+        ARCH=${2:-x64}
         # remove trailing m
-        export version=${version:0:9}
-        export itk_build_dir=/work/$(basename /ITKPythonPackage/ITK-${version}*-manylinux2014_${ARCH})
+        version=${version:0:9}
+        echo "version = ${version}"
+        itk_build_dir=/work/$(basename /ITKPythonPackage/ITK-${version}*-manylinux2014_${ARCH})
+        echo "itk_build_dir = ${itk_build_dir}"
+        ls /work
         ln -fs /ITKPythonPackage/ITK-${version}*-manylinux2014_${ARCH} $itk_build_dir
 
         if [[ ! -d ${itk_build_dir} ]]; then

--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -252,12 +252,16 @@ jobs:
         cat > git-configure-build-sem.sh << EOF
         #!/bin/sh
 
+        echo "Dir /ITKPythonPackage"
+        ls /ITKPythonPackage
+        echo "Dir /work"
+        ls /work
         ln -fs /ITKPythonPackage/ITK-cp36-cp36m-manylinux2014_x64 /work/ITKPythonPackage/ITK-cp36-cp36m-manylinux2014_x64
         git clone https://github.com/Slicer/SlicerExecutionModel
         mkdir -p SlicerExecutionModel-build
         cd SlicerExecutionModel-build
+        export ITK_DIR="/work/ITKPythonPackage/ITK-cp36-cp36m-manylinux2014_x64"
         cmake -DCMAKE_BUILD_TYPE:STRING=Release \
-          -DITK_DIR:PATH=/work/ITKPythonPackage/ITK-cp36-cp36m-manylinux2014_x64 \
           -GNinja \
           ../SlicerExecutionModel
         ninja

--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -233,7 +233,7 @@ jobs:
         curl -L https://raw.githubusercontent.com/InsightSoftwareConsortium/ITKPythonPackage/master/scripts/dockcross-manylinux-download-cache-and-build-module-wheels.sh -O
         chmod u+x dockcross-manylinux-download-cache-and-build-module-wheels.sh
 
-    - name: 'Build MinimalPathExtraction'
+    - name: 'Git-Configure-Build MinimalPathExtraction'
       run: |
         export ITK_PACKAGE_VERSION=${{ matrix.itk-python-git-tag }}
         git clone https://github.com/InsightSoftwareConsortium/ITKMinimalPathExtraction
@@ -300,9 +300,9 @@ jobs:
         chmod +x ./git-configure-build-vtk.sh
         /tmp/dockcross-manylinux-x64 -a "-v $PWD/ITKPythonPackage:/ITKPythonPackage" ./git-configure-build-vtk.sh
 
-    - name: Build TubeTK package
+    - name: 'Build 🐍 Python 📦 package TubeTK'
       run: |
-      ./ITKPythonPackage/scripts/dockcross-manylinux-build-module-wheels.sh cp${{ matrix.python-version }}
+        ./ITKPythonPackage/scripts/dockcross-manylinux-build-module-wheels.sh cp${{ matrix.python-version }}
 
     - name: Publish Python package as GitHub Artifact
       uses: actions/upload-artifact@v1
@@ -338,7 +338,7 @@ jobs:
         curl -L https://raw.githubusercontent.com/InsightSoftwareConsortium/ITKPythonPackage/master/scripts/macpython-download-cache-and-build-module-wheels.sh -O
         chmod u+x macpython-download-cache-and-build-module-wheels.sh
 
-    - name: 'Build 🐍 Python 📦 package'
+    - name: 'Git-Configure-Build VTK'
       run: |
         export ITK_PACKAGE_VERSION=${{ matrix.itk-python-git-tag }}
         export MACOSX_DEPLOYMENT_TARGET=10.9
@@ -351,7 +351,11 @@ jobs:
         pushd VTK-build
         cmake -DCMAKE_C_COMPILER:FILEPATH="${{ matrix.c-compiler }}" -DBUILD_TESTING:BOOL=OFF -DBUILD_SHARED_LIBS:BOOL=OFF -DCMAKE_CXX_COMPILER="${{ matrix.cxx-compiler }}" -DCMAKE_BUILD_TYPE:STRING=${{ matrix.cmake-build-type }} -GNinja ../VTK
         ninja
-        popd
+
+    - name: 'Git-Configure-Build MinimalPathExtraction'
+      run: |
+        export ITK_PACKAGE_VERSION=${{ matrix.itk-python-git-tag }}
+        export MACOSX_DEPLOYMENT_TARGET=10.9
 
         git clone https://github.com/InsightSoftwareConsortium/ITKMinimalPathExtraction
         cp ./macpython-download-cache-and-build-module-wheels.sh ITKMinimalPathExtraction/
@@ -361,6 +365,11 @@ jobs:
         popd
         cp ITKMinimalPathExtraction/include/* include/
 
+    - name: 'Git-Configure-Build SEM'
+      run: |
+        export ITK_PACKAGE_VERSION=${{ matrix.itk-python-git-tag }}
+        export MACOSX_DEPLOYMENT_TARGET=10.9
+
         #  Can build SEM using any version of python wrapping
         export ITK_DIR="/Users/svc-dashboard/D/P/ITKPythonPackage/ITK-3.6-macosx_x86_64/"
         git clone https://github.com/Slicer/SlicerExecutionModel
@@ -368,7 +377,11 @@ jobs:
         pushd SlicerExecutionModel-build
         cmake -DCMAKE_C_COMPILER:FILEPATH="${{ matrix.c-compiler }}" -DCMAKE_CXX_COMPILER="${{ matrix.cxx-compiler }}" -DCMAKE_BUILD_TYPE:STRING=${{ matrix.cmake-build-type }} -GNinja ../SlicerExecutionModel
         ninja
-        popd
+
+    - name: 'Build 🐍 Python 📦 package TubeTK'
+      run: |
+        export ITK_PACKAGE_VERSION=${{ matrix.itk-python-git-tag }}
+        export MACOSX_DEPLOYMENT_TARGET=10.9
 
         /Users/svc-dashboard/D/P/ITKPythonPackage/scripts/macpython-build-module-wheels.sh
 

--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -249,56 +249,54 @@ jobs:
     - name: 'Git-Configure-Build SEM'
       run: |
         cat > git-configure-build-sem.sh << EOF
-          #!/bin/sh
+        #!/bin/sh
 
-          version=${1:-cp38-cp38}
-          ARCH=${2:-x64}
+        version=${1:-cp38-cp38}
+        ARCH=${2:-x64}
 
-          version=${version:0:9}
-          itk_build_dir=/work/$(basename /ITKPythonPackage/ITK-${version}*-manylinux2014_${ARCH})
-          ln -fs /ITKPythonPackage/ITK-${version}*-manylinux2014_${ARCH} $itk_build_dir
+        version=${version:0:9}
+        itk_build_dir=/work/$(basename /ITKPythonPackage/ITK-${version}*-manylinux2014_${ARCH})
+        ln -fs /ITKPythonPackage/ITK-${version}*-manylinux2014_${ARCH} $itk_build_dir
 
-          if [[ ! -d ${itk_build_dir} ]]; then
-            echo 'ITK build tree not available!' 1>&2
-            exit 1
-          fi
+        if [[ ! -d ${itk_build_dir} ]]; then
+          echo 'ITK build tree not available!' 1>&2
+          exit 1
+        fi
 
-          git clone https://github.com/Slicer/SlicerExecutionModel
-          mkdir -p SlicerExecutionModel-build
-          cd SlicerExecutionModel-build
-          cmake \
-            -DCMAKE_BUILD_TYPE:STRING=Release \
-            -DITK_DIR:PATH=${itk_build_dir} \
-            -GNinja \
-            ../SlicerExecutionModel
-          ninja
-          EOF
+        git clone https://github.com/Slicer/SlicerExecutionModel
+        mkdir -p SlicerExecutionModel-build
+        cd SlicerExecutionModel-build
+        cmake -DCMAKE_BUILD_TYPE:STRING=Release \
+          -DITK_DIR:PATH=${itk_build_dir} \
+          -GNinja \
+          ../SlicerExecutionModel
+        ninja
+        EOF
         chmod +x ./git-configure-build-sem.sh
-        # /tmp/dockcross-manylinux-x64 is created by the run of ./dockcross-manylinux-download-cache-and-build-module-wheels.sh
-        /tmp/dockcross-manylinux-x64 -a "-v $PWD/ITKPythonPackage:/ITKPythonPackage" ./git-configure-build-sem.sh
+        /tmp/dockcross-manylinux-x64 -a "-v $PWD/ITKPythonPackage:/ITKPythonPackage" ./git-configure-build-sem.sh cp${{ matrix.python-version }}-cp${{ matrix.python-version }}
 
     - name: 'Git-Configure-Build VTK'
       run: |
         cat > git-configure-build-vtk.sh << EOF
-          #!/bin/sh
+        #!/bin/sh
 
-          git clone https://github.com/Kitware/VTK.git
-          cd VTK
-          git checkout ${{ env.vtk-git-tag }}
-          cd ..
-          mkdir -p VTK-build
-          cd VTK-build
-          cmake -DCMAKE_C_COMPILER:FILEPATH="${{ matrix.c-compiler }}" \
-                -DBUILD_TESTING:BOOL=OFF \
-                -DBUILD_SHARED_LIBS:BOOL=OFF \
-                -DCMAKE_CXX_COMPILER="${{ matrix.cxx-compiler }}" \
-                -DCMAKE_BUILD_TYPE:STRING=${{ matrix.cmake-build-type }} \
-                -GNinja \
-                ../VTK
-          ninja
-          EOF
+        git clone https://github.com/Kitware/VTK.git
+        cd VTK
+        git checkout ${{ env.vtk-git-tag }}
+        cd ..
+        mkdir -p VTK-build
+        cd VTK-build
+        cmake -DCMAKE_C_COMPILER:FILEPATH="${{ matrix.c-compiler }}" \
+              -DBUILD_TESTING:BOOL=OFF \
+              -DBUILD_SHARED_LIBS:BOOL=OFF \
+              -DCMAKE_CXX_COMPILER="${{ matrix.cxx-compiler }}" \
+              -DCMAKE_BUILD_TYPE:STRING=${{ matrix.cmake-build-type }} \
+              -GNinja \
+              ../VTK
+        ninja
+        EOF
         chmod +x ./git-configure-build-vtk.sh
-        /tmp/dockcross-manylinux-x64 -a "-v $PWD/ITKPythonPackage:/ITKPythonPackage" ./git-configure-build-vtk.sh
+        /tmp/dockcross-manylinux-x64 -a "-v $PWD/ITKPythonPackage:/ITKPythonPackage" ./git-configure-build-vtk.sh cp${{ matrix.python-version }}-cp${{ matrix.python-version }}
 
     - name: 'Build 🐍 Python 📦 package TubeTK'
       run: |

--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -252,15 +252,12 @@ jobs:
         cat > git-configure-build-sem.sh << EOF
         #!/bin/sh
 
-        export itk_build_dir=/work/ITKPythonPackage/ITK-cp36-cp36m-manylinux2014_x64
-        ln -fs /ITKPythonPackage/ITK-cp36-cp36m-manylinux2014_x64 ${itk_build_dir}
-        echo "ITK = ${itk_build_dir}"
-        ls ${itk_build_dir}
+        ln -fs /ITKPythonPackage/ITK-cp36-cp36m-manylinux2014_x64 /work/ITKPythonPackage/ITK-cp36-cp36m-manylinux2014_x64
         git clone https://github.com/Slicer/SlicerExecutionModel
         mkdir -p SlicerExecutionModel-build
         cd SlicerExecutionModel-build
         cmake -DCMAKE_BUILD_TYPE:STRING=Release \
-          -DITK_DIR:PATH=${itk_build_dir} \
+          -DITK_DIR:PATH=/work/ITKPythonPackage/ITK-cp36-cp36m-manylinux2014_x64 \
           -GNinja \
           ../SlicerExecutionModel
         ninja


### PR DESCRIPTION
With the inclusion of SlicerExecutionModel to build applications as part of the TubeTK wheels, it is necessary to set ITK_DIR to build SlicerExecutionModel.

Deciphering the scripts used to build the wheels in an attempt to determine ITK_DIR.