### PR TITLE
BUG: Fix landmark registration to use versorrigid3dtransform

### DIFF
--- a/examples/Applications/RegisterImages/RegisterImages.cxx
+++ b/examples/Applications/RegisterImages/RegisterImages.cxx
@@ -2,8 +2,7 @@
 
 Library:   TubeTK
 
-Copyright 2010 Kitware Inc. 28 Corporate Drive,
-Clifton Park, NY, 12065, USA.
+Copyright Kitware Inc.
 
 All rights reserved.
 
@@ -91,16 +90,6 @@ int DoIt( int argc, char * argv[] )
       }
     }
 
-  if( fixedLandmarks.size() > 1 || movingLandmarks.size() > 1 )
-    {
-    if( initialization != "Landmarks" )
-      {
-      std::cout << "WARNING: Landmarks specified, but initialization "
-                << "process was not told to use landmarks. " << std::endl;
-      std::cout << "Changing initialization to use landmarks." << std::endl;
-      reger->SetInitialMethodEnum( RegistrationType::INIT_WITH_LANDMARKS );
-      }
-    }
   if( skipInitialRandomSearch )
     {
     reger->SetUseEvolutionaryOptimization( false );
@@ -110,8 +99,19 @@ int DoIt( int argc, char * argv[] )
     reger->SetUseEvolutionaryOptimization( true );
     }
 
-  if( initialization == "Landmarks" )
+  if( fixedLandmarks.size() > 0 || movingLandmarks.size() > 0 )
     {
+    if( initialization != "Landmarks" )
+      {
+      std::cout << "WARNING: Landmarks specified, but initialization "
+                << "process was not told to use landmarks. " << std::endl;
+      std::cout << "Changing initialization to use landmarks." << std::endl;
+      }
+    if( verbosity >= STANDARD )
+      {
+      std::cout << "###Initialization: Landmarks" << std::endl;
+      }
+    initialization = "Landmarks";
     reger->SetInitialMethodEnum( RegistrationType::INIT_WITH_LANDMARKS );
     reger->SetFixedLandmarks( fixedLandmarks );
     reger->SetMovingLandmarks( movingLandmarks );

--- a/examples/Applications/RegisterImages/RegisterImages.xml
+++ b/examples/Applications/RegisterImages/RegisterImages.xml
@@ -223,6 +223,7 @@
       <description>Ordered list of landmarks in the fixed image</description>
       <label>Fixed landmarks</label>
       <longflag>fixedLandmarks</longflag>
+      <flag>f</flag>
       <default/>
     </point>
     <point multiple="true">
@@ -230,6 +231,7 @@
       <description>Ordered list of landmarks in the moving image</description>
       <label>Moving landmarks</label>
       <longflag>movingLandmarks</longflag>
+      <flag>m</flag>
       <default/>
     </point>
   </parameters>

--- a/src/Registration/itkAnisotropicSimilarityLandmarkBasedTransformInitializer.h
+++ b/src/Registration/itkAnisotropicSimilarityLandmarkBasedTransformInitializer.h
@@ -21,6 +21,7 @@
 #include "itkObjectFactory.h"
 #include "itkAnisotropicSimilarity3DTransform.h"
 #include "itkRigid2DTransform.h"
+#include "itkVersorRigid3DTransform.h"
 #include <vector>
 #include <iostream>
 
@@ -151,6 +152,7 @@ public:
   /**  Supported Transform typedefs */
   typedef AnisotropicSimilarity3DTransform<ParameterValueType>
   AnisotropicSimilarity3DTransformType;
+  typedef VersorRigid3DTransform<ParameterValueType> VersorRigid3DTransformType;
   typedef Rigid2DTransform<ParameterValueType> Rigid2DTransformType;
 
   /** Initialize the transform from the landmarks */
@@ -168,7 +170,8 @@ protected:
   typedef enum
     {
     AnisotropicSimilarity3Dtransform = 1,
-    Rigid2Dtransfrom,
+    VersorRigid3Dtransform,
+    Rigid2Dtransform,
     Else
     } InputTransformType;
 private:

--- a/src/Registration/itkInitialImageToImageRegistrationMethod.hxx
+++ b/src/Registration/itkInitialImageToImageRegistrationMethod.hxx
@@ -1,17 +1,22 @@
 /*=========================================================================
 
-  Program:   Insight Segmentation & Registration Toolkit
-  Module:    $RCSfile: MomentRegistrator.txx,v $
-  Language:  C++
-  Date:      $Date: 2007/03/29 17:52:55 $
-  Version:   $Revision: 1.6 $
+Library:   TubeTK
 
-  Copyright (c) Insight Software Consortium. All rights reserved.
-  See ITKCopyright.txt or http://www.itk.org/HTML/Copyright.htm for details.
+Copyright Kitware Inc.
 
-     This software is distributed WITHOUT ANY WARRANTY; without even
-     the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
-     PURPOSE.  See the above copyright notices for more information.
+All rights reserved.
+
+Licensed under the Apache License, Version 2.0 ( the "License" );
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
 
 =========================================================================*/
 
@@ -67,7 +72,7 @@ InitialImageToImageRegistrationMethod<TImage>
 
     if( TImage::ImageDimension == 3 )
       {
-      typedef AnisotropicSimilarity3DTransform<double> LandmarkTransformType;
+      typedef VersorRigid3DTransform<double> LandmarkTransformType;
       typedef AnisotropicSimilarityLandmarkBasedTransformInitializer<LandmarkTransformType,
                                                                      TImage, TImage>
       LandmarkTransformCalculatorType;


### PR DESCRIPTION
Only rigid transforms can be defined the the initialization method
of RegisterImages.  Landmarks previously produced a similarity
transform.