### PR TITLE
COMP: Updating to match API change in ITK for ValidTimeStep

### DIFF
--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -5,7 +5,7 @@ on: [push,pull_request]
 env:
   ITKMinimalPathExtraction-git-tag: v1.2.0
   vtk-git-tag: "1681cee3489800373c2e183af2d3ca8552e05940"
-  itk-git-tag: "a89145bccda6a36f42cfdd45d3a6b27234ff54fe"
+  itk-git-tag: "v5.3rc03"
 
 jobs:
   build-test-cxx:
@@ -200,7 +200,7 @@ jobs:
       matrix:
         python-version: [37, 38, 39]
         include:
-          - itk-python-git-tag: "v5.3rc02"
+          - itk-python-git-tag: "v5.3rc03"
             c-compiler: "gcc"
             cxx-compiler: "g++"
             cmake-build-type: "Release"
@@ -308,7 +308,7 @@ jobs:
       max-parallel: 1
       matrix:
         include:
-          - itk-python-git-tag: "v5.3rc02"
+          - itk-python-git-tag: "v5.3rc03"
             c-compiler: "clang"
             cxx-compiler: "clang++"
             cmake-build-type: "Release"
@@ -391,7 +391,7 @@ jobs:
       matrix:
         python-version-minor: [7, 8, 9]
         include:
-          - itk-python-git-tag: "v5.3rc02"
+          - itk-python-git-tag: "v5.3rc03"
             c-compiler: "cl.exe"
             cxx-compiler: "cl.exe"
             cmake-build-type: "Release"

--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -253,7 +253,7 @@ jobs:
         ln -s -f -T /ITKPythonPackage/ITK-source /work/ITK-source
         ln -s -f -T /ITKPythonPackage/oneTBB-prefix /work/oneTBB-prefix
         export ITK_DIR="/work/ITK-cp39-cp39-manylinux2014_x64"
-        echo "itk_dir = $ITK_DIR"
+        export
         ls -la /work
         git clone https://github.com/Slicer/SlicerExecutionModel
         mkdir -p SlicerExecutionModel-build

--- a/examples/Demo-ImageRegistration.ipynb
+++ b/examples/Demo-ImageRegistration.ipynb
@@ -114,7 +114,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.6"
+   "version": "3.7.10"
   }
  },
  "nbformat": 4,

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setup(
     url=r'https://itk.org/',
     install_requires=[
         r'numpy',
-        r'itk>=5.3rc2.post1',
+        r'itk>=5.3rc3',
         r'itk-minimalpathextraction>=1.2.0'
     ]
     )

--- a/src/Filtering/itktubeAnisotropicDiffusionTensorImageFilter.h
+++ b/src/Filtering/itktubeAnisotropicDiffusionTensorImageFilter.h
@@ -199,7 +199,7 @@ private:
     AnisotropicDiffusionTensorImageFilter *Filter;
     TimeStepType TimeStep;
     std::vector< TimeStepType > TimeStepList;
-    std::vector< bool > ValidTimeStepList;
+    std::vector< itk::uint8_t > ValidTimeStepList;
 
     }; // End struct DenseFDThreadStruct
 

--- a/src/Filtering/itktubeAnisotropicDiffusionTensorImageFilter.hxx
+++ b/src/Filtering/itktubeAnisotropicDiffusionTensorImageFilter.hxx
@@ -273,7 +273,7 @@ AnisotropicDiffusionTensorImageFilter<TInputImage, TOutputImage>
   str.ValidTimeStepList.resize( threadCount );
   for( ThreadIdType i =0; i < threadCount; ++i )
     {
-    str.ValidTimeStepList[i] = false;
+    str.ValidTimeStepList[i] = 0;
     }
 
   // Multithread the execution
@@ -318,7 +318,7 @@ AnisotropicDiffusionTensorImageFilter<TInputImage, TOutputImage>
     str->TimeStepList[threadId]
       = str->Filter->ThreadedCalculateChange( splitRegion,
         splitDiffusionimageRegion, threadId );
-    str->ValidTimeStepList[threadId] = true;
+    str->ValidTimeStepList[threadId] = 1;
     }
 
   return ITK_THREAD_RETURN_DEFAULT_VALUE;

--- a/src/Registration/itktubeDiffusiveRegistrationFilter.h
+++ b/src/Registration/itktubeDiffusiveRegistrationFilter.h
@@ -815,7 +815,7 @@ private:
     OutputImagePointer OutputImage;
     TimeStepType TimeStep;
     TimeStepType *TimeStepList;
-    bool *ValidTimeStepList;
+    itk::uint8_t *ValidTimeStepList;
     }; // End struct DenseFDThreadStruct
 
   /** Structure for passing information into static callback methods.  Used
@@ -841,7 +841,7 @@ private:
     DiffusiveRegistrationFilter *Filter;
     TimeStepType TimeStep;
     std::vector< TimeStepType > TimeStepList;
-    std::vector< bool > ValidTimeStepList;
+    std::vector< itk::uint8_t > ValidTimeStepList;
     UpdateMetricsIntermediateStruct *UpdateMetricsIntermediate;
     }; // End struct CalculateChangeGradientThreadStruct
 

--- a/src/Registration/itktubeDiffusiveRegistrationFilter.hxx
+++ b/src/Registration/itktubeDiffusiveRegistrationFilter.hxx
@@ -896,7 +896,7 @@ DiffusiveRegistrationFilter
   str.ValidTimeStepList.resize( threadCount );
   for( int i = 0; i < threadCount; ++i )
     {
-    str.ValidTimeStepList[i] = false;
+    str.ValidTimeStepList[i] = 0; // false
     }
 
   // Multithread the execution
@@ -996,7 +996,7 @@ DiffusiveRegistrationFilter
         splitTensorDerivativeRegion, splitScalarDerivativeRegion,
         splitStoppingCriterionMaskImageRegion,
         str->UpdateMetricsIntermediate[threadId], threadId );
-    str->ValidTimeStepList[threadId] = true;
+    str->ValidTimeStepList[threadId] = 1; // True
     }
 
   return ITK_THREAD_RETURN_DEFAULT_VALUE;


### PR DESCRIPTION
ITK's finite difference methods changed the validtimestep variables from bool to uint8_t in commit: https://github.com/InsightSoftwareConsortium/ITK/commit/b66133ab53369bdf265348c0c31cfa6451b53934

For example, see  [ITK/Modules/Core/FiniteDifference/include/itkDenseFiniteDifferenceImageFilter.h](https://github.com/InsightSoftwareConsortium/ITK/blob/master/Modules/Core/FiniteDifference/include/itkDenseFiniteDifferenceImageFilter.h)
