### PR TITLE
COMP: Remove inclusion of .hxx files as headers

### DIFF
--- a/examples/Applications/AtlasBuilderUsingIntensity/itktubeCompleteImageResampleFilter.hxx
+++ b/examples/Applications/AtlasBuilderUsingIntensity/itktubeCompleteImageResampleFilter.hxx
@@ -24,7 +24,6 @@ limitations under the License.
 #ifndef __itktubeCompleteImageResampleFilter_hxx
 #define __itktubeCompleteImageResampleFilter_hxx
 
-#include "itktubeCompleteImageResampleFilter.h"
 
 namespace itk
 {

--- a/examples/Applications/AtlasBuilderUsingIntensity/itktubeMeanAndSigmaImageBuilder.hxx
+++ b/examples/Applications/AtlasBuilderUsingIntensity/itktubeMeanAndSigmaImageBuilder.hxx
@@ -24,7 +24,6 @@ limitations under the License.
 #ifndef __itktubeMeanAndSigmaImageBuilder_hxx
 #define __itktubeMeanAndSigmaImageBuilder_hxx
 
-#include "itktubeMeanAndSigmaImageBuilder.h"
 
 template< class TInputImageType, class TOutputMeanImageType,
   class TOutputSigmaImageType >

--- a/examples/Applications/AtlasBuilderUsingIntensity/itktubeMinimizeImageSizeFilter.hxx
+++ b/examples/Applications/AtlasBuilderUsingIntensity/itktubeMinimizeImageSizeFilter.hxx
@@ -24,7 +24,6 @@ limitations under the License.
 #ifndef __itktubeMinimizeImageSizeFilter_hxx
 #define __itktubeMinimizeImageSizeFilter_hxx
 
-#include "itktubeMinimizeImageSizeFilter.h"
 
 namespace itk
 {

--- a/examples/Applications/AtlasBuilderUsingIntensity/itktubeRobustMeanAndSigmaImageBuilder.hxx
+++ b/examples/Applications/AtlasBuilderUsingIntensity/itktubeRobustMeanAndSigmaImageBuilder.hxx
@@ -24,7 +24,6 @@ limitations under the License.
 #ifndef __itktubeRobustMeanAndSigmaImageBuilder_hxx
 #define __itktubeRobustMeanAndSigmaImageBuilder_hxx
 
-#include "itktubeRobustMeanAndSigmaImageBuilder.h"
 
 template< class TInputImageType, class TOutputMeanImageType,
   class TOutputSigmaImageType >

--- a/examples/Applications/SimulateAcquisitionArtifactsUsingPrior/tubeCompareImageWithPrior.hxx
+++ b/examples/Applications/SimulateAcquisitionArtifactsUsingPrior/tubeCompareImageWithPrior.hxx
@@ -24,7 +24,6 @@ limitations under the License.
 #ifndef __tubeCompareImageWithPrior_hxx
 #define __tubeCompareImageWithPrior_hxx
 
-#include "tubeCompareImageWithPrior.h"
 
 #include "../CLI/tubeCLIFilterWatcher.h"
 #include "../CLI/tubeCLIProgressReporter.h"

--- a/include/tubeComputeBinaryImageSimilarityMetrics.hxx
+++ b/include/tubeComputeBinaryImageSimilarityMetrics.hxx
@@ -18,7 +18,6 @@
 #ifndef __tubeComputeBinaryImageSimilarityMetrics_hxx
 #define __tubeComputeBinaryImageSimilarityMetrics_hxx
 
-#include "tubeComputeBinaryImageSimilarityMetrics.h"
 
 namespace tube
 {

--- a/include/tubeComputeImageSimilarityMetrics.hxx
+++ b/include/tubeComputeImageSimilarityMetrics.hxx
@@ -23,7 +23,6 @@ limitations under the License.
 #ifndef __tubeComputeImageSimilarityMetrics_hxx
 #define __tubeComputeImageSimilarityMetrics_hxx
 
-#include "tubeComputeImageSimilarityMetrics.h"
 
 namespace tube
 {

--- a/include/tubeComputeImageStatistics.hxx
+++ b/include/tubeComputeImageStatistics.hxx
@@ -23,7 +23,6 @@ limitations under the License.
 #ifndef __tubeComputeImageStatistics_hxx
 #define __tubeComputeImageStatistics_hxx
 
-#include "tubeComputeImageStatistics.h"
 
 namespace tube
 {

--- a/include/tubeComputeTrainingMask.hxx
+++ b/include/tubeComputeTrainingMask.hxx
@@ -22,7 +22,6 @@ limitations under the License.
 #ifndef __tubeComputeTrainingMask_hxx
 #define __tubeComputeTrainingMask_hxx
 
-#include "tubeComputeTrainingMask.h"
 
 namespace tube {
 

--- a/include/tubeComputeTubeFlyThroughImage.hxx
+++ b/include/tubeComputeTubeFlyThroughImage.hxx
@@ -23,7 +23,6 @@ limitations under the License.
 #ifndef __tubeComputeTubeFlyThroughImage_hxx
 #define __tubeComputeTubeFlyThroughImage_hxx
 
-#include "tubeComputeTubeFlyThroughImage.h"
 
 namespace tube
 {

--- a/include/tubeComputeTubeMeasures.hxx
+++ b/include/tubeComputeTubeMeasures.hxx
@@ -23,7 +23,6 @@ limitations under the License.
 #ifndef __tubeComputeTubeMeasures_hxx
 #define __tubeComputeTubeMeasures_hxx
 
-#include "tubeComputeTubeMeasures.h"
 
 namespace tube
 {

--- a/include/tubeConvertImagesToCSV.hxx
+++ b/include/tubeConvertImagesToCSV.hxx
@@ -23,7 +23,6 @@ limitations under the License.
 #ifndef __tubeConvertImagesToCSV_hxx
 #define __tubeConvertImagesToCSV_hxx
 
-#include "tubeConvertImagesToCSV.h"
 
 
 namespace tube

--- a/include/tubeConvertShrunkenSeedImageToList.hxx
+++ b/include/tubeConvertShrunkenSeedImageToList.hxx
@@ -23,7 +23,6 @@ limitations under the License.
 #ifndef __tubeConvertShrunkenSeedImageToList_hxx
 #define __tubeConvertShrunkenSeedImageToList_hxx
 
-#include "tubeConvertShrunkenSeedImageToList.h"
 
 
 namespace tube

--- a/include/tubeConvertSpatialGraphToImage.hxx
+++ b/include/tubeConvertSpatialGraphToImage.hxx
@@ -18,7 +18,6 @@
 #ifndef __tubeConvertSpatialGraphToImage_hxx
 #define __tubeConvertSpatialGraphToImage_hxx
 
-#include "tubeConvertSpatialGraphToImage.h"
 
 namespace tube
 {

--- a/include/tubeConvertTubesToDensityImage.hxx
+++ b/include/tubeConvertTubesToDensityImage.hxx
@@ -18,7 +18,6 @@
 #ifndef __tubeConvertTubesToDensityImage_hxx
 #define __tubeConvertTubesToDensityImage_hxx
 
-#include "tubeConvertTubesToDensityImage.h"
 
 namespace tube
 {

--- a/include/tubeConvertTubesToImage.hxx
+++ b/include/tubeConvertTubesToImage.hxx
@@ -23,7 +23,6 @@ limitations under the License.
 #ifndef __tubeConvertTubesToImage_hxx
 #define __tubeConvertTubesToImage_hxx
 
-#include "tubeConvertTubesToImage.h"
 
 namespace tube
 {

--- a/include/tubeConvertTubesToTubeGraph.hxx
+++ b/include/tubeConvertTubesToTubeGraph.hxx
@@ -23,7 +23,6 @@ limitations under the License.
 #ifndef __tubeConvertTubesToTubeGraph_hxx
 #define __tubeConvertTubesToTubeGraph_hxx
 
-#include "tubeConvertTubesToTubeGraph.h"
 
 namespace tube
 {

--- a/include/tubeCropImage.hxx
+++ b/include/tubeCropImage.hxx
@@ -23,7 +23,6 @@ limitations under the License.
 #ifndef __tubeCropImage_hxx
 #define __tubeCropImage_hxx
 
-#include "tubeCropImage.h"
 
 
 namespace tube

--- a/include/tubeCropTubes.hxx
+++ b/include/tubeCropTubes.hxx
@@ -18,7 +18,6 @@
 #ifndef __tubeCropTubes_hxx
 #define __tubeCropTubes_hxx
 
-#include "tubeCropTubes.h"
 
 
 namespace tube

--- a/include/tubeEnhanceContrastUsingPrior.hxx
+++ b/include/tubeEnhanceContrastUsingPrior.hxx
@@ -18,7 +18,6 @@
 #ifndef __tubeEnhanceContrastUsingPrior_hxx
 #define __tubeEnhanceContrastUsingPrior_hxx
 
-#include "tubeEnhanceContrastUsingPrior.h"
 
 namespace tube
 {

--- a/include/tubeEnhanceEdgesUsingDiffusion.hxx
+++ b/include/tubeEnhanceEdgesUsingDiffusion.hxx
@@ -23,7 +23,6 @@ limitations under the License.
 #ifndef __tubeEnhanceEdgesUsingDiffusion_hxx
 #define __tubeEnhanceEdgesUsingDiffusion_hxx
 
-#include "tubeEnhanceEdgesUsingDiffusion.h"
 
 namespace tube
 {

--- a/include/tubeEnhanceTubesUsingDiffusion.hxx
+++ b/include/tubeEnhanceTubesUsingDiffusion.hxx
@@ -23,7 +23,6 @@ limitations under the License.
 #ifndef __tubeEnhanceTubesUsingDiffusion_hxx
 #define __tubeEnhanceTubesUsingDiffusion_hxx
 
-#include "tubeEnhanceTubesUsingDiffusion.h"
 
 #include <vector>
 

--- a/include/tubeEnhanceTubesUsingDiscriminantAnalysis.hxx
+++ b/include/tubeEnhanceTubesUsingDiscriminantAnalysis.hxx
@@ -18,7 +18,6 @@
 #ifndef __tubeEnhanceTubesUsingDiscriminantAnalysis_hxx
 #define __tubeEnhanceTubesUsingDiscriminantAnalysis_hxx
 
-#include "tubeEnhanceTubesUsingDiscriminantAnalysis.h"
 
 
 namespace tube

--- a/include/tubeImageMath.hxx
+++ b/include/tubeImageMath.hxx
@@ -23,7 +23,6 @@ limitations under the License.
 #ifndef __tubeImageMath_hxx
 #define __tubeImageMath_hxx
 
-#include "tubeImageMath.h"
 
 namespace tube
 {

--- a/include/tubeMergeAdjacentImages.hxx
+++ b/include/tubeMergeAdjacentImages.hxx
@@ -24,7 +24,6 @@ limitations under the License.
 #ifndef __tubeMergeAdjacentImages_hxx
 #define __tubeMergeAdjacentImages_hxx
 
-#include "tubeMergeAdjacentImages.h"
 
 namespace tube
 {

--- a/include/tubeRegisterImages.hxx
+++ b/include/tubeRegisterImages.hxx
@@ -18,7 +18,6 @@
 #ifndef __tubeRegisterImages_hxx
 #define __tubeRegisterImages_hxx
 
-#include "tubeRegisterImages.h"
 
 namespace tube
 {

--- a/include/tubeResampleImage.hxx
+++ b/include/tubeResampleImage.hxx
@@ -18,7 +18,6 @@
 #ifndef __tubeResampleImage_hxx
 #define __tubeResampleImage_hxx
 
-#include "tubeResampleImage.h"
 
 namespace tube
 {

--- a/include/tubeSegmentBinaryImageSkeleton3D.hxx
+++ b/include/tubeSegmentBinaryImageSkeleton3D.hxx
@@ -23,7 +23,6 @@ limitations under the License.
 #ifndef __tubeSegmentBinaryImageSkeleton3D_hxx
 #define __tubeSegmentBinaryImageSkeleton3D_hxx
 
-#include "tubeSegmentBinaryImageSkeleton3D.h"
 
 namespace tube
 {

--- a/include/tubeSegmentConnectedComponents.hxx
+++ b/include/tubeSegmentConnectedComponents.hxx
@@ -22,7 +22,6 @@ limitations under the License.
 #ifndef __tubeSegmentConnectedComponents_hxx
 #define __tubeSegmentConnectedComponents_hxx
 
-#include "tubeSegmentConnectedComponents.h"
 
 namespace tube
 {

--- a/include/tubeSegmentConnectedComponentsUsingParzenPDFs.hxx
+++ b/include/tubeSegmentConnectedComponentsUsingParzenPDFs.hxx
@@ -23,7 +23,6 @@ limitations under the License.
 #ifndef __tubeSegmentConnectedComponentsUsingParzenPDFs_hxx
 #define __tubeSegmentConnectedComponentsUsingParzenPDFs_hxx
 
-#include "tubeSegmentConnectedComponentsUsingParzenPDFs.h"
 
 namespace tube
 {

--- a/include/tubeSegmentTubeUsingMinimalPath.hxx
+++ b/include/tubeSegmentTubeUsingMinimalPath.hxx
@@ -18,7 +18,6 @@
 #ifndef __tubeSegmentTubeUsingMinimalPath_hxx
 #define __tubeSegmentTubeUsingMinimalPath_hxx
 
-#include "tubeSegmentTubeUsingMinimalPath.h"
 
 namespace tube
 {

--- a/include/tubeSegmentTubes.hxx
+++ b/include/tubeSegmentTubes.hxx
@@ -18,7 +18,6 @@
 #ifndef __tubeSegmentTubes_hxx
 #define __tubeSegmentTubes_hxx
 
-#include "tubeSegmentTubes.h"
 
 
 namespace tube

--- a/include/tubeSegmentUsingOtsuThreshold.hxx
+++ b/include/tubeSegmentUsingOtsuThreshold.hxx
@@ -22,7 +22,6 @@ limitations under the License.
 #ifndef __tubeSegmentUsingOtsuThreshold_hxx
 #define __tubeSegmentUsingOtsuThreshold_hxx
 
-#include "tubeSegmentUsingOtsuThreshold.h"
 
 namespace tube
 {

--- a/include/tubeShrinkImageWithBlending.hxx
+++ b/include/tubeShrinkImageWithBlending.hxx
@@ -23,7 +23,6 @@ limitations under the License.
 #ifndef __tubeShrinkImageWithBlending_hxx
 #define __tubeShrinkImageWithBlending_hxx
 
-#include "tubeShrinkImageWithBlending.h"
 
 namespace tube {
 

--- a/include/tubeWrite4DImageFrom3DImages.hxx
+++ b/include/tubeWrite4DImageFrom3DImages.hxx
@@ -23,7 +23,6 @@ limitations under the License.
 #define __tubeWrite4DImageFrom3DImages_hxx
 
 
-#include "tubeWrite4DImageFrom3DImages.h"
 
 #include "tubeMessage.h"
 

--- a/src/Filtering/itkImageRegionSplitter.hxx
+++ b/src/Filtering/itkImageRegionSplitter.hxx
@@ -18,7 +18,6 @@
 #ifndef __itkImageRegionSplitter_hxx
 #define __itkImageRegionSplitter_hxx
 
-#include "itkImageRegionSplitter.h"
 #include <cmath>
 
 namespace itk

--- a/src/Filtering/itktubeAnisotropicCoherenceEnhancingDiffusionImageFilter.hxx
+++ b/src/Filtering/itktubeAnisotropicCoherenceEnhancingDiffusionImageFilter.hxx
@@ -23,7 +23,6 @@ limitations under the License.
 #ifndef __itktubeAnisotropicCoherenceEnhancingDiffusionImageFilter_hxx
 #define __itktubeAnisotropicCoherenceEnhancingDiffusionImageFilter_hxx
 
-#include "itktubeAnisotropicCoherenceEnhancingDiffusionImageFilter.h"
 
 #include <itkFixedArray.h>
 #include <itkImageFileWriter.h>

--- a/src/Filtering/itktubeAnisotropicDiffusionTensorFunction.hxx
+++ b/src/Filtering/itktubeAnisotropicDiffusionTensorFunction.hxx
@@ -23,7 +23,6 @@ limitations under the License.
 #ifndef __itktubeAnisotropicDiffusionTensorFunction_hxx
 #define __itktubeAnisotropicDiffusionTensorFunction_hxx
 
-#include "itktubeAnisotropicDiffusionTensorFunction.h"
 
 #include <itkTextOutput.h>
 

--- a/src/Filtering/itktubeAnisotropicDiffusionTensorImageFilter.hxx
+++ b/src/Filtering/itktubeAnisotropicDiffusionTensorImageFilter.hxx
@@ -23,7 +23,6 @@ limitations under the License.
 #ifndef __itktubeAnisotropicDiffusionTensorImageFilter_hxx
 #define __itktubeAnisotropicDiffusionTensorImageFilter_hxx
 
-#include "itktubeAnisotropicDiffusionTensorImageFilter.h"
 
 #include "itktubeAnisotropicDiffusionTensorFunction.h"
 

--- a/src/Filtering/itktubeAnisotropicEdgeEnhancementDiffusionImageFilter.hxx
+++ b/src/Filtering/itktubeAnisotropicEdgeEnhancementDiffusionImageFilter.hxx
@@ -23,7 +23,6 @@ limitations under the License.
 #ifndef __itktubeAnisotropicEdgeEnhancementDiffusionImageFilter_hxx
 #define __itktubeAnisotropicEdgeEnhancementDiffusionImageFilter_hxx
 
-#include "itktubeAnisotropicEdgeEnhancementDiffusionImageFilter.h"
 
 #include <itkFixedArray.h>
 #include <itkGradientMagnitudeRecursiveGaussianImageFilter.h>

--- a/src/Filtering/itktubeAnisotropicHybridDiffusionImageFilter.hxx
+++ b/src/Filtering/itktubeAnisotropicHybridDiffusionImageFilter.hxx
@@ -23,7 +23,6 @@ limitations under the License.
 #ifndef __itktubeAnisotropicHybridDiffusionImageFilter_hxx
 #define __itktubeAnisotropicHybridDiffusionImageFilter_hxx
 
-#include "itktubeAnisotropicHybridDiffusionImageFilter.h"
 
 #include <itkFixedArray.h>
 #include <itkGradientMagnitudeRecursiveGaussianImageFilter.h>

--- a/src/Filtering/itktubeBinaryThinningImageFilter3D.hxx
+++ b/src/Filtering/itktubeBinaryThinningImageFilter3D.hxx
@@ -24,7 +24,6 @@ limitations under the License.
 
 #include <iostream>
 
-#include "itktubeBinaryThinningImageFilter3D.h"
 #include "itkImageRegionConstIterator.h"
 #include "itkImageRegionIterator.h"
 #include "itkNeighborhoodIterator.h"

--- a/src/Filtering/itktubeCVTImageFilter.hxx
+++ b/src/Filtering/itktubeCVTImageFilter.hxx
@@ -24,7 +24,6 @@ limitations under the License.
 #ifndef __itktubeCVTImageFilter_hxx
 #define __itktubeCVTImageFilter_hxx
 
-#include "itktubeCVTImageFilter.h"
 
 #include <itkDanielssonDistanceMapImageFilter.h>
 #include <itkMersenneTwisterRandomVariateGenerator.h>

--- a/src/Filtering/itktubeComputeTubeFlyThroughImageFilter.hxx
+++ b/src/Filtering/itktubeComputeTubeFlyThroughImageFilter.hxx
@@ -23,7 +23,6 @@ limitations under the License.
 #ifndef __itktubeComputeTubeFlyThroughImageFilter_hxx
 #define __itktubeComputeTubeFlyThroughImageFilter_hxx
 
-#include "itktubeComputeTubeFlyThroughImageFilter.h"
 
 #include <itkImageRegionIterator.h>
 #include <itkImageRegionIteratorWithIndex.h>

--- a/src/Filtering/itktubeComputeTubeMeasuresFilter.hxx
+++ b/src/Filtering/itktubeComputeTubeMeasuresFilter.hxx
@@ -23,7 +23,6 @@ limitations under the License.
 #ifndef __itktubeComputeTubeMeasuresFilter_hxx
 #define __itktubeComputeTubeMeasuresFilter_hxx
 
-#include "itktubeComputeTubeMeasuresFilter.h"
 
 namespace itk
 {

--- a/src/Filtering/itktubeContrastCostFunction.hxx
+++ b/src/Filtering/itktubeContrastCostFunction.hxx
@@ -23,7 +23,6 @@ limitations under the License.
 #ifndef __itktubeContrastCostFunction_hxx
 #define __itktubeContrastCostFunction_hxx
 
-#include "itktubeContrastCostFunction.h"
 
 namespace itk
 {

--- a/src/Filtering/itktubeConvertImagesToCSVFilter.hxx
+++ b/src/Filtering/itktubeConvertImagesToCSVFilter.hxx
@@ -19,7 +19,6 @@
 #ifndef __itktubeConvertImagesToCSVFilter_hxx
 #define __itktubeConvertImagesToCSVFilter_hxx
 
-#include "itktubeConvertImagesToCSVFilter.h"
 
 namespace itk
 {

--- a/src/Filtering/itktubeConvertShrunkenSeedImageToListFilter.hxx
+++ b/src/Filtering/itktubeConvertShrunkenSeedImageToListFilter.hxx
@@ -23,7 +23,6 @@ limitations under the License.
 #ifndef __itktubeConvertShrunkenSeedImageToListFilter_hxx
 #define __itktubeConvertShrunkenSeedImageToListFilter_hxx
 
-#include "itktubeConvertShrunkenSeedImageToListFilter.h"
 
 namespace itk
 {

--- a/src/Filtering/itktubeConvertSpatialGraphToImageFilter.hxx
+++ b/src/Filtering/itktubeConvertSpatialGraphToImageFilter.hxx
@@ -23,7 +23,6 @@ limitations under the License.
 #ifndef __itktubeConvertSpatialGraphToImageFilter_hxx
 #define __itktubeConvertSpatialGraphToImageFilter_hxx
 
-#include "itktubeConvertSpatialGraphToImageFilter.h"
 
 namespace itk
 {

--- a/src/Filtering/itktubeCropImageFilter.hxx
+++ b/src/Filtering/itktubeCropImageFilter.hxx
@@ -18,7 +18,6 @@
 #ifndef __itktubeCropImageFilter_hxx
 #define __itktubeCropImageFilter_hxx
 
-#include "itktubeCropImageFilter.h"
 
 namespace itk
 {

--- a/src/Filtering/itktubeCropTubesFilter.hxx
+++ b/src/Filtering/itktubeCropTubesFilter.hxx
@@ -23,7 +23,6 @@
 #ifndef __itktubeCropTubesFilter_hxx
 #define __itktubeCropTubesFilter_hxx
 
-#include "itktubeCropTubesFilter.h"
 #include "tubeMacro.h"
 #include "tubeTubeMathFilters.h"
 

--- a/src/Filtering/itktubeDifferenceImageFilter.hxx
+++ b/src/Filtering/itktubeDifferenceImageFilter.hxx
@@ -24,7 +24,6 @@ limitations under the License.
 #ifndef __itktubeDifferenceImageFilter_hxx
 #define __itktubeDifferenceImageFilter_hxx
 
-#include "itktubeDifferenceImageFilter.h"
 
 #include <itkImageRegionIterator.h>
 #include <itkNeighborhoodAlgorithm.h>

--- a/src/Filtering/itktubeEnhanceContrastUsingPriorImageFilter.hxx
+++ b/src/Filtering/itktubeEnhanceContrastUsingPriorImageFilter.hxx
@@ -24,7 +24,6 @@ limitations under the License.
 #ifndef __itktubeEnhanceContrastUsingPriorImageFilter_hxx
 #define __itktubeEnhanceContrastUsingPriorImageFilter_hxx
 
-#include "itktubeEnhanceContrastUsingPriorImageFilter.h"
 
 namespace itk
 {

--- a/src/Filtering/itktubeExtractTubePointsSpatialObjectFilter.hxx
+++ b/src/Filtering/itktubeExtractTubePointsSpatialObjectFilter.hxx
@@ -23,7 +23,6 @@ limitations under the License.
 #ifndef __itktubeExtractTubePointsSpatialObjectFilter_hxx
 #define __itktubeExtractTubePointsSpatialObjectFilter_hxx
 
-#include "itktubeExtractTubePointsSpatialObjectFilter.h"
 
 #include "tubeTubeMathFilters.h"
 

--- a/src/Filtering/itktubeFFTGaussianDerivativeIFFTFilter.hxx
+++ b/src/Filtering/itktubeFFTGaussianDerivativeIFFTFilter.hxx
@@ -17,7 +17,6 @@
 #ifndef __itktubeFFTGaussianDerivativeIFFTFilter_hxx
 #define __itktubeFFTGaussianDerivativeIFFTFilter_hxx
 
-#include "itktubeFFTGaussianDerivativeIFFTFilter.h"
 #include "itktubeGaussianDerivativeImageSource.h"
 #include "itktubePadImageFilter.h"
 #include "itktubeRegionFromReferenceImageFilter.h"

--- a/src/Filtering/itktubeGaussianDerivativeImageSource.hxx
+++ b/src/Filtering/itktubeGaussianDerivativeImageSource.hxx
@@ -18,7 +18,6 @@
 #ifndef __itktubeGaussianDerivativeImageSource_hxx
 #define __itktubeGaussianDerivativeImageSource_hxx
 
-#include "itktubeGaussianDerivativeImageSource.h"
 #include <itkGaussianSpatialFunction.h>
 #include <itkImageRegionIterator.h>
 #include <itkObjectFactory.h>

--- a/src/Filtering/itktubeInverseIntensityImageFilter.hxx
+++ b/src/Filtering/itktubeInverseIntensityImageFilter.hxx
@@ -24,7 +24,6 @@ limitations under the License.
 #ifndef __itktubeInverseIntensityImageFilter_hxx
 #define __itktubeInverseIntensityImageFilter_hxx
 
-#include "itktubeInverseIntensityImageFilter.h"
 
 #include <itkImageRegionIterator.h>
 #include <itkMinimumMaximumImageFilter.h>

--- a/src/Filtering/itktubeLimitedMinimumMaximumImageFilter.hxx
+++ b/src/Filtering/itktubeLimitedMinimumMaximumImageFilter.hxx
@@ -17,7 +17,6 @@
  *=========================================================================*/
 #ifndef itktubeLimitedMinimumMaximumImageFilter_hxx
 #define itktubeLimitedMinimumMaximumImageFilter_hxx
-#include "itktubeLimitedMinimumMaximumImageFilter.h"
 
 
 #include "itkImageScanlineIterator.h"

--- a/src/Filtering/itktubeMinimumSpanningTreeVesselConnectivityFilter.hxx
+++ b/src/Filtering/itktubeMinimumSpanningTreeVesselConnectivityFilter.hxx
@@ -23,7 +23,6 @@
 #ifndef __itktubeMinimumSpanningTreeVesselConnectivityFilter_hxx
 #define __itktubeMinimumSpanningTreeVesselConnectivityFilter_hxx
 
-#include "itktubeMinimumSpanningTreeVesselConnectivityFilter.h"
 #include "tubeMatrixMath.h"
 #include "itkMath.h"
 #include "tubeMacro.h"

--- a/src/Filtering/itktubePadImageFilter.hxx
+++ b/src/Filtering/itktubePadImageFilter.hxx
@@ -18,7 +18,6 @@
 #ifndef __itktubePadImageFilter_hxx
 #define __itktubePadImageFilter_hxx
 
-#include "itktubePadImageFilter.h"
 #include "itkProgressAccumulator.h"
 #include "itkNumericTraits.h"
 #include "itkConstantPadImageFilter.h"

--- a/src/Filtering/itktubeReResampleImageFilter.hxx
+++ b/src/Filtering/itktubeReResampleImageFilter.hxx
@@ -24,7 +24,6 @@ limitations under the License.
 #ifndef __itktubeReResampleImageFilter_hxx
 #define __itktubeReResampleImageFilter_hxx
 
-#include "itktubeReResampleImageFilter.h"
 
 namespace itk
 {

--- a/src/Filtering/itktubeRegionFromReferenceImageFilter.hxx
+++ b/src/Filtering/itktubeRegionFromReferenceImageFilter.hxx
@@ -18,7 +18,6 @@
 #ifndef __itktubeRegionFromReferenceImageFilter_hxx
 #define __itktubeRegionFromReferenceImageFilter_hxx
 
-#include "itktubeRegionFromReferenceImageFilter.h"
 
 namespace itk {
 

--- a/src/Filtering/itktubeResampleTubesFilter.hxx
+++ b/src/Filtering/itktubeResampleTubesFilter.hxx
@@ -25,7 +25,6 @@
 
 #include <iterator>
 
-#include "itktubeResampleTubesFilter.h"
 
 #include "itkMath.h"
 

--- a/src/Filtering/itktubeRidgeFFTFilter.hxx
+++ b/src/Filtering/itktubeRidgeFFTFilter.hxx
@@ -21,7 +21,6 @@
 
 #include "tubetkConfigure.h"
 
-#include "itktubeRidgeFFTFilter.h"
 #include "itktubeFFTGaussianDerivativeIFFTFilter.h"
 
 #include "tubeMatrixMath.h"

--- a/src/Filtering/itktubeSheetnessMeasureImageFilter.hxx
+++ b/src/Filtering/itktubeSheetnessMeasureImageFilter.hxx
@@ -23,7 +23,6 @@ limitations under the License.
 #ifndef __itktubeSheetnessMeasureImageFilter_hxx
 #define __itktubeSheetnessMeasureImageFilter_hxx
 
-#include "itktubeSheetnessMeasureImageFilter.h"
 
 #include <itkImageRegionIterator.h>
 

--- a/src/Filtering/itktubeShrinkWithBlendingImageFilter.hxx
+++ b/src/Filtering/itktubeShrinkWithBlendingImageFilter.hxx
@@ -23,7 +23,6 @@ limitations under the License.
 #ifndef __itktubeShrinkWithBlendingImageFilter_hxx
 #define __itktubeShrinkWithBlendingImageFilter_hxx
 
-#include "itktubeShrinkWithBlendingImageFilter.h"
 
 #include "itkConstNeighborhoodIterator.h"
 #include "itkImageRegionConstIteratorWithIndex.h"

--- a/src/Filtering/itktubeSmoothingRecursiveGaussianImageFilter.hxx
+++ b/src/Filtering/itktubeSmoothingRecursiveGaussianImageFilter.hxx
@@ -17,7 +17,6 @@
 #ifndef __itktubeSmoothingRecursiveGaussianImageFilter_hxx
 #define __itktubeSmoothingRecursiveGaussianImageFilter_hxx
 
-#include "itktubeSmoothingRecursiveGaussianImageFilter.h"
 #include "itkImageRegionIteratorWithIndex.h"
 #include "itkProgressAccumulator.h"
 

--- a/src/Filtering/itktubeSpatialObjectFilter.hxx
+++ b/src/Filtering/itktubeSpatialObjectFilter.hxx
@@ -23,7 +23,6 @@ limitations under the License.
 #ifndef __itktubeSpatialObjectFilter_hxx
 #define __itktubeSpatialObjectFilter_hxx
 
-#include "itktubeSpatialObjectFilter.h"
 
 namespace itk
 {

--- a/src/Filtering/itktubeSpatialObjectSource.hxx
+++ b/src/Filtering/itktubeSpatialObjectSource.hxx
@@ -23,7 +23,6 @@ limitations under the License.
 #ifndef __itktubeSpatialObjectSource_hxx
 #define __itktubeSpatialObjectSource_hxx
 
-#include "itktubeSpatialObjectSource.h"
 
 #include <itkTextOutput.h>
 

--- a/src/Filtering/itktubeSpatialObjectToSpatialObjectFilter.hxx
+++ b/src/Filtering/itktubeSpatialObjectToSpatialObjectFilter.hxx
@@ -23,7 +23,6 @@ limitations under the License.
 #ifndef __itktubeSpatialObjectToSpatialObjectFilter_hxx
 #define __itktubeSpatialObjectToSpatialObjectFilter_hxx
 
-#include "itktubeSpatialObjectToSpatialObjectFilter.h"
 
 namespace itk
 {

--- a/src/Filtering/itktubeStructureTensorRecursiveGaussianImageFilter.hxx
+++ b/src/Filtering/itktubeStructureTensorRecursiveGaussianImageFilter.hxx
@@ -24,7 +24,6 @@ limitations under the License.
 #ifndef __itktubeStructureTensorRecursiveGaussianImageFilter_hxx
 #define __itktubeStructureTensorRecursiveGaussianImageFilter_hxx
 
-#include "itktubeStructureTensorRecursiveGaussianImageFilter.h"
 
 #include <itkImageRegionIteratorWithIndex.h>
 

--- a/src/Filtering/itktubeSubSampleSpatialObjectFilter.hxx
+++ b/src/Filtering/itktubeSubSampleSpatialObjectFilter.hxx
@@ -23,7 +23,6 @@ limitations under the License.
 #ifndef __itktubeSubSampleSpatialObjectFilter_hxx
 #define __itktubeSubSampleSpatialObjectFilter_hxx
 
-#include "itktubeSubSampleSpatialObjectFilter.h"
 
 #include "itktubeSubSampleTubeSpatialObjectFilter.h"
 

--- a/src/Filtering/itktubeSubSampleTubeSpatialObjectFilter.hxx
+++ b/src/Filtering/itktubeSubSampleTubeSpatialObjectFilter.hxx
@@ -23,7 +23,6 @@ limitations under the License.
 #ifndef __itktubeSubSampleTubeSpatialObjectFilter_hxx
 #define __itktubeSubSampleTubeSpatialObjectFilter_hxx
 
-#include "itktubeSubSampleTubeSpatialObjectFilter.h"
 
 namespace itk
 {

--- a/src/Filtering/itktubeTortuositySpatialObjectFilter.hxx
+++ b/src/Filtering/itktubeTortuositySpatialObjectFilter.hxx
@@ -24,7 +24,6 @@ limitations under the License.
 #ifndef __itktubeTortuositySpatialObjectFilter_hxx
 #define __itktubeTortuositySpatialObjectFilter_hxx
 
-#include "itktubeTortuositySpatialObjectFilter.h"
 
 #include "itkSampleToHistogramFilter.h"
 #include "itkListSample.h"

--- a/src/Filtering/itktubeTubeEnhancingDiffusion2DImageFilter.hxx
+++ b/src/Filtering/itktubeTubeEnhancingDiffusion2DImageFilter.hxx
@@ -24,7 +24,6 @@ limitations under the License.
 #ifndef __itktubeTubeEnhancingDiffusion2DImageFilter_hxx
 #define __itktubeTubeEnhancingDiffusion2DImageFilter_hxx
 
-#include "itktubeTubeEnhancingDiffusion2DImageFilter.h"
 
 #include <itkCastImageFilter.h>
 #include <itkConstShapedNeighborhoodIterator.h>

--- a/src/Filtering/itktubeTubeSpatialObjectToDensityImageFilter.hxx
+++ b/src/Filtering/itktubeTubeSpatialObjectToDensityImageFilter.hxx
@@ -24,7 +24,6 @@ limitations under the License.
 #ifndef __itktubeTubeSpatialObjectToDensityImageFilter_hxx
 #define __itktubeTubeSpatialObjectToDensityImageFilter_hxx
 
-#include "itktubeTubeSpatialObjectToDensityImageFilter.h"
 
 /** Constructor */
 template< class TDensityImageType, class TRadiusImageType,

--- a/src/Filtering/itktubeTubeSpatialObjectToImageFilter.hxx
+++ b/src/Filtering/itktubeTubeSpatialObjectToImageFilter.hxx
@@ -23,7 +23,6 @@ limitations under the License.
 #ifndef __itktubeTubeSpatialObjectToImageFilter_hxx
 #define __itktubeTubeSpatialObjectToImageFilter_hxx
 
-#include "itktubeTubeSpatialObjectToImageFilter.h"
 
 #include <itkImageRegionIteratorWithIndex.h>
 

--- a/src/Filtering/itktubeTubeSpatialObjectToTubeGraphFilter.hxx
+++ b/src/Filtering/itktubeTubeSpatialObjectToTubeGraphFilter.hxx
@@ -23,7 +23,6 @@ limitations under the License.
 #ifndef __itktubeTubeSpatialObjectToTubeGraphFilter_hxx
 #define __itktubeTubeSpatialObjectToTubeGraphFilter_hxx
 
-#include "itktubeTubeSpatialObjectToTubeGraphFilter.h"
 
 /** Constructor */
 template< class TPixel, unsigned int Dimension >

--- a/src/IO/itktubePDFSegmenterParzenIO.hxx
+++ b/src/IO/itktubePDFSegmenterParzenIO.hxx
@@ -23,7 +23,6 @@ limitations under the License.
 #ifndef __itktubePDFSegmenterParzenIO_hxx
 #define __itktubePDFSegmenterParzenIO_hxx
 
-#include "itktubePDFSegmenterParzenIO.h"
 #include "itktubeMetaClassPDF.h"
 #include "metaUtils.h"
 

--- a/src/IO/itktubeRidgeSeedFilterIO.hxx
+++ b/src/IO/itktubeRidgeSeedFilterIO.hxx
@@ -22,7 +22,6 @@ limitations under the License.
 #ifndef __itktubeRidgeSeedFilterIO_hxx
 #define __itktubeRidgeSeedFilterIO_hxx
 
-#include "itktubeRidgeSeedFilterIO.h"
 #include "itktubePDFSegmenterParzenIO.h"
 
 namespace itk

--- a/src/IO/itktubeTubeExtractorIO.hxx
+++ b/src/IO/itktubeTubeExtractorIO.hxx
@@ -23,7 +23,6 @@ limitations under the License.
 #ifndef __itktubeTubeExtractorIO_hxx
 #define __itktubeTubeExtractorIO_hxx
 
-#include "itktubeTubeExtractorIO.h"
 
 namespace itk
 {

--- a/src/IO/itktubeTubeXIO.hxx
+++ b/src/IO/itktubeTubeXIO.hxx
@@ -25,7 +25,6 @@ limitations under the License.
 
 #include <cmath>
 
-#include "itktubeTubeXIO.h"
 
 #include "tubeStringUtilities.h"
 #include "metaUtils.h"

--- a/src/Numerics/itktubeBasisFeatureVectorGenerator.hxx
+++ b/src/Numerics/itktubeBasisFeatureVectorGenerator.hxx
@@ -24,7 +24,6 @@ limitations under the License.
 #ifndef __itktubeBasisFeatureVectorGenerator_hxx
 #define __itktubeBasisFeatureVectorGenerator_hxx
 
-#include "itktubeBasisFeatureVectorGenerator.h"
 #include "tubeMatrixMath.h"
 
 #include <itkImage.h>

--- a/src/Numerics/itktubeBlurImageFunction.hxx
+++ b/src/Numerics/itktubeBlurImageFunction.hxx
@@ -24,7 +24,6 @@ limitations under the License.
 #ifndef __itktubeBlurImageFunction_hxx
 #define __itktubeBlurImageFunction_hxx
 
-#include "itktubeBlurImageFunction.h"
 
 #include <itkContinuousIndex.h>
 #include <itkImage.h>

--- a/src/Numerics/itktubeComputeImageSimilarityMetrics.hxx
+++ b/src/Numerics/itktubeComputeImageSimilarityMetrics.hxx
@@ -30,7 +30,6 @@ limitations under the License.
 #include <itkNormalizeImageFilter.h>
 
 // TubeTK includes
-#include "itktubeComputeImageSimilarityMetrics.h"
 
 namespace itk
 {

--- a/src/Numerics/itktubeComputeImageStatistics.hxx
+++ b/src/Numerics/itktubeComputeImageStatistics.hxx
@@ -27,7 +27,6 @@ limitations under the License.
 #include "itkImageRegionIterator.h"
 
 // TubeTK includes
-#include "itktubeComputeImageStatistics.h"
 
 #include <fstream>
 

--- a/src/Numerics/itktubeFeatureVectorGenerator.hxx
+++ b/src/Numerics/itktubeFeatureVectorGenerator.hxx
@@ -25,7 +25,6 @@ limitations under the License.
 #define __itktubeFeatureVectorGenerator_hxx
 
 
-#include "itktubeFeatureVectorGenerator.h"
 
 #include "tubeMatrixMath.h"
 

--- a/src/Numerics/itktubeImageRegionMomentsCalculator.hxx
+++ b/src/Numerics/itktubeImageRegionMomentsCalculator.hxx
@@ -24,7 +24,6 @@ limitations under the License.
 #ifndef __itktubeImageRegionMomentsCalculator_hxx
 #define __itktubeImageRegionMomentsCalculator_hxx
 
-#include "itktubeImageRegionMomentsCalculator.h"
 
 #include <itkImageRegionConstIteratorWithIndex.h>
 

--- a/src/Numerics/itktubeJointHistogramImageFunction.hxx
+++ b/src/Numerics/itktubeJointHistogramImageFunction.hxx
@@ -24,7 +24,6 @@ limitations under the License.
 #ifndef __itktubeJointHistogramImageFunction_hxx
 #define __itktubeJointHistogramImageFunction_hxx
 
-#include "itktubeJointHistogramImageFunction.h"
 
 #include <itkAddImageFilter.h>
 #include <itkDiscreteGaussianImageFilter.h>

--- a/src/Numerics/itktubeNJetFeatureVectorGenerator.hxx
+++ b/src/Numerics/itktubeNJetFeatureVectorGenerator.hxx
@@ -24,7 +24,6 @@ limitations under the License.
 #ifndef __itktubeNJetFeatureVectorGenerator_hxx
 #define __itktubeNJetFeatureVectorGenerator_hxx
 
-#include "itktubeNJetFeatureVectorGenerator.h"
 #include "itktubeNJetImageFunction.h"
 #include "tubeMatrixMath.h"
 

--- a/src/Numerics/itktubeNJetImageFunction.hxx
+++ b/src/Numerics/itktubeNJetImageFunction.hxx
@@ -25,7 +25,6 @@ limitations under the License.
 #define __itktubeNJetImageFunction_hxx
 
 #include "tubeMatrixMath.h"
-#include "itktubeNJetImageFunction.h"
 
 #include <itkImageRegionConstIterator.h>
 #include <itkImageRegionIteratorWithIndex.h>

--- a/src/Numerics/itktubeRidgeFFTFeatureVectorGenerator.hxx
+++ b/src/Numerics/itktubeRidgeFFTFeatureVectorGenerator.hxx
@@ -24,7 +24,6 @@ limitations under the License.
 #ifndef __itktubeRidgeFFTFeatureVectorGenerator_hxx
 #define __itktubeRidgeFFTFeatureVectorGenerator_hxx
 
-#include "itktubeRidgeFFTFeatureVectorGenerator.h"
 #include "itktubeRidgeFFTFilter.h"
 #include "tubeMatrixMath.h"
 

--- a/src/Numerics/itktubeSingleValuedCostFunctionImageSource.hxx
+++ b/src/Numerics/itktubeSingleValuedCostFunctionImageSource.hxx
@@ -24,7 +24,6 @@ limitations under the License.
 #ifndef __itktubeSingleValuedCostFunctionImageSource_hxx
 #define __itktubeSingleValuedCostFunctionImageSource_hxx
 
-#include "itktubeSingleValuedCostFunctionImageSource.h"
 
 #include <itkImageRegionIteratorWithIndex.h>
 #include <itkProgressReporter.h>

--- a/src/Numerics/itktubeVectorImageToListGenerator.hxx
+++ b/src/Numerics/itktubeVectorImageToListGenerator.hxx
@@ -24,7 +24,6 @@ limitations under the License.
 #ifndef __itktubeVectorImageToListGenerator_hxx
 #define __itktubeVectorImageToListGenerator_hxx
 
-#include "itktubeVectorImageToListGenerator.h"
 
 #include <itkImageRegionConstIterator.h>
 

--- a/src/Numerics/itktubeVotingResampleImageFunction.hxx
+++ b/src/Numerics/itktubeVotingResampleImageFunction.hxx
@@ -24,7 +24,6 @@ limitations under the License.
 #ifndef __itktubeVotingResampleImageFunction_hxx
 #define __itktubeVotingResampleImageFunction_hxx
 
-#include "itktubeVotingResampleImageFunction.h"
 
 #include <itkConstNeighborhoodIterator.h>
 #include <itkNeighborhood.h>

--- a/src/Numerics/tubeMatrixMath.hxx
+++ b/src/Numerics/tubeMatrixMath.hxx
@@ -23,7 +23,6 @@ limitations under the License.
 #ifndef __tubeMatrixMath_hxx
 #define __tubeMatrixMath_hxx
 
-#include "tubeMatrixMath.h"
 
 #include <vnl/algo/vnl_symmetric_eigensystem.h>
 #include <vnl/algo/vnl_real_eigensystem.h>

--- a/src/ObjectDocuments/itktubeObjectDocumentToImageFilter.hxx
+++ b/src/ObjectDocuments/itktubeObjectDocumentToImageFilter.hxx
@@ -24,7 +24,6 @@ limitations under the License.
 #ifndef __itktubeObjectDocumentToImageFilter_hxx
 #define __itktubeObjectDocumentToImageFilter_hxx
 
-#include "itktubeObjectDocumentToImageFilter.h"
 
 namespace itk
 {

--- a/src/ObjectDocuments/itktubeObjectDocumentToObjectSource.hxx
+++ b/src/ObjectDocuments/itktubeObjectDocumentToObjectSource.hxx
@@ -24,7 +24,6 @@ limitations under the License.
 #ifndef __itktubeObjectDocumentToObjectSource_hxx
 #define __itktubeObjectDocumentToObjectSource_hxx
 
-#include "itktubeObjectDocumentToObjectSource.h"
 
 namespace itk
 {

--- a/src/Registration/itkAffineImageToImageRegistrationMethod.hxx
+++ b/src/Registration/itkAffineImageToImageRegistrationMethod.hxx
@@ -23,7 +23,6 @@ limitations under the License.
 #ifndef __itkAffineImageToImageRegistrationMethod_txx
 #define __itkAffineImageToImageRegistrationMethod_txx
 
-#include "itkAffineImageToImageRegistrationMethod.h"
 
 namespace itk
 {

--- a/src/Registration/itkAnisotropicSimilarity3DTransform.hxx
+++ b/src/Registration/itkAnisotropicSimilarity3DTransform.hxx
@@ -23,7 +23,6 @@ limitations under the License.
 #ifndef __itkAnisotropicSimilarity3DTransform_txx
 #define __itkAnisotropicSimilarity3DTransform_txx
 
-#include "itkAnisotropicSimilarity3DTransform.h"
 #include "vnl/vnl_math.h"
 #include "vnl/vnl_det.h"
 

--- a/src/Registration/itkAnisotropicSimilarityLandmarkBasedTransformInitializer.hxx
+++ b/src/Registration/itkAnisotropicSimilarityLandmarkBasedTransformInitializer.hxx
@@ -23,7 +23,6 @@ limitations under the License.
 #ifndef __itkAnisotropicSimilarityLandmarkBasedTransformInitializer_txx
 #define __itkAnisotropicSimilarityLandmarkBasedTransformInitializer_txx
 
-#include "itkAnisotropicSimilarityLandmarkBasedTransformInitializer.h"
 #include "itkMatrix.h"
 #include "itkSymmetricEigenAnalysis.h"
 

--- a/src/Registration/itkBSplineImageToImageRegistrationMethod.hxx
+++ b/src/Registration/itkBSplineImageToImageRegistrationMethod.hxx
@@ -23,7 +23,6 @@ limitations under the License.
 #ifndef __itkBSplineImageToImageRegistrationMethod_txx
 #define __itkBSplineImageToImageRegistrationMethod_txx
 
-#include "itkBSplineImageToImageRegistrationMethod.h"
 
 #include "itkBSplineTransformInitializer.h"
 #include "itkBSplineResampleImageFunction.h"

--- a/src/Registration/itkImageRegionMomentsCalculator.hxx
+++ b/src/Registration/itkImageRegionMomentsCalculator.hxx
@@ -22,7 +22,6 @@ limitations under the License.
 
 #ifndef _itkImageRegionMomentsCalculator_txx
 #define _itkImageRegionMomentsCalculator_txx
-#include "itkImageRegionMomentsCalculator.h"
 
 #include "vnl/algo/vnl_real_eigensystem.h"
 #include "vnl/algo/vnl_symmetric_eigensystem.h"

--- a/src/Registration/itkImageRegionSplitter.hxx
+++ b/src/Registration/itkImageRegionSplitter.hxx
@@ -23,7 +23,6 @@ limitations under the License.
 #ifndef __itkImageRegionSplitter_hxx
 #define __itkImageRegionSplitter_hxx
 
-#include "itkImageRegionSplitter.h"
 #include <cmath>
 
 namespace itk

--- a/src/Registration/itkImageToImageRegistrationHelper.hxx
+++ b/src/Registration/itkImageToImageRegistrationHelper.hxx
@@ -23,7 +23,6 @@ limitations under the License.
 #ifndef __itkImageToImageRegistrationHelper_txx
 #define __itkImageToImageRegistrationHelper_txx
 
-#include "itkImageToImageRegistrationHelper.h"
 
 #include "itkImageFileReader.h"
 #include "itkImageFileWriter.h"

--- a/src/Registration/itkImageToImageRegistrationMethod.hxx
+++ b/src/Registration/itkImageToImageRegistrationMethod.hxx
@@ -23,7 +23,6 @@ limitations under the License.
 #ifndef __ImageToImageRegistrationMethod_txx
 #define __ImageToImageRegistrationMethod_txx
 
-#include "itkImageToImageRegistrationMethod.h"
 
 namespace itk
 {

--- a/src/Registration/itkInitialImageToImageRegistrationMethod.hxx
+++ b/src/Registration/itkInitialImageToImageRegistrationMethod.hxx
@@ -23,7 +23,6 @@ limitations under the License.
 #ifndef __InitialImageToImageRegistrationMethod_txx
 #define __InitialImageToImageRegistrationMethod_txx
 
-#include "itkInitialImageToImageRegistrationMethod.h"
 
 #include "itkImageRegionMomentsCalculator.h"
 

--- a/src/Registration/itkOptimizedImageToImageRegistrationMethod.hxx
+++ b/src/Registration/itkOptimizedImageToImageRegistrationMethod.hxx
@@ -23,7 +23,6 @@ limitations under the License.
 #ifndef __OptimizedImageToImageRegistrationMethod_txx
 #define __OptimizedImageToImageRegistrationMethod_txx
 
-#include "itkOptimizedImageToImageRegistrationMethod.h"
 
 #include "itkMattesMutualInformationImageToImageMetric.h"
 #include "itkNormalizedCorrelationImageToImageMetric.h"

--- a/src/Registration/itkRigidImageToImageRegistrationMethod.hxx
+++ b/src/Registration/itkRigidImageToImageRegistrationMethod.hxx
@@ -18,7 +18,6 @@
 #ifndef __RigidImageToImageRegistrationMethod_txx
 #define __RigidImageToImageRegistrationMethod_txx
 
-#include "itkRigidImageToImageRegistrationMethod.h"
 #include "vnl/vnl_inverse.h"
 
 namespace itk

--- a/src/Registration/itkScaleSkewAngle2DImageToImageRegistrationMethod.hxx
+++ b/src/Registration/itkScaleSkewAngle2DImageToImageRegistrationMethod.hxx
@@ -23,7 +23,6 @@ limitations under the License.
 #ifndef __itkScaleSkewAngle2DImageToImageRegistrationMethod_txx
 #define __itkScaleSkewAngle2DImageToImageRegistrationMethod_txx
 
-#include "itkScaleSkewAngle2DImageToImageRegistrationMethod.h"
 
 namespace itk
 {

--- a/src/Registration/itkScaleSkewAngle2DTransform.hxx
+++ b/src/Registration/itkScaleSkewAngle2DTransform.hxx
@@ -23,7 +23,6 @@ limitations under the License.
 #ifndef itkScaleSkewAngle2DTransform_hxx
 #define itkScaleSkewAngle2DTransform_hxx
 
-#include "itkScaleSkewAngle2DTransform.h"
 #include "itkMath.h"
 
 namespace itk

--- a/src/Registration/itkScaleSkewVersor3DImageToImageRegistrationMethod.hxx
+++ b/src/Registration/itkScaleSkewVersor3DImageToImageRegistrationMethod.hxx
@@ -23,7 +23,6 @@ limitations under the License.
 #ifndef __itkScaleSkewVersor3DImageToImageRegistrationMethod_txx
 #define __itkScaleSkewVersor3DImageToImageRegistrationMethod_txx
 
-#include "itkScaleSkewVersor3DImageToImageRegistrationMethod.h"
 
 namespace itk
 {

--- a/src/Registration/itkSimilarity2DTransform.hxx
+++ b/src/Registration/itkSimilarity2DTransform.hxx
@@ -23,7 +23,6 @@ limitations under the License.
 #ifndef itkSimilarity2DTransform_hxx
 #define itkSimilarity2DTransform_hxx
 
-#include "itkSimilarity2DTransform.h"
 #include "itkMath.h"
 
 namespace itk

--- a/src/Registration/itktubeAffineSpatialObjectToImageRegistrationMethod.hxx
+++ b/src/Registration/itktubeAffineSpatialObjectToImageRegistrationMethod.hxx
@@ -23,7 +23,6 @@ limitations under the License.
 #ifndef __itktubeAffineSpatialObjectToImageRegistrationMethod_hxx
 #define __itktubeAffineSpatialObjectToImageRegistrationMethod_hxx
 
-#include "itktubeAffineSpatialObjectToImageRegistrationMethod.h"
 
 namespace itk
 {

--- a/src/Registration/itktubeAnisotropicDiffusiveRegistrationFilter.hxx
+++ b/src/Registration/itktubeAnisotropicDiffusiveRegistrationFilter.hxx
@@ -23,7 +23,6 @@ limitations under the License.
 #ifndef __itktubeAnisotropicDiffusiveRegistrationFilter_hxx
 #define __itktubeAnisotropicDiffusiveRegistrationFilter_hxx
 
-#include "itktubeAnisotropicDiffusiveRegistrationFilter.h"
 
 #include "itktubeDiffusiveRegistrationFilterUtils.h"
 

--- a/src/Registration/itktubeAnisotropicDiffusiveRegistrationFunction.hxx
+++ b/src/Registration/itktubeAnisotropicDiffusiveRegistrationFunction.hxx
@@ -23,7 +23,6 @@ limitations under the License.
 #ifndef __itktubeAnisotropicDiffusiveRegistrationFunction_hxx
 #define __itktubeAnisotropicDiffusiveRegistrationFunction_hxx
 
-#include "itktubeAnisotropicDiffusiveRegistrationFunction.h"
 
 namespace itk
 {

--- a/src/Registration/itktubeAnisotropicDiffusiveSparseRegistrationFilter.hxx
+++ b/src/Registration/itktubeAnisotropicDiffusiveSparseRegistrationFilter.hxx
@@ -24,7 +24,6 @@ limitations under the License.
 #define __itktubeAnisotropicDiffusiveSparseRegistrationFilter_hxx
 
 
-#include "itktubeAnisotropicDiffusiveSparseRegistrationFilter.h"
 
 #include "itktubeDiffusiveRegistrationFilterUtils.h"
 #include "tubeTubeMathFilters.h"

--- a/src/Registration/itktubeDiffusiveRegistrationFilter.hxx
+++ b/src/Registration/itktubeDiffusiveRegistrationFilter.hxx
@@ -23,7 +23,6 @@ limitations under the License.
 #ifndef __itktubeDiffusiveRegistrationFilter_hxx
 #define __itktubeDiffusiveRegistrationFilter_hxx
 
-#include "itktubeDiffusiveRegistrationFilter.h"
 
 #include "itktubeDiffusiveRegistrationFilterUtils.h"
 

--- a/src/Registration/itktubeDiffusiveRegistrationFilterUtils.hxx
+++ b/src/Registration/itktubeDiffusiveRegistrationFilterUtils.hxx
@@ -23,7 +23,6 @@ limitations under the License.
 #ifndef __itktubeDiffusiveRegistrationFilterUtils_hxx
 #define __itktubeDiffusiveRegistrationFilterUtils_hxx
 
-#include "itktubeDiffusiveRegistrationFilterUtils.h"
 
 #include <itkMinimumMaximumImageCalculator.h>
 #include <itkResampleImageFilter.h>

--- a/src/Registration/itktubeInitialSpatialObjectToImageRegistrationMethod.hxx
+++ b/src/Registration/itktubeInitialSpatialObjectToImageRegistrationMethod.hxx
@@ -23,7 +23,6 @@ limitations under the License.
 #ifndef __itktubeInitialSpatialObjectToImageRegistrationMethod_txx
 #define __itktubeInitialSpatialObjectToImageRegistrationMethod_txx
 
-#include "itktubeInitialSpatialObjectToImageRegistrationMethod.h"
 
 //#include "itktubeSpatialObjectRegionMomentsCalculator.h"
 #include "itkAnisotropicSimilarity3DTransform.h"

--- a/src/Registration/itktubeMeanSquareRegistrationFunction.hxx
+++ b/src/Registration/itktubeMeanSquareRegistrationFunction.hxx
@@ -23,7 +23,6 @@ limitations under the License.
 #ifndef __itktubeMeanSquareRegistrationFunction_hxx
 #define __itktubeMeanSquareRegistrationFunction_hxx
 
-#include "itktubeMeanSquareRegistrationFunction.h"
 
 #include <vnl/vnl_math.h>
 

--- a/src/Registration/itktubeMergeAdjacentImagesFilter.hxx
+++ b/src/Registration/itktubeMergeAdjacentImagesFilter.hxx
@@ -31,7 +31,6 @@ limitations under the License.
 
 // TubeTK includes
 #include "itkGeneralizedDistanceTransformImageFilter.h"
-#include "itktubeMergeAdjacentImagesFilter.h"
 
 namespace itk
 {

--- a/src/Registration/itktubeOptimizedSpatialObjectToImageRegistrationMethod.hxx
+++ b/src/Registration/itktubeOptimizedSpatialObjectToImageRegistrationMethod.hxx
@@ -24,7 +24,6 @@ limitations under the License.
 #define __itktubeOptimizedSpatialObjectToImageRegistrationMethod_txx
 
 #include "itktubeSpatialObjectToImageRegistrationMethod.h"
-#include "itktubeOptimizedSpatialObjectToImageRegistrationMethod.h"
 #include "itktubePointBasedSpatialObjectToImageMetric.h"
 
 #include "itkRealTimeClock.h"

--- a/src/Registration/itktubePointBasedSpatialObjectToImageMetric.hxx
+++ b/src/Registration/itktubePointBasedSpatialObjectToImageMetric.hxx
@@ -23,7 +23,6 @@ limitations under the License.
 #ifndef __itktubePointBasedSpatialObjectToImageMetric_hxx
 #define __itktubePointBasedSpatialObjectToImageMetric_hxx
 
-#include "itktubePointBasedSpatialObjectToImageMetric.h"
 #include "itktubeNJetImageFunction.h"
 
 namespace itk

--- a/src/Registration/itktubePointBasedSpatialObjectTransformFilter.hxx
+++ b/src/Registration/itktubePointBasedSpatialObjectTransformFilter.hxx
@@ -23,7 +23,6 @@ limitations under the License.
 #ifndef __itktubePointBasedSpatialObjectTransformFilter_hxx
 #define __itktubePointBasedSpatialObjectTransformFilter_hxx
 
-#include "itktubePointBasedSpatialObjectTransformFilter.h"
 
 #include <itkSpatialObject.h>
 #include <itkSpatialObjectFactory.h>

--- a/src/Registration/itktubeRigidSpatialObjectToImageRegistrationMethod.hxx
+++ b/src/Registration/itktubeRigidSpatialObjectToImageRegistrationMethod.hxx
@@ -23,7 +23,6 @@ limitations under the License.
 #ifndef __tubeRigidSpatialObjectToImageRegistrationMethod_hxx
 #define __tubeRigidSpatialObjectToImageRegistrationMethod_hxx
 
-#include "itktubeRigidSpatialObjectToImageRegistrationMethod.h"
 
 #include "vnl/vnl_inverse.h"
 

--- a/src/Registration/itktubeScaleSkewAngle2DSpatialObjectToImageRegistrationMethod.hxx
+++ b/src/Registration/itktubeScaleSkewAngle2DSpatialObjectToImageRegistrationMethod.hxx
@@ -23,7 +23,6 @@ limitations under the License.
 #ifndef __itktubeScaleSkewAngle2DSpatialObjectToImageRegistrationMethod_txx
 #define __itktubeScaleSkewAngle2DSpatialObjectToImageRegistrationMethod_txx
 
-#include "itktubeScaleSkewAngle2DSpatialObjectToImageRegistrationMethod.h"
 
 namespace itk
 {

--- a/src/Registration/itktubeScaleSkewVersor3DSpatialObjectToImageRegistrationMethod.hxx
+++ b/src/Registration/itktubeScaleSkewVersor3DSpatialObjectToImageRegistrationMethod.hxx
@@ -24,7 +24,6 @@ limitations under the License.
 #ifndef __itktubeScaleSkewVersor3DSpatialObjectToImageRegistrationMethod_txx
 #define __itktubeScaleSkewVersor3DSpatialObjectToImageRegistrationMethod_txx
 
-#include "itktubeScaleSkewVersor3DSpatialObjectToImageRegistrationMethod.h"
 
 namespace itk
 {

--- a/src/Registration/itktubeSpatialObjectToImageMetric.hxx
+++ b/src/Registration/itktubeSpatialObjectToImageMetric.hxx
@@ -23,7 +23,6 @@ limitations under the License.
 #ifndef itktubeSpatialObjectToImageMetric_hxx
 #define itktubeSpatialObjectToImageMetric_hxx
 
-#include "itktubeSpatialObjectToImageMetric.h"
 
 namespace itk
 {

--- a/src/Registration/itktubeSpatialObjectToImageRegistrationHelper.hxx
+++ b/src/Registration/itktubeSpatialObjectToImageRegistrationHelper.hxx
@@ -23,7 +23,6 @@ limitations under the License.
 #ifndef __itktubeSpatialObjectToImageRegistrationHelper_txx
 #define __itktubeSpatialObjectToImageRegistrationHelper_txx
 
-#include "itktubeSpatialObjectToImageRegistrationHelper.h"
 
 #include "itktubePointBasedSpatialObjectTransformFilter.h"
 

--- a/src/Registration/itktubeSpatialObjectToImageRegistrationMethod.hxx
+++ b/src/Registration/itktubeSpatialObjectToImageRegistrationMethod.hxx
@@ -23,7 +23,6 @@ limitations under the License.
 #ifndef __itktubeSpatialObjectToImageRegistrationMethod_txx
 #define __itktubeSpatialObjectToImageRegistrationMethod_txx
 
-#include "itktubeSpatialObjectToImageRegistrationMethod.h"
 
 namespace itk
 {

--- a/src/Segmentation/itktubeComputeTrainingMaskFilter.hxx
+++ b/src/Segmentation/itktubeComputeTrainingMaskFilter.hxx
@@ -23,7 +23,6 @@ limitations under the License.
 #ifndef __itktubeComputeTrainingMaskFilter_hxx
 #define __itktubeComputeTrainingMaskFilter_hxx
 
-#include "itktubeComputeTrainingMaskFilter.h"
 
 namespace itk
 {

--- a/src/Segmentation/itktubePDFSegmenterBase.hxx
+++ b/src/Segmentation/itktubePDFSegmenterBase.hxx
@@ -24,7 +24,6 @@ limitations under the License.
 #ifndef __itktubePDFSegmenterBase_hxx
 #define __itktubePDFSegmenterBase_hxx
 
-#include "itktubePDFSegmenterBase.h"
 #include "itktubeVectorImageToListGenerator.h"
 
 #include <itkBinaryBallStructuringElement.h>

--- a/src/Segmentation/itktubePDFSegmenterParzen.hxx
+++ b/src/Segmentation/itktubePDFSegmenterParzen.hxx
@@ -24,7 +24,6 @@ limitations under the License.
 #ifndef __itktubePDFSegmenterParzen_hxx
 #define __itktubePDFSegmenterParzen_hxx
 
-#include "itktubePDFSegmenterParzen.h"
 #include "itktubeVectorImageToListGenerator.h"
 
 #include <itkBinaryBallStructuringElement.h>

--- a/src/Segmentation/itktubeRadiusExtractor2.hxx
+++ b/src/Segmentation/itktubeRadiusExtractor2.hxx
@@ -28,7 +28,6 @@ limitations under the License.
 #ifndef __itktubeRadiusExtractor2_hxx
 #define __itktubeRadiusExtractor2_hxx
 
-#include "itktubeRadiusExtractor2.h"
 
 #include "tubeMessage.h"
 #include "tubeMatrixMath.h"

--- a/src/Segmentation/itktubeRadiusExtractor3.hxx
+++ b/src/Segmentation/itktubeRadiusExtractor3.hxx
@@ -31,7 +31,6 @@ limitations under the License.
 #include <algorithm>
 #include <math.h>
 
-#include "itktubeRadiusExtractor3.h"
 
 #include "tubeMessage.h"
 #include "tubeMatrixMath.h"

--- a/src/Segmentation/itktubeRidgeExtractor.hxx
+++ b/src/Segmentation/itktubeRidgeExtractor.hxx
@@ -31,7 +31,6 @@ limitations under the License.
 
 #include "tubeMessage.h"
 #include "tubeMatrixMath.h"
-#include "itktubeRidgeExtractor.h"
 
 #include <itkImageRegionIterator.h>
 #include <itkMinimumMaximumImageFilter.h>

--- a/src/Segmentation/itktubeRidgeSeedFilter.hxx
+++ b/src/Segmentation/itktubeRidgeSeedFilter.hxx
@@ -24,7 +24,6 @@ limitations under the License.
 #ifndef __itktubeRidgeSeedFilter_hxx
 #define __itktubeRidgeSeedFilter_hxx
 
-#include "itktubeRidgeSeedFilter.h"
 
 #include "tubeMatrixMath.h"
 #include "itktubePDFSegmenterParzen.h"

--- a/src/Segmentation/itktubeSegmentTubeUsingMinimalPathFilter.hxx
+++ b/src/Segmentation/itktubeSegmentTubeUsingMinimalPathFilter.hxx
@@ -18,7 +18,6 @@
 #ifndef __itktubeSegmentTubeUsingMinimalPathFilter_hxx
 #define __itktubeSegmentTubeUsingMinimalPathFilter_hxx
 
-#include "itktubeSegmentTubeUsingMinimalPathFilter.h"
 
 // MinimalPathExtraction Imports
 #include "itkSpeedFunctionToPathFilter.h"

--- a/src/Segmentation/itktubeTubeExtractor.hxx
+++ b/src/Segmentation/itktubeTubeExtractor.hxx
@@ -29,7 +29,6 @@ limitations under the License.
 #ifndef __itktubeTubeExtractor_hxx
 #define __itktubeTubeExtractor_hxx
 
-#include "itktubeTubeExtractor.h"
 
 #include <itktubeLimitedMinimumMaximumImageFilter.h>
 


### PR DESCRIPTION
COMP: Remove inclusion of .hxx files as headers

The ability to include either .h or .hxx files as
header files required recursively reading the
.h files twice.  The added complexity is
unnecessary, costly, and can confuse static
analysis tools that monitor header guardes (due
to reaching the maximum depth of recursion
limits for nested #ifdefs in checking).

