### PR TITLE
ENH: Replace ITKv5_CONST with const for ITKv6 compatibility

### DIFF
--- a/src/Filtering/itktubeShrinkWithBlendingImageFilter.h
+++ b/src/Filtering/itktubeShrinkWithBlendingImageFilter.h
@@ -147,10 +147,10 @@ protected:
 
   void UpdateInternalShrinkFactors();
 
-  void VerifyInputInformation() ITKv5_CONST override;
+  void VerifyInputInformation() const override;
 
   template<class ArrayType>
-  bool NotValue( ArrayType array, double val, double tolerance=0.00001 ) ITKv5_CONST;
+  bool NotValue( ArrayType array, double val, double tolerance=0.00001 ) const;
 
 private:
   ShrinkWithBlendingImageFilter( const Self & ); //purposely not implemented

--- a/src/Filtering/itktubeShrinkWithBlendingImageFilter.hxx
+++ b/src/Filtering/itktubeShrinkWithBlendingImageFilter.hxx
@@ -367,7 +367,7 @@ template< class TInputImage, class TOutputImage >
 template <typename ArrayType>
 bool
 ShrinkWithBlendingImageFilter< TInputImage, TOutputImage >
-::NotValue( ArrayType array, double val, double tolerance ) ITKv5_CONST
+::NotValue( ArrayType array, double val, double tolerance ) const
 {
   for( unsigned int i = 0; i < ImageDimension; i++ )
     {
@@ -382,7 +382,7 @@ ShrinkWithBlendingImageFilter< TInputImage, TOutputImage >
 template< class TInputImage, class TOutputImage >
 void
 ShrinkWithBlendingImageFilter< TInputImage, TOutputImage >
-::VerifyInputInformation() ITKv5_CONST
+::VerifyInputInformation() const
 {
   bool useNewSize;
   bool useShrinkFactors;


### PR DESCRIPTION
Per the migration guide (https://docs.itk.org/en/latest/migration_guides/itk_6_migration_guide.html) have replaced ITKv5_CONST with const.

Addresses compilation issue in https://github.com/InsightSoftwareConsortium/ITKTubeTK/issues/157