### PR TITLE
BUG: TubeTK STATIC, even if itkTubeTK SHARED

### DIFF
--- a/include/MinimalPathExtractionExport.h
+++ b/include/MinimalPathExtractionExport.h
@@ -2,7 +2,7 @@
 
 #include "itkConfigure.h"
 // Workaround for ITKTubeTK Python package builds
-#if !defined(ITK_BUILD_SHARED_LIBS) && !defined(MinimalPathExtraction_EXPORT)
+#if !defined(MinimalPathExtraction_EXPORT)
 #  define MinimalPathExtraction_EXPORT
 #  define MinimalPathExtraction_HIDDEN
 #else

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -31,4 +31,6 @@ include( ObjectDocuments.cmake )
 include( Registration.cmake )
 include( Segmentation.cmake )
 
-itk_module_add_library( TubeTK ${TubeTK_SRCS} )
+add_library(TubeTK STATIC ${TubeTK_SRCS})
+itk_module_link_dependencies()
+itk_module_target(TubeTK)


### PR DESCRIPTION
itkTubeTK is a two-library system:

1) The include directory contains the itkTubeTK library which depends on the TubeTK library. The itkTubeTK library is a high-quality (or perhaps we should say constantly improving) ITK interface to the TubeTK library (e.g., it is a compliant ITK module, supports wrapping, etc.).

2) The src directory contains the TubeTK library which is an (ancient) mix of ITK and non-ITK classes, functions, applications, and
examples.   It is poorly documented and inconsistent in style, but it is (arguably, for some users) rich in functionality. :)

Regretfully the old TubeTK library in src does not support being built as a shared library.  So, even if itkTubeTK is being built shared, the underlying TubeTK library will always be built static.