### PR TITLE
ENH: Add support for 2D images in the python wrapped RegisterImages

### DIFF
--- a/src/Registration/itkBSplineImageToImageRegistrationMethod.h
+++ b/src/Registration/itkBSplineImageToImageRegistrationMethod.h
@@ -55,8 +55,7 @@ public:
   itkStaticConstMacro( ImageDimension, unsigned int, TImage::ImageDimension );
 
   // Overrides the superclass' TransformType typedef
-  typedef BSplineTransform<double, itkGetStaticConstMacro( ImageDimension ),
-    itkGetStaticConstMacro( ImageDimension )>
+  typedef BSplineTransform<double, itkGetStaticConstMacro( ImageDimension ), 3>
       BSplineTransformType;
 
   typedef typename BSplineTransformType::Pointer BSplineTransformPointer;

--- a/wrapping/tubeRegisterImages.wrap
+++ b/wrapping/tubeRegisterImages.wrap
@@ -3,7 +3,7 @@ itk_wrap_include( itkImage.h )
 
 itk_wrap_named_class("tube::RegisterImages" tubeRegisterImages POINTER)
   foreach(t ${WRAP_ITK_SCALAR})
-    foreach(d 3)
+    foreach(d 2 3)
       itk_wrap_template("${ITKM_${t}}${d}"  "itk::Image<${ITKT_${t}},${d}>")
     endforeach()
  endforeach()


### PR DESCRIPTION
Add 2D to wrapping and fixed specificiation of BSpline transform to
correctly support 2D images.