### PR TITLE
ENH: Add apt-get update to remove stale repos

### DIFF
--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -39,6 +39,7 @@ jobs:
     - name: Set up OpenGL
       if: matrix.os == 'ubuntu-18.04'
       run: |
+        sudo apt-get update
         sudo apt-get install -y libglu1-mesa-dev mesa-common-dev
         sudo apt-get install -y libgl1-mesa-glx
         sudo apt-get install -y libglvnd-core-dev


### PR DESCRIPTION
Err:12 http://security.ubuntu.com/ubuntu bionic-updates/main amd64
libx11-xcb-dev amd64 2:1.6.4-3ubuntu0.3
  404  Not Found [IP: 52.147.219.192 80]
  Fetched 1618 kB in 0s (14.1 MB/s)
  E: Failed to fetch
  http://security.ubuntu.com/ubuntu/pool/main/libx/libx11/libx11-xcb-dev_1.6.4-3ubuntu0.3_amd64.deb
  404  Not Found [IP: 52.147.219.192 80]
  E: Unable to fetch some archives, maybe run apt-get update or try with
  --fix-missing?