### PR TITLE
COMP: Address ITK Windows warnings

### DIFF
--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -4,7 +4,7 @@ on: [push,pull_request]
 
 env:
   vtk-git-tag: "v9.2.2"
-  itk-git-tag: "v5.3.0"
+  itk-git-tag: "37c107436f163436d9f9caf015b6f642eacdf651"
   itk-wheel-tag: "v5.3.0"
   itk-minimalpathextraction-git-tag: "v1.2.4"
 
@@ -90,7 +90,7 @@ jobs:
         cd ..
         mkdir ITK-build
         pushd ITK-build
-        cmake -DCMAKE_C_COMPILER:FILEPATH="${{ matrix.c-compiler }}" -DModule_MinimalPathExtraction:BOOL=ON -DBUILD_SHARED_LIBS:BOOL=ON -DCMAKE_CXX_COMPILER="${{ matrix.cxx-compiler }}" -DCMAKE_BUILD_TYPE:STRING=${{ matrix.cmake-build-type }} -DBUILD_TESTING:BOOL=OFF -GNinja ../ITK
+        cmake -DCMAKE_C_COMPILER:FILEPATH="${{ matrix.c-compiler }}" -DITK_LEGACY_REMOVE:BOOL=ON -DModule_MinimalPathExtraction:BOOL=ON -DBUILD_SHARED_LIBS:BOOL=ON -DCMAKE_CXX_COMPILER="${{ matrix.cxx-compiler }}" -DCMAKE_BUILD_TYPE:STRING=${{ matrix.cmake-build-type }} -DBUILD_TESTING:BOOL=OFF -GNinja ../ITK
         ninja
 
     - name: Build ITK
@@ -100,7 +100,7 @@ jobs:
         mkdir ITK-build
         pushd ITK-build
         call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
-        cmake -DCMAKE_C_COMPILER:FILEPATH="${{ matrix.c-compiler }}" -DModule_MinimalPathExtraction:BOOL=ON -DBUILD_SHARED_LIBS:BOOL=ON -DCMAKE_CXX_COMPILER="${{ matrix.cxx-compiler }}" -DCMAKE_BUILD_TYPE:STRING=${{ matrix.cmake-build-type }} -DBUILD_TESTING:BOOL=OFF -GNinja ../ITK
+        cmake -DCMAKE_C_COMPILER:FILEPATH="${{ matrix.c-compiler }}" -DITK_LEGACY_REMOVE:BOOL=ON -DModule_MinimalPathExtraction:BOOL=ON -DBUILD_SHARED_LIBS:BOOL=ON -DCMAKE_CXX_COMPILER="${{ matrix.cxx-compiler }}" -DCMAKE_BUILD_TYPE:STRING=${{ matrix.cmake-build-type }} -DBUILD_TESTING:BOOL=OFF -GNinja ../ITK
         ninja
       shell: cmd
 


### PR DESCRIPTION
Bumps to CI to HEAD of current ITK `release` branch to incorporate:

- https://github.com/InsightSoftwareConsortium/ITK/commit/0892cd1e3f314efb2a1d92490352b891b88100eb

to address related Windows CI warnings such as:

```
\d\a\ITKTubeTK\ITKTubeTK\Modules\Core\Common\src\itkNumericTraits.cxx(76): warning C4996: 'std::complex<char>::complex': warning STL4037: The effect of instantiating the template std::complex for any type other than float, double, or long double is unspecified. You can define _SILENCE_NONFLOATING_COMPLEX_DEPRECATION_WARNING to suppress this warning.
```