### PR TITLE
BUG: Update Write4D python API to support python ITK Image args

### DIFF
--- a/include/tubeWrite4DImageFrom3DImages.h
+++ b/include/tubeWrite4DImageFrom3DImages.h
@@ -66,7 +66,7 @@ public:
 
   /** Set the index'th output image slice */
   void SetNthInputImage( unsigned int outputIndex,
-    const typename InputImageType::Pointer & img);
+    const InputImageType * img);
 
   itkSetMacro( FileName, std::string );
 

--- a/include/tubeWrite4DImageFrom3DImages.hxx
+++ b/include/tubeWrite4DImageFrom3DImages.hxx
@@ -62,7 +62,7 @@ template< class InputImageT >
 void
 Write4DImageFrom3DImages< InputImageT >::
 SetNthInputImage( unsigned int outputIndex,
-  const typename InputImageType::Pointer & img )
+  const InputImageType * img )
 {
   if( m_OutputImage == nullptr )
     {
@@ -89,6 +89,11 @@ SetNthInputImage( unsigned int outputIndex,
     outSize[3] = m_NumberOfInputImages;
     outSpacing[3] = 1;
     outIndex[3] = 0;
+    for( unsigned int j=0; j<3; ++j )
+      {
+      outDirection(3, j) = 0;
+      }
+    outDirection(3, 3) = 1;
 
     typename OutputImageType::RegionType outRegion;
     outRegion.SetSize( outSize );


### PR DESCRIPTION
Python args should be raw pointers to images, not smart pointers.