### PR TITLE
ENH: Add building of python wheels for Python 3.6, 3.7, and 3.8

### DIFF
--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -199,9 +199,30 @@ jobs:
     strategy:
       max-parallel: 1
       matrix:
-        python-version: [39]
+        python-version: [36, 37, 38, 39]
         include:
-          - itk-python-git-tag: "v5.3rc03"
+          - python-version: 36
+            itk-package: "ITK-cp36m-cp36-manylinux2014_x64"
+            itk-python-git-tag: "v5.3rc03"
+            c-compiler: "gcc"
+            cxx-compiler: "g++"
+            cmake-build-type: "Release"
+          - python-version: 38
+          - python-version: 37
+            itk-package: "ITK-cp37m-cp37-manylinux2014_x64"
+            itk-python-git-tag: "v5.3rc03"
+            c-compiler: "gcc"
+            cxx-compiler: "g++"
+            cmake-build-type: "Release"
+          - python-version: 38
+            itk-package: "ITK-cp38-cp38-manylinux2014_x64"
+            itk-python-git-tag: "v5.3rc03"
+            c-compiler: "gcc"
+            cxx-compiler: "g++"
+            cmake-build-type: "Release"
+          - python-version: 39
+            itk-package: "ITK-cp39-cp39-manylinux2014_x64"
+            itk-python-git-tag: "v5.3rc03"
             c-compiler: "gcc"
             cxx-compiler: "g++"
             cmake-build-type: "Release"
@@ -253,15 +274,15 @@ jobs:
       run: |
         cat > git-configure-build-sem.sh << EOF
         #!/bin/sh
-        ln -s -f -T /ITKPythonPackage/ITK-cp39-cp39-manylinux2014_x64 /work/ITK-cp39-cp39-manylinux2014_x64
+        ln -s -f -T /ITKPythonPackage/${{ matrix.itk-package }} /work/${{ matrix.itk-package }}
         ln -s -f -T /ITKPythonPackage/ITK-source /work/ITK-source
         ln -s -f -T /ITKPythonPackage/oneTBB-prefix /work/oneTBB-prefix
-        export ITK_DIR="/work/ITK-cp39-cp39-manylinux2014_x64"
+        export ITK_DIR="/work/${{ matrix.itk-package }}"
         git clone https://github.com/Slicer/SlicerExecutionModel
         mkdir -p SlicerExecutionModel-build
         cd SlicerExecutionModel-build
         cmake -DCMAKE_BUILD_TYPE:STRING=Release \
-          -DITK_DIR=/work/ITK-cp39-cp39-manylinux2014_x64 \
+          -DITK_DIR=/work/${{ matrix.itk-package }} \
           -GNinja \
           ../SlicerExecutionModel
         ninja

--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -199,15 +199,8 @@ jobs:
     strategy:
       max-parallel: 1
       matrix:
-        python-version: [36, 37, 38, 39]
+        python-version: [37, 38, 39]
         include:
-          - python-version: 36
-            itk-package: "ITK-cp36-cp36m-manylinux2014_x64"
-            itk-python-git-tag: "v5.3rc03"
-            c-compiler: "gcc"
-            cxx-compiler: "g++"
-            cmake-build-type: "Release"
-          - python-version: 38
           - python-version: 37
             itk-package: "ITK-cp37-cp37m-manylinux2014_x64"
             itk-python-git-tag: "v5.3rc03"

--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -202,14 +202,14 @@ jobs:
         python-version: [36, 37, 38, 39]
         include:
           - python-version: 36
-            itk-package: "ITK-cp36m-cp36-manylinux2014_x64"
+            itk-package: "ITK-cp36-cp36m-manylinux2014_x64"
             itk-python-git-tag: "v5.3rc03"
             c-compiler: "gcc"
             cxx-compiler: "g++"
             cmake-build-type: "Release"
           - python-version: 38
           - python-version: 37
-            itk-package: "ITK-cp37m-cp37-manylinux2014_x64"
+            itk-package: "ITK-cp37-cp37m-manylinux2014_x64"
             itk-python-git-tag: "v5.3rc03"
             c-compiler: "gcc"
             cxx-compiler: "g++"


### PR DESCRIPTION
Correctly resolve the naming convention used for pre-compiled ITK packages against which Linux python wheels are built.