### PR TITLE
ENH: Remove the generation of vectoritkImageF4, since ITK now provides

### DIFF
--- a/wrapping/tubeSegmentConnectedComponentsUsingParzenPDFs.wrap
+++ b/wrapping/tubeSegmentConnectedComponentsUsingParzenPDFs.wrap
@@ -1,9 +1,5 @@
 itk_wrap_include( tubeSegmentConnectedComponentsUsingParzenPDFs.h )
-itk_wrap_include( itkImage.h )
 
-itk_wrap_class("itk::Image" POINTER)
-  itk_wrap_template("${ITKM_F}4" "${ITKT_F}, 4")
-itk_end_wrap_class()
 itk_wrap_named_class("tube::SegmentConnectedComponentsUsingParzenPDFs" tubeSegmentConnectedComponentsUsingParzenPDFs POINTER)
   foreach(t ${WRAP_ITK_SCALAR})
     foreach(t2 ${WRAP_ITK_SCALAR})


### PR DESCRIPTION
Eliminating this warning:

tubeSegmentConnectedComponentsUsingParzenPDFs_ext.i(78) : Warning 404: Duplicate template instantiation of 'vector< itkImageF4_Pointer >' with name 'vectoritkImageF4' ignored,
itkImage_ext.i(560) : Warning 404: previous instantiation of 'vector< itkImageF4_Pointer >' with name 'vectoritkImageF4'.