### PR TITLE
STYLE: Add itkVirtualGetNameOfClassMacro + itkOverrideGetNameOfClassMacro

### DIFF
--- a/examples/Applications/AtlasBuilderUsingIntensity/itktubeCompleteImageResampleFilter.h
+++ b/examples/Applications/AtlasBuilderUsingIntensity/itktubeCompleteImageResampleFilter.h
@@ -71,7 +71,7 @@ public:
   itkNewMacro( Self );
 
   /** Run-time type information ( and related methods ). */
-  itkTypeMacro( CompleteImageResampleFilter, ImageToImageFilter );
+  itkOverrideGetNameOfClassMacro( CompleteImageResampleFilter);
 
   /** Number of dimensions. */
   itkStaticConstMacro( ImageDimension, unsigned int,

--- a/examples/Applications/AtlasBuilderUsingIntensity/itktubeMeanAndSigmaImageBuilder.h
+++ b/examples/Applications/AtlasBuilderUsingIntensity/itktubeMeanAndSigmaImageBuilder.h
@@ -64,7 +64,7 @@ public:
                        TInputImageType::ImageDimension );
 
   itkNewMacro( Self );
-  itkTypeMacro( MeanAndSigmaImageBuilder, Object );
+  itkOverrideGetNameOfClassMacro( MeanAndSigmaImageBuilder);
 
   typedef TInputImageType                               InputImageType;
   typedef TOutputMeanImageType                          OutputMeanImageType;

--- a/examples/Applications/AtlasBuilderUsingIntensity/itktubeMinimizeImageSizeFilter.h
+++ b/examples/Applications/AtlasBuilderUsingIntensity/itktubeMinimizeImageSizeFilter.h
@@ -58,7 +58,7 @@ public:
   typedef SmartPointer< const Self >              ConstPointer;
 
   itkNewMacro( Self );
-  itkTypeMacro( MinimizeImageSizeFilter, ImageToImageFilter );
+  itkOverrideGetNameOfClassMacro( MinimizeImageSizeFilter);
 
   typedef TInputImage                             InputImageType;
   typedef typename InputImageType::PixelType      InputPixelType;

--- a/examples/Applications/AtlasBuilderUsingIntensity/itktubeRobustMeanAndSigmaImageBuilder.h
+++ b/examples/Applications/AtlasBuilderUsingIntensity/itktubeRobustMeanAndSigmaImageBuilder.h
@@ -64,7 +64,7 @@ public:
   typedef SmartPointer< const Self >                        ConstPointer;
 
   itkNewMacro( Self );
-  itkTypeMacro( RobustMeanAndSigmaImageBuilder, MeanAndSigmaImageBuilder );
+  itkOverrideGetNameOfClassMacro( RobustMeanAndSigmaImageBuilder);
 
   typedef TInputImageType                              InputImageType;
   typedef TOutputMeanImageType                         OutputMeanImageType;

--- a/examples/Applications/DeblendTomosynthesisSlicesUsingPrior/DeblendTomosynthesisSlicesUsingPrior.cxx
+++ b/examples/Applications/DeblendTomosynthesisSlicesUsingPrior/DeblendTomosynthesisSlicesUsingPrior.cxx
@@ -56,7 +56,7 @@ public:
   typedef SmartPointer< Self >                    Pointer;
   typedef SmartPointer< const Self >              ConstPointer;
 
-  itkTypeMacro( BlendCostFunction, SingleValuedCostFunction );
+  itkOverrideGetNameOfClassMacro( BlendCostFunction);
 
   itkNewMacro( Self );
 
@@ -261,7 +261,7 @@ public:
   typedef SmartPointer< Self >                    Pointer;
   typedef SmartPointer< const Self >              ConstPointer;
 
-  itkTypeMacro( BlendScaleCostFunction, SingleValuedCostFunction );
+  itkOverrideGetNameOfClassMacro( BlendScaleCostFunction);
 
   itkNewMacro( Self );
 

--- a/include/tubeComputeBinaryImageSimilarityMetrics.h
+++ b/include/tubeComputeBinaryImageSimilarityMetrics.h
@@ -57,7 +57,7 @@ public:
   itkNewMacro( Self );
 
   /** Run-time type information ( and related methods ). */
-  itkTypeMacro( ComputeBinaryImageSimilarityMetrics, ProcessObject );
+  itkOverrideGetNameOfClassMacro( ComputeBinaryImageSimilarityMetrics);
 
   /** Set the source image. */
   tubeWrapSetConstObjectMacro( SourceImage, InputImageType, Filter );

--- a/include/tubeComputeImageSimilarityMetrics.h
+++ b/include/tubeComputeImageSimilarityMetrics.h
@@ -60,7 +60,7 @@ public:
   itkNewMacro( Self );
 
   /** Run-time type information ( and related methods ). */
-  itkTypeMacro( ComputeImageSimilarityMetrics, Object );
+  itkOverrideGetNameOfClassMacro( ComputeImageSimilarityMetrics);
 
   /** Set/Get use of correlation or mutual information to compute similarity */
   tubeWrapSetMacro( UseCorrelation, bool, Filter );

--- a/include/tubeComputeImageStatistics.h
+++ b/include/tubeComputeImageStatistics.h
@@ -62,7 +62,7 @@ public:
   itkNewMacro( Self );
 
   /** Run-time type information ( and related methods ). */
-  itkTypeMacro( ComputeImageStatistics, ProcessObject );
+  itkOverrideGetNameOfClassMacro( ComputeImageStatistics);
 
   /** Get statistics components */
   tubeWrapGetMacro( CompMean, std::vector< double >, Filter );

--- a/include/tubeComputeTrainingMask.h
+++ b/include/tubeComputeTrainingMask.h
@@ -53,7 +53,7 @@ public:
   itkNewMacro( Self );
 
   /** Run-time type information ( and related methods ). */
-  itkTypeMacro( ComputeTrainingMask, ProcessObject );
+  itkOverrideGetNameOfClassMacro( ComputeTrainingMask);
 
 
   /** Typedef to images */

--- a/include/tubeComputeTubeFlyThroughImage.h
+++ b/include/tubeComputeTubeFlyThroughImage.h
@@ -63,7 +63,7 @@ public:
   itkNewMacro( Self );
 
   /** Run-time type information ( and related methods ). */
-  itkTypeMacro( ComputeTubeFlyThroughImage, ProcessObject );
+  itkOverrideGetNameOfClassMacro( ComputeTubeFlyThroughImage);
 
   /** Set/Get tube id for which the fly through image is to be generated */
   tubeWrapSetMacro( TubeId, unsigned long, Filter );

--- a/include/tubeComputeTubeMeasures.h
+++ b/include/tubeComputeTubeMeasures.h
@@ -59,7 +59,7 @@ public:
   itkNewMacro( Self );
 
   /** Run-time type information ( and related methods ). */
-  itkTypeMacro( ComputeTubeMeasures, ProcessObject );
+  itkOverrideGetNameOfClassMacro( ComputeTubeMeasures);
 
   /** Set/Get scale */
   tubeWrapSetMacro( Scale, int, Filter );

--- a/include/tubeConvertImagesToCSV.h
+++ b/include/tubeConvertImagesToCSV.h
@@ -52,7 +52,7 @@ public:
   itkNewMacro( Self );
 
   /** Run-time type information ( and related methods ). */
-  itkTypeMacro( ConvertImagesToCSV, ProcessObject );
+  itkOverrideGetNameOfClassMacro( ConvertImagesToCSV);
 
   typedef TInputMask                                      InputMaskType;
   typedef typename InputMaskType::PixelType               MaskPixelType;

--- a/include/tubeConvertShrunkenSeedImageToList.h
+++ b/include/tubeConvertShrunkenSeedImageToList.h
@@ -52,7 +52,7 @@ public:
   itkNewMacro( Self );
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro( ConvertShrunkenSeedImageToList, ProcessObject );
+  itkOverrideGetNameOfClassMacro( ConvertShrunkenSeedImageToList);
 
   typedef TImage                                           ImageType;
   typedef typename ImageType::PixelType                    PixelType;

--- a/include/tubeConvertSpatialGraphToImage.h
+++ b/include/tubeConvertSpatialGraphToImage.h
@@ -61,7 +61,7 @@ public:
   itkNewMacro( Self );
 
   /** Run-time type information ( and related methods ). */
-  itkTypeMacro( ConvertSpatialGraphToImage, ProcessObject );
+  itkOverrideGetNameOfClassMacro( ConvertSpatialGraphToImage);
 
   /** Get Adjacency Matrix Image */
   tubeWrapGetMacro( AdjacencyMatrixImage, OutputImagePointer, Filter );

--- a/include/tubeConvertTubesToDensityImage.h
+++ b/include/tubeConvertTubesToDensityImage.h
@@ -62,7 +62,7 @@ public:
   itkNewMacro( Self );
 
   /** Run-time type information ( and related methods ). */
-  itkTypeMacro( ConvertTubesToDensityImage, Object );
+  itkOverrideGetNameOfClassMacro( ConvertTubesToDensityImage);
 
   typedef itk::Image< TOutputPixel, Dimension >          RadiusImageType;
   typedef typename RadiusImageType::Pointer              RadiusImagePointer;

--- a/include/tubeConvertTubesToImage.h
+++ b/include/tubeConvertTubesToImage.h
@@ -63,7 +63,7 @@ public:
   itkNewMacro( Self );
 
   /** Run-time type information ( and related methods ). */
-  itkTypeMacro( ConvertTubesToImage, ProcessObject );
+  itkOverrideGetNameOfClassMacro( ConvertTubesToImage);
 
   /** Set if the tube should be full inside */
   tubeWrapSetMacro( UseRadius, bool, Filter );

--- a/include/tubeConvertTubesToTubeGraph.h
+++ b/include/tubeConvertTubesToTubeGraph.h
@@ -61,7 +61,7 @@ public:
   itkNewMacro( Self );
 
   /** Run-time type information ( and related methods ). */
-  itkTypeMacro( ConvertTubesToTubeGraph, ProcessObject );
+  itkOverrideGetNameOfClassMacro( ConvertTubesToTubeGraph);
 
   /** Set Number of Centroids */
   tubeWrapSetMacro( NumberOfCenteroids, int, Filter );

--- a/include/tubeCropImage.h
+++ b/include/tubeCropImage.h
@@ -52,7 +52,7 @@ public:
   itkNewMacro( Self );
 
   /** Run-time type information ( and related methods ). */
-  itkTypeMacro( CropImage, ProcessObject );
+  itkOverrideGetNameOfClassMacro( CropImage);
 
 
   /** Typedef to images */

--- a/include/tubeCropTubes.h
+++ b/include/tubeCropTubes.h
@@ -56,7 +56,7 @@ public:
   itkNewMacro( Self );
 
   /** Run-time type information ( and related methods ). */
-  itkTypeMacro( CropTubes, ProcessObject );
+  itkOverrideGetNameOfClassMacro( CropTubes);
 
  /* Set input tubes */
   tubeWrapSetMacro( Input, TubeGroupPointer, Filter );

--- a/include/tubeEnhanceContrastUsingPrior.h
+++ b/include/tubeEnhanceContrastUsingPrior.h
@@ -61,7 +61,7 @@ public:
   itkNewMacro( Self );
 
   /** Run-time type information ( and related methods ). */
-  itkTypeMacro( EnhanceContrastUsingPrior, ProcessObject );
+  itkOverrideGetNameOfClassMacro( EnhanceContrastUsingPrior);
 
   /* Set input image */
   tubeWrapSetConstObjectMacro( Input, ImageType, Filter );

--- a/include/tubeEnhanceEdgesUsingDiffusion.h
+++ b/include/tubeEnhanceEdgesUsingDiffusion.h
@@ -59,7 +59,7 @@ public:
   itkNewMacro( Self );
 
   /** Run-time type information ( and related methods ). */
-  itkTypeMacro( EnhanceEdgesUsingDiffusion, ProcessObject );
+  itkOverrideGetNameOfClassMacro( EnhanceEdgesUsingDiffusion);
 
   /** Set/Get input image */
   tubeWrapSetConstObjectMacro( Input, InputImageType, Filter );

--- a/include/tubeEnhanceTubesUsingDiffusion.h
+++ b/include/tubeEnhanceTubesUsingDiffusion.h
@@ -60,7 +60,7 @@ public:
   itkNewMacro( Self );
 
   /** Run-time type information ( and related methods ). */
-  itkTypeMacro( EnhanceTubesUsingDiffusion, ProcessObject );
+  itkOverrideGetNameOfClassMacro( EnhanceTubesUsingDiffusion);
 
   /** Set/Get minimum sigma/scale */
   itkSetMacro( MinSigma, double );

--- a/include/tubeEnhanceTubesUsingDiscriminantAnalysis.h
+++ b/include/tubeEnhanceTubesUsingDiscriminantAnalysis.h
@@ -72,7 +72,7 @@ public:
   itkNewMacro( Self );
 
   /** Run-time type information ( and related methods ). */
-  itkTypeMacro( EnhanceTubesUsingDiscriminantAnalysis, ProcessObject );
+  itkOverrideGetNameOfClassMacro( EnhanceTubesUsingDiscriminantAnalysis);
 
   /***/
   /***/

--- a/include/tubeImageMath.h
+++ b/include/tubeImageMath.h
@@ -63,7 +63,7 @@ public:
   itkNewMacro( Self );
 
   /** Run-time type information ( and related methods ). */
-  itkTypeMacro( ImageMath, ProcessObject );
+  itkOverrideGetNameOfClassMacro( ImageMath);
 
   void SetInput( InputImageType * input )
   { typedef itk::CastImageFilter< InputImageType, ImageType > CastFilterType;

--- a/include/tubeMergeAdjacentImages.h
+++ b/include/tubeMergeAdjacentImages.h
@@ -65,7 +65,7 @@ public:
   itkNewMacro( Self );
 
   /** Run-time type information ( and related methods ). */
-  itkTypeMacro( MergeAdjacentImages, ProcessObject );
+  itkOverrideGetNameOfClassMacro( MergeAdjacentImages);
 
   /** Set input image 1 */
   tubeWrapSetConstObjectMacro( Input1, ImageType, Filter );

--- a/include/tubeRegisterImages.h
+++ b/include/tubeRegisterImages.h
@@ -68,7 +68,7 @@ public:
   itkNewMacro( Self );
 
   /** Run-time type information ( and related methods ). */
-  itkTypeMacro( RegisterImages, ProcessObject );
+  itkOverrideGetNameOfClassMacro( RegisterImages);
 
   /* Set input image */
   tubeWrapCallWithConstReferenceArgMacro( LoadFixedImage, std::string, Filter );

--- a/include/tubeResampleImage.h
+++ b/include/tubeResampleImage.h
@@ -60,7 +60,7 @@ public:
   itkNewMacro( Self );
 
   /** Run-time type information ( and related methods ). */
-  itkTypeMacro( ResampleImage, ProcessObject );
+  itkOverrideGetNameOfClassMacro( ResampleImage);
 
   /* Set input image */
   tubeWrapSetObjectMacro( Input, ImageType, Filter );

--- a/include/tubeSegmentBinaryImageSkeleton3D.h
+++ b/include/tubeSegmentBinaryImageSkeleton3D.h
@@ -62,7 +62,7 @@ public:
   itkNewMacro( Self );
 
   /** Run-time type information ( and related methods ). */
-  itkTypeMacro( SegmentBinaryImageSkeleton3D, ProcessObject );
+  itkOverrideGetNameOfClassMacro( SegmentBinaryImageSkeleton3D);
 
   /** Set/Get input image */
   tubeWrapSetConstObjectMacro( Input, ImageType, Filter );

--- a/include/tubeSegmentConnectedComponents.h
+++ b/include/tubeSegmentConnectedComponents.h
@@ -59,7 +59,7 @@ public:
   itkNewMacro( Self );
 
   /** Run-time type information ( and related methods ). */
-  itkTypeMacro( SegmentConnectedComponents, ProcessObject );
+  itkOverrideGetNameOfClassMacro( SegmentConnectedComponents);
 
   itkStaticConstMacro( ImageDimension, unsigned int, ImageType::ImageDimension );
 

--- a/include/tubeSegmentConnectedComponentsUsingParzenPDFs.h
+++ b/include/tubeSegmentConnectedComponentsUsingParzenPDFs.h
@@ -74,7 +74,7 @@ public:
   itkNewMacro( Self );
 
   /** Run-time type information ( and related methods ). */
-  itkTypeMacro( SegmentConnectedComponentsUsingParzenPDFs, ProcessObject );
+  itkOverrideGetNameOfClassMacro( SegmentConnectedComponentsUsingParzenPDFs);
 
   /** Set/Get input image */
   void SetFeatureImage( InputImageType * img );

--- a/include/tubeSegmentTubeUsingMinimalPath.h
+++ b/include/tubeSegmentTubeUsingMinimalPath.h
@@ -65,7 +65,7 @@ public:
   itkNewMacro( Self );
 
   /** Run-time type information ( and related methods ). */
-  itkTypeMacro( SegmentTubeUsingMinimalPath, Object );
+  itkOverrideGetNameOfClassMacro( SegmentTubeUsingMinimalPath);
 
   /* Set target tubes */
   tubeWrapSetMacro( TargetTubeGroup, TubeGroupPointer, Filter );

--- a/include/tubeSegmentTubes.h
+++ b/include/tubeSegmentTubes.h
@@ -71,7 +71,7 @@ public:
   itkNewMacro( Self );
 
   /** Run-time type information ( and related methods ). */
-  itkTypeMacro( SegmentTubes, ProcessObject );
+  itkOverrideGetNameOfClassMacro( SegmentTubes);
 
   /***/
   /***/

--- a/include/tubeSegmentUsingOtsuThreshold.h
+++ b/include/tubeSegmentUsingOtsuThreshold.h
@@ -64,7 +64,7 @@ public:
   itkNewMacro( Self );
 
   /** Run-time type information ( and related methods ). */
-  itkTypeMacro( SegmentUsingOtsuThreshold, ProcessObject );
+  itkOverrideGetNameOfClassMacro( SegmentUsingOtsuThreshold);
 
   /** Set/Get mask image */
   tubeWrapSetConstObjectMacro( MaskImage, MaskImageType, Filter );

--- a/include/tubeShrinkImageWithBlending.h
+++ b/include/tubeShrinkImageWithBlending.h
@@ -51,7 +51,7 @@ public:
   itkNewMacro( Self );
 
   /** Run-time type information ( and related methods ). */
-  itkTypeMacro( ShrinkImageWithBlending, ProcessObject );
+  itkOverrideGetNameOfClassMacro( ShrinkImageWithBlending);
 
 
   /** Typedef to images */

--- a/include/tubeTubeMath.h
+++ b/include/tubeTubeMath.h
@@ -61,7 +61,7 @@ public:
   itkNewMacro( Self );
 
   /** Run-time type information ( and related methods ). */
-  itkTypeMacro( TubeMath, ProcessObject );
+  itkOverrideGetNameOfClassMacro( TubeMath);
 
   void SetInputTubeGroup( TubeGroupType * tubeGroup )
   { m_Filter.SetInputTubeGroup( tubeGroup ); this->Modified(); };

--- a/include/tubeWrite4DImageFrom3DImages.h
+++ b/include/tubeWrite4DImageFrom3DImages.h
@@ -55,7 +55,7 @@ public:
   itkNewMacro( Self );
 
   /** Run-time type information ( and related methods ). */
-  itkTypeMacro( Write4DImageFrom3DImages, ProcessObject );
+  itkOverrideGetNameOfClassMacro( Write4DImageFrom3DImages);
 
   /***/
   /***/

--- a/include/tubeWriteTubesAsPolyData.h
+++ b/include/tubeWriteTubesAsPolyData.h
@@ -51,7 +51,7 @@ public:
   itkNewMacro( Self );
 
   /** Run-time type information ( and related methods ). */
-  itkTypeMacro( WriteTubesAsPolyData, ProcessObject );
+  itkOverrideGetNameOfClassMacro( WriteTubesAsPolyData);
 
   /***/
   /***/

--- a/src/Filtering/itkImageRegionSplitter.h
+++ b/src/Filtering/itkImageRegionSplitter.h
@@ -78,7 +78,7 @@ public:
   itkNewMacro( Self );
 
   /** Run-time type information ( and related methods ). */
-  itkTypeMacro( ImageRegionSplitter, Object );
+  itkOverrideGetNameOfClassMacro( ImageRegionSplitter);
 
   /** Dimension of the image available at compile time. */
   itkStaticConstMacro( ImageDimension, unsigned int, VImageDimension );

--- a/src/Filtering/itktubeAnisotropicHybridDiffusionImageFilter.h
+++ b/src/Filtering/itktubeAnisotropicHybridDiffusionImageFilter.h
@@ -73,7 +73,7 @@ public:
   itkNewMacro( Self );
 
   /** Run-time type information ( and related methods ) */
-  itkTypeMacro( AnisotropicHybridDiffusionImageFilter, ImageToImageFilter );
+  itkOverrideGetNameOfClassMacro( AnisotropicHybridDiffusionImageFilter);
 
   /** Convenient typedefs */
   typedef typename Superclass::InputImageType  InputImageType;

--- a/src/Filtering/itktubeBinaryThinningImageFilter3D.h
+++ b/src/Filtering/itktubeBinaryThinningImageFilter3D.h
@@ -87,7 +87,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro( BinaryThinningImageFilter3D, ImageToImageFilter );
+  itkOverrideGetNameOfClassMacro( BinaryThinningImageFilter3D);
 
   /** Type for input image. */
   typedef   TInputImage       InputImageType;

--- a/src/Filtering/itktubeCVTImageFilter.h
+++ b/src/Filtering/itktubeCVTImageFilter.h
@@ -56,7 +56,7 @@ public:
   /** Method for creation through the object factory. */
   itkNewMacro( Self );
 
-  itkTypeMacro( CVTImageFilter, ImageToImageFilter );
+  itkOverrideGetNameOfClassMacro( CVTImageFilter);
 
   itkStaticConstMacro( ImageDimension, unsigned int,
                        TInputImage::ImageDimension );

--- a/src/Filtering/itktubeContrastCostFunction.h
+++ b/src/Filtering/itktubeContrastCostFunction.h
@@ -49,7 +49,7 @@ public:
   itkNewMacro( Self );
 
   /** Run-time type information ( and related methods ). */
-  itkTypeMacro( ContrastCostFunction, SingleValuedCostFunction );
+  itkOverrideGetNameOfClassMacro( ContrastCostFunction);
 
   typedef Superclass::MeasureType          MeasureType;
   typedef Superclass::ParametersType       ParametersType;

--- a/src/Filtering/itktubeConvertImagesToCSVFilter.h
+++ b/src/Filtering/itktubeConvertImagesToCSVFilter.h
@@ -64,7 +64,7 @@ public:
   itkNewMacro( Self );
 
   /** Run-time type information ( and related methods ). */
-  itkTypeMacro( ConvertImagesToCSVFilter, ProcessObject );
+  itkOverrideGetNameOfClassMacro( ConvertImagesToCSVFilter);
 
   /** ImageDimension constants */
   itkStaticConstMacro( ImageDimension, unsigned int,

--- a/src/Filtering/itktubeConvertShrunkenSeedImageToListFilter.h
+++ b/src/Filtering/itktubeConvertShrunkenSeedImageToListFilter.h
@@ -67,7 +67,7 @@ public:
   itkNewMacro( Self );
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro( ConvertShrunkenSeedImageToListFilter, ProcessObject );
+  itkOverrideGetNameOfClassMacro( ConvertShrunkenSeedImageToListFilter);
 
   /** ImageDimension constants */
   itkStaticConstMacro( ImageDimension, unsigned int,

--- a/src/Filtering/itktubeConvertSpatialGraphToImageFilter.h
+++ b/src/Filtering/itktubeConvertSpatialGraphToImageFilter.h
@@ -50,7 +50,7 @@ public:
   /** Method for creation through the object factory. */
   itkNewMacro( Self );
 
-  itkTypeMacro( ConvertSpatialGraphToImageFilter, ImageToImageFilter );
+  itkOverrideGetNameOfClassMacro( ConvertSpatialGraphToImageFilter);
 
   itkStaticConstMacro( ImageDimension, unsigned int,
                        TInputImage::ImageDimension );

--- a/src/Filtering/itktubeCropImageFilter.h
+++ b/src/Filtering/itktubeCropImageFilter.h
@@ -58,7 +58,7 @@ public:
   itkNewMacro( Self );
 
   /** Run-time type information ( and related methods ). */
-  itkTypeMacro( CropImageFilter, ExtractImageFilter );
+  itkOverrideGetNameOfClassMacro( CropImageFilter);
 
   /** Typedef to describe the output and input image region types. */
   typedef typename Superclass::OutputImageRegionType OutputImageRegionType;

--- a/src/Filtering/itktubeDifferenceImageFilter.h
+++ b/src/Filtering/itktubeDifferenceImageFilter.h
@@ -59,7 +59,7 @@ public:
   itkNewMacro( Self );
 
   /** Run-time type information ( and related methods ). */
-  itkTypeMacro( DifferenceImageFilter, ImageToImageFilter );
+  itkOverrideGetNameOfClassMacro( DifferenceImageFilter);
 
   /** Some convenient typedefs. */
   typedef TInputImage                               InputImageType;

--- a/src/Filtering/itktubeEnhanceContrastUsingPriorImageFilter.h
+++ b/src/Filtering/itktubeEnhanceContrastUsingPriorImageFilter.h
@@ -58,7 +58,7 @@ public:
   itkNewMacro( Self );
 
   /** Run-time type information ( and related methods ). */
-  itkTypeMacro( EnhanceContrastUsingPriorImageFilter, ImageToImageFilter );
+  itkOverrideGetNameOfClassMacro( EnhanceContrastUsingPriorImageFilter);
 
   /** Some convenient typedefs. */
   typedef itk::tube::ContrastCostFunction< TPixel, VDimension >

--- a/src/Filtering/itktubeExtractTubePointsSpatialObjectFilter.h
+++ b/src/Filtering/itktubeExtractTubePointsSpatialObjectFilter.h
@@ -75,7 +75,7 @@ public:
                                                GroupSpatialObjectType;
 
   /** Run-time type information ( and related methods ). */
-  itkTypeMacro( ExtractTubePointsSpatialObjectFilter, ProcessObject );
+  itkOverrideGetNameOfClassMacro( ExtractTubePointsSpatialObjectFilter);
 
   /** Standard New method. */
   itkNewMacro( Self );

--- a/src/Filtering/itktubeFFTGaussianDerivativeIFFTFilter.h
+++ b/src/Filtering/itktubeFFTGaussianDerivativeIFFTFilter.h
@@ -54,7 +54,7 @@ public:
 
   itkNewMacro( Self );
 
-  itkTypeMacro( FFTGaussianDerivativeIFFTFilter, GaussianDerivativeFilter );
+  itkOverrideGetNameOfClassMacro( FFTGaussianDerivativeIFFTFilter);
 
   itkStaticConstMacro( ImageDimension, unsigned int,
     TInputImage::ImageDimension );

--- a/src/Filtering/itktubeGaussianDerivativeFilter.h
+++ b/src/Filtering/itktubeGaussianDerivativeFilter.h
@@ -41,7 +41,7 @@ public:
   typedef SmartPointer< const Self >                      ConstPointer;
 
   /** Run-time type information ( and related methods ). */
-  itkTypeMacro( GaussianDerivativeFilter, ImageToImageFilter );
+  itkOverrideGetNameOfClassMacro( GaussianDerivativeFilter);
 
   itkStaticConstMacro( ImageDimension, unsigned int,
                        TInputImage::ImageDimension );

--- a/src/Filtering/itktubeGaussianDerivativeImageSource.h
+++ b/src/Filtering/itktubeGaussianDerivativeImageSource.h
@@ -93,7 +93,7 @@ public:
   typedef typename Superclass::ParametersType      ParametersType;
 
   /** Run-time type information ( and related methods ). */
-  itkTypeMacro( GaussianDerivativeImageSource, ParametricImageSource );
+  itkOverrideGetNameOfClassMacro( GaussianDerivativeImageSource);
 
   /** Method for creation through the object factory. */
   itkNewMacro( Self );

--- a/src/Filtering/itktubeInverseIntensityImageFilter.h
+++ b/src/Filtering/itktubeInverseIntensityImageFilter.h
@@ -67,7 +67,7 @@ public:
   itkGetMacro( InverseMaximumIntensity, InputPixelType );
 
   /** Run-time type information ( and related methods ). */
-  itkTypeMacro( InverseIntensityImageFilter, ImageToImageFilter );
+  itkOverrideGetNameOfClassMacro( InverseIntensityImageFilter);
 
 protected:
 

--- a/src/Filtering/itktubeLimitedMinimumMaximumImageFilter.h
+++ b/src/Filtering/itktubeLimitedMinimumMaximumImageFilter.h
@@ -79,7 +79,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(LimitedMinimumMaximumImageFilter, ImageToImageFilter);
+  itkOverrideGetNameOfClassMacro(LimitedMinimumMaximumImageFilter);
 
   /** Image type alias support */
   using InputImageType = TInputImage;

--- a/src/Filtering/itktubePadImageFilter.h
+++ b/src/Filtering/itktubePadImageFilter.h
@@ -86,7 +86,7 @@ public:
   itkNewMacro( Self );
 
   /** Runtime information support. */
-  itkTypeMacro( PadImageFilter, ImageToImageFilter );
+  itkOverrideGetNameOfClassMacro( PadImageFilter);
 
   /**
    * Set/Get whether the images must be padded to a size equal to a

--- a/src/Filtering/itktubeReResampleImageFilter.h
+++ b/src/Filtering/itktubeReResampleImageFilter.h
@@ -58,7 +58,7 @@ public:
   /** Method for creation through the object factory. */
   itkNewMacro( Self );
 
-  itkTypeMacro( ReResampleImageFilter, ProcessObject );
+  itkOverrideGetNameOfClassMacro( ReResampleImageFilter);
 
   typedef typename ImageType::Pointer                     ImagePointer;
   typedef itk::Transform< double, VDimension, VDimension> TransformType;

--- a/src/Filtering/itktubeRegionFromReferenceImageFilter.h
+++ b/src/Filtering/itktubeRegionFromReferenceImageFilter.h
@@ -51,7 +51,7 @@ public:
   itkNewMacro( Self );
 
   /** Run-time type information ( and related methods ). */
-  itkTypeMacro( RegionFromReferenceImageFilter, ExtractImageFilter );
+  itkOverrideGetNameOfClassMacro( RegionFromReferenceImageFilter);
 
   /** Typedef to describe the output and input image region types. */
   typedef typename Superclass::OutputImageRegionType OutputImageRegionType;

--- a/src/Filtering/itktubeRidgeFFTFilter.h
+++ b/src/Filtering/itktubeRidgeFFTFilter.h
@@ -45,7 +45,7 @@ public:
 
   itkNewMacro( Self );
 
-  itkTypeMacro( RidgeFFTFilter, ImageToImageFilter );
+  itkOverrideGetNameOfClassMacro( RidgeFFTFilter);
 
   itkStaticConstMacro( ImageDimension, unsigned int,
     TInputImage::ImageDimension );

--- a/src/Filtering/itktubeSheetnessMeasureImageFilter.h
+++ b/src/Filtering/itktubeSheetnessMeasureImageFilter.h
@@ -88,7 +88,7 @@ public:
     InputImageType, EigenValueImageType >           EigenAnalysisFilterType;
 
   /** Run-time type information ( and related methods ).   */
-  itkTypeMacro( SheetnessMeasureImageFilter, ImageToImageFilter );
+  itkOverrideGetNameOfClassMacro( SheetnessMeasureImageFilter);
 
   /** Method for creation through the object factory. */
   itkNewMacro( Self );

--- a/src/Filtering/itktubeShrinkWithBlendingImageFilter.h
+++ b/src/Filtering/itktubeShrinkWithBlendingImageFilter.h
@@ -73,7 +73,7 @@ public:
   itkNewMacro( Self );
 
   /** Run-time type information ( and related methods ). */
-  itkTypeMacro( ShrinkWithBlendingImageFilter, ShrinkImageFilter );
+  itkOverrideGetNameOfClassMacro( ShrinkWithBlendingImageFilter);
 
   /** Typedef to images */
   typedef TOutputImage                          OutputImageType;

--- a/src/Filtering/itktubeSpatialObjectFilter.h
+++ b/src/Filtering/itktubeSpatialObjectFilter.h
@@ -49,7 +49,7 @@ public:
   typedef SmartPointer< const Self >                           ConstPointer;
 
   /** Run-time type information ( and related methods ). */
-  itkTypeMacro( SpatialObjectFilter, SpatialObjectSource );
+  itkOverrideGetNameOfClassMacro( SpatialObjectFilter);
 
   typedef SpatialObject<ObjectDimension>  SpatialObjectType;
 

--- a/src/Filtering/itktubeSpatialObjectSource.h
+++ b/src/Filtering/itktubeSpatialObjectSource.h
@@ -59,7 +59,7 @@ public:
     DataObjectPointerArraySizeType;
 
   /** Run-time type information ( and related methods ). */
-  itkTypeMacro( SpatialObjectSource, ProcessObject );
+  itkOverrideGetNameOfClassMacro( SpatialObjectSource);
 
   OutputSpatialObjectType * GetOutput( void );
   const OutputSpatialObjectType * GetOutput( void ) const;

--- a/src/Filtering/itktubeSpatialObjectToSpatialObjectFilter.h
+++ b/src/Filtering/itktubeSpatialObjectToSpatialObjectFilter.h
@@ -47,7 +47,7 @@ public:
   typedef SmartPointer< const Self >                  ConstPointer;
 
   /** Run-time type information ( and related methods ). */
-  itkTypeMacro( SpatialObjectToSpatialObjectFilter, SpatialObjectSource );
+  itkOverrideGetNameOfClassMacro( SpatialObjectToSpatialObjectFilter);
 
   typedef TInputSpatialObject  InputSpatialObjectType;
   typedef TOutputSpatialObject OutputSpatialObjectType;

--- a/src/Filtering/itktubeTubeEnhancingDiffusion2DImageFilter.h
+++ b/src/Filtering/itktubeTubeEnhancingDiffusion2DImageFilter.h
@@ -92,7 +92,7 @@ public:
   typedef SmartPointer< const Self >                      ConstPointer;
 
   itkNewMacro( Self );
-  itkTypeMacro( TubeEnhancingDiffusion2DImageFilter, ImageToImageFilter );
+  itkOverrideGetNameOfClassMacro( TubeEnhancingDiffusion2DImageFilter);
 
   /** Set/Get time step */
   itkSetMacro( TimeStep, Precision );

--- a/src/Filtering/itktubeTubeSpatialObjectToDensityImageFilter.h
+++ b/src/Filtering/itktubeTubeSpatialObjectToDensityImageFilter.h
@@ -50,7 +50,7 @@ public:
   typedef SmartPointer< Self >                    Pointer;
 
   itkNewMacro( Self );
-  itkTypeMacro( TubeSpatialObjectToDensityImageFilter, Object );
+  itkOverrideGetNameOfClassMacro( TubeSpatialObjectToDensityImageFilter);
 
   /** Typdefs */
   typedef TDensityImageType                              DensityImageType;

--- a/src/IO/itktubeTubeXIO.h
+++ b/src/IO/itktubeTubeXIO.h
@@ -49,7 +49,7 @@ public:
 
   typedef Size< TDimension >                      SizeType;
 
-  itkTypeMacro( TubeXIO, Object );
+  itkOverrideGetNameOfClassMacro( TubeXIO);
 
   itkNewMacro( TubeXIO );
 

--- a/src/Numerics/itktubeBasisFeatureVectorGenerator.h
+++ b/src/Numerics/itktubeBasisFeatureVectorGenerator.h
@@ -49,7 +49,7 @@ public:
   typedef SmartPointer< Self >                   Pointer;
   typedef SmartPointer< const Self >             ConstPointer;
 
-  itkTypeMacro( BasisFeatureVectorGenerator, FeatureVectorGenerator );
+  itkOverrideGetNameOfClassMacro( BasisFeatureVectorGenerator);
 
   itkNewMacro( Self );
 

--- a/src/Numerics/itktubeBlurImageFunction.h
+++ b/src/Numerics/itktubeBlurImageFunction.h
@@ -50,7 +50,7 @@ public:
   typedef SmartPointer< Self >                         Pointer;
   typedef SmartPointer< const Self >                   ConstPointer;
 
-  itkTypeMacro( BlurImageFunction, ImageFunction );
+  itkOverrideGetNameOfClassMacro( BlurImageFunction);
 
   itkNewMacro( Self );
 

--- a/src/Numerics/itktubeComputeImageSimilarityMetrics.h
+++ b/src/Numerics/itktubeComputeImageSimilarityMetrics.h
@@ -58,7 +58,7 @@ public:
   itkNewMacro( Self );
 
   /** Run-time type information ( and related methods ). */
-  itkTypeMacro( ComputeImageSimilarityMetrics, Object );
+  itkOverrideGetNameOfClassMacro( ComputeImageSimilarityMetrics);
 
   /** Set/Get use of correlation or mutual information to compute similarity */
   itkSetMacro( UseCorrelation, bool );

--- a/src/Numerics/itktubeComputeImageStatistics.h
+++ b/src/Numerics/itktubeComputeImageStatistics.h
@@ -61,7 +61,7 @@ public:
   itkNewMacro( Self );
 
   /** Run-time type information ( and related methods ). */
-  itkTypeMacro( ComputeImageStatistics, ImageToImageFilter );
+  itkOverrideGetNameOfClassMacro( ComputeImageStatistics);
 
   /** Set/Get input mask */
   itkSetObjectMacro( InputMask, MaskType );

--- a/src/Numerics/itktubeFeatureVectorGenerator.h
+++ b/src/Numerics/itktubeFeatureVectorGenerator.h
@@ -47,7 +47,7 @@ public:
   typedef SmartPointer< Self >                 Pointer;
   typedef SmartPointer< const Self >           ConstPointer;
 
-  itkTypeMacro( FeatureVectorGenerator, LightProcessObject );
+  itkOverrideGetNameOfClassMacro( FeatureVectorGenerator);
 
   itkNewMacro( Self );
 

--- a/src/Numerics/itktubeImageRegionMomentsCalculator.h
+++ b/src/Numerics/itktubeImageRegionMomentsCalculator.h
@@ -80,7 +80,7 @@ public:
   itkNewMacro( Self );
 
   /** Run-time type information ( and related methods ). */
-  itkTypeMacro( ImageRegionMomentsCalculator, Object );
+  itkOverrideGetNameOfClassMacro( ImageRegionMomentsCalculator);
 
   /** Extract the dimension of the image. */
   itkStaticConstMacro( ImageDimension, unsigned int,

--- a/src/Numerics/itktubeImageRegionMomentsCalculator.hxx
+++ b/src/Numerics/itktubeImageRegionMomentsCalculator.hxx
@@ -57,7 +57,7 @@ public:
     this->SetDescription( "No valid image moments are availble." );
     }
 
-  itkTypeMacro( InvalidImageRegionMomentsError, ExceptionObject );
+  itkOverrideGetNameOfClassMacro( InvalidImageRegionMomentsError);
 
 }; // End class InvalidImageRegionMomentsError
 

--- a/src/Numerics/itktubeJointHistogramImageFunction.h
+++ b/src/Numerics/itktubeJointHistogramImageFunction.h
@@ -61,7 +61,7 @@ public:
   typedef itk::Image<float, 2>                          HistogramType;
 
   /** Run-time type information ( and related methods ). */
-  itkTypeMacro( JointHistogramImageFunction, ImageFunction );
+  itkOverrideGetNameOfClassMacro( JointHistogramImageFunction);
 
   /** Standard New Macro. */
   itkNewMacro( Self );

--- a/src/Numerics/itktubeNJetFeatureVectorGenerator.h
+++ b/src/Numerics/itktubeNJetFeatureVectorGenerator.h
@@ -51,7 +51,7 @@ public:
   typedef SmartPointer< Self >                 Pointer;
   typedef SmartPointer< const Self >           ConstPointer;
 
-  itkTypeMacro( NJetFeatureVectorGenerator, FeatureVectorGenerator );
+  itkOverrideGetNameOfClassMacro( NJetFeatureVectorGenerator);
 
   itkNewMacro( Self );
 

--- a/src/Numerics/itktubeNJetImageFunction.h
+++ b/src/Numerics/itktubeNJetImageFunction.h
@@ -68,8 +68,8 @@ public:
    */
   itkNewMacro( Self );
 
-  itkTypeMacro( NJetImageFunction, Object );
-  //itkTypeMacro( NJetImageFunction, ImageFunction );
+  itkOverrideGetNameOfClassMacro( NJetImageFunction);
+  //itkOverrideGetNameOfClassMacro( NJetImageFunction);
 
   /**
    * Dimension of the underlying image.

--- a/src/Numerics/itktubeRidgeFFTFeatureVectorGenerator.h
+++ b/src/Numerics/itktubeRidgeFFTFeatureVectorGenerator.h
@@ -50,7 +50,7 @@ public:
   typedef SmartPointer< Self >                 Pointer;
   typedef SmartPointer< const Self >           ConstPointer;
 
-  itkTypeMacro( RidgeFFTFeatureVectorGenerator, FeatureVectorGenerator );
+  itkOverrideGetNameOfClassMacro( RidgeFFTFeatureVectorGenerator);
 
   itkNewMacro( Self );
 

--- a/src/Numerics/itktubeSingleValuedCostFunctionImageSource.h
+++ b/src/Numerics/itktubeSingleValuedCostFunctionImageSource.h
@@ -64,7 +64,7 @@ public:
   itkStaticConstMacro( NumberOfParameters, unsigned int, VNumberOfParameters );
 
   /** Run-time type information ( and related methods ). */
-  itkTypeMacro( SingleValuedCostFunctionImageSource, ImageSource );
+  itkOverrideGetNameOfClassMacro( SingleValuedCostFunctionImageSource);
 
   /** Method for creation through the object factory. */
   itkNewMacro( Self );

--- a/src/Numerics/itktubeVectorImageToListGenerator.h
+++ b/src/Numerics/itktubeVectorImageToListGenerator.h
@@ -74,7 +74,7 @@ public:
   typedef SmartPointer< const Self >        ConstPointer;
 
   /** Run-time type information ( and related methods ). */
-  itkTypeMacro( VectorImageToListGenerator, ProcessObject );
+  itkOverrideGetNameOfClassMacro( VectorImageToListGenerator);
 
   /** Method for creation through the object factory. */
   itkNewMacro( Self );

--- a/src/Numerics/itktubeVotingResampleImageFunction.h
+++ b/src/Numerics/itktubeVotingResampleImageFunction.h
@@ -61,7 +61,7 @@ public:
   typedef SmartPointer< const Self >                       ConstPointer;
 
   /** Run-time type information ( and related methods ). */
-  itkTypeMacro( VotingResampleImageFunction, InterpolateImageFunction );
+  itkOverrideGetNameOfClassMacro( VotingResampleImageFunction);
 
   /** Method for creation through the object factory. */
   itkNewMacro( Self );

--- a/src/ObjectDocuments/itktubeBlobSpatialObjectDocument.h
+++ b/src/ObjectDocuments/itktubeBlobSpatialObjectDocument.h
@@ -52,7 +52,7 @@ public:
   typedef Superclass::TransformNameListType  TransformNameListType;
 
   itkNewMacro( Self );
-  itkTypeMacro( BlobSpatialObjectDocument, SpatialObjectDocument );
+  itkOverrideGetNameOfClassMacro( BlobSpatialObjectDocument);
 
 protected:
 

--- a/src/ObjectDocuments/itktubeDocument.h
+++ b/src/ObjectDocuments/itktubeDocument.h
@@ -48,7 +48,7 @@ public:
   typedef SmartPointer< const Self >  ConstPointer;
 
   itkNewMacro( Self );
-  itkTypeMacro( Document, DataObject );
+  itkOverrideGetNameOfClassMacro( Document);
 
   /** Return the date modified. */
   itkGetStringMacro( DateModified );

--- a/src/ObjectDocuments/itktubeImageDocument.h
+++ b/src/ObjectDocuments/itktubeImageDocument.h
@@ -51,7 +51,7 @@ public:
   typedef Superclass::TransformNameListType  TransformNameListType;
 
   itkNewMacro( Self );
-  itkTypeMacro( ImageDocument, ObjectDocument );
+  itkOverrideGetNameOfClassMacro( ImageDocument);
 
 protected:
 

--- a/src/ObjectDocuments/itktubeObjectDocument.h
+++ b/src/ObjectDocuments/itktubeObjectDocument.h
@@ -49,7 +49,7 @@ public:
   typedef std::vector< std::string >       TransformNameListType;
 
   itkNewMacro( Self );
-  itkTypeMacro( ObjectDocument, Document );
+  itkOverrideGetNameOfClassMacro( ObjectDocument);
 
   /** Return the object type. */
   itkGetStringMacro( ObjectType );

--- a/src/ObjectDocuments/itktubeObjectDocumentToImageFilter.h
+++ b/src/ObjectDocuments/itktubeObjectDocumentToImageFilter.h
@@ -72,7 +72,7 @@ public:
     InterpolateImageFunctionPointer;
 
   itkNewMacro( Self );
-  itkTypeMacro( ObjectDocumentToImageFilter, ObjectDocumentToObjectSource );
+  itkOverrideGetNameOfClassMacro( ObjectDocumentToImageFilter);
 
   /** Return the interpolator. */
   itkGetModifiableObjectMacro( Interpolator, InterpolateImageFunctionType );

--- a/src/ObjectDocuments/itktubeObjectDocumentToObjectSource.h
+++ b/src/ObjectDocuments/itktubeObjectDocumentToObjectSource.h
@@ -62,7 +62,7 @@ public:
   typedef typename TransformType::Pointer      TransformPointer;
 
   itkNewMacro( Self );
-  itkTypeMacro( ObjectDocumentToObjectSource, ProcessObject );
+  itkOverrideGetNameOfClassMacro( ObjectDocumentToObjectSource);
 
   /** Return whether the transforms should be applied. */
   itkGetMacro( ApplyTransforms, bool );

--- a/src/ObjectDocuments/itktubeSpatialObjectDocument.h
+++ b/src/ObjectDocuments/itktubeSpatialObjectDocument.h
@@ -52,7 +52,7 @@ public:
   typedef Superclass::TransformNameListType  TransformNameListType;
 
   itkNewMacro( Self );
-  itkTypeMacro( SpatialObjectDocument, ObjectDocument );
+  itkOverrideGetNameOfClassMacro( SpatialObjectDocument);
 
 protected:
 

--- a/src/Registration/Deprecated/itktubeSpatialObjectRegionMomentsCalculator.h
+++ b/src/Registration/Deprecated/itktubeSpatialObjectRegionMomentsCalculator.h
@@ -69,7 +69,7 @@ public:
   itkNewMacro( Self );
 
   /** Run-time type information ( and related methods ). */
-  itkTypeMacro( SpatialObjectMomentsCalculator, Object );
+  itkOverrideGetNameOfClassMacro( SpatialObjectMomentsCalculator);
 
   /** Standard scalar type within this class. */
   typedef double ScalarType;

--- a/src/Registration/Deprecated/itktubeSpatialObjectRegionMomentsCalculator.hxx
+++ b/src/Registration/Deprecated/itktubeSpatialObjectRegionMomentsCalculator.hxx
@@ -54,7 +54,7 @@ public:
     this->SetDescription("No valid spatial Object moments are availble.");
   }
 
-  itkTypeMacro(InvalidSpatialObjectRegionMomentsError, ExceptionObject);
+  itkOverrideGetNameOfClassMacro(InvalidSpatialObjectRegionMomentsError);
 };
 
 // ----------------------------------------------------------------------

--- a/src/Registration/itkAnisotropicSimilarity3DTransform.h
+++ b/src/Registration/itkAnisotropicSimilarity3DTransform.h
@@ -68,7 +68,7 @@ public:
   itkNewMacro( Self );
 
   /** Run-time type information ( and related methods ). */
-  itkTypeMacro( AnisotropicSimilarity3DTransform, VersorRigid3DTransform );
+  itkOverrideGetNameOfClassMacro( AnisotropicSimilarity3DTransform);
 
   /** Dimension of parameters. */
   itkStaticConstMacro( SpaceDimension, unsigned int, 3 );

--- a/src/Registration/itkBSplineImageToImageRegistrationMethod.hxx
+++ b/src/Registration/itkBSplineImageToImageRegistrationMethod.hxx
@@ -49,7 +49,7 @@ public:
   typedef Command                        Superclass;
   typedef SmartPointer<Self>             Pointer;
 
-  itkTypeMacro( BSplineImageRegistrationViewer, Command );
+  itkOverrideGetNameOfClassMacro( BSplineImageRegistrationViewer);
 
   itkNewMacro( BSplineImageRegistrationViewer );
 

--- a/src/Registration/itkImageRegionMomentsCalculator.h
+++ b/src/Registration/itkImageRegionMomentsCalculator.h
@@ -77,7 +77,7 @@ public:
   itkNewMacro( Self );
 
   /** Run-time type information ( and related methods ). */
-  itkTypeMacro( ImageRegionMomentsCalculator, Object );
+  itkOverrideGetNameOfClassMacro( ImageRegionMomentsCalculator);
 
   /** Extract the dimension of the image. */
   itkStaticConstMacro( ImageDimension, unsigned int,

--- a/src/Registration/itkImageRegionMomentsCalculator.hxx
+++ b/src/Registration/itkImageRegionMomentsCalculator.hxx
@@ -49,7 +49,7 @@ public:
     this->SetDescription("No valid image moments are availble.");
   }
 
-  itkTypeMacro(InvalidImageRegionMomentsError, ExceptionObject);
+  itkOverrideGetNameOfClassMacro(InvalidImageRegionMomentsError);
 };
 
 // ----------------------------------------------------------------------

--- a/src/Registration/itkImageToImageRegistrationHelper.h
+++ b/src/Registration/itkImageToImageRegistrationHelper.h
@@ -49,7 +49,7 @@ public:
   typedef SmartPointer<Self>             Pointer;
   typedef SmartPointer<const Self>       ConstPointer;
 
-  itkTypeMacro( ImageToImageRegistrationHelper, Object );
+  itkOverrideGetNameOfClassMacro( ImageToImageRegistrationHelper);
 
   itkNewMacro( Self );
 

--- a/src/Registration/itkImageToImageRegistrationMethod.h
+++ b/src/Registration/itkImageToImageRegistrationMethod.h
@@ -52,7 +52,7 @@ public:
   typedef SmartPointer<Self>             Pointer;
   typedef SmartPointer<const Self>       ConstPointer;
 
-  itkTypeMacro( ImageToImageRegistrationMethod, ProcessObject );
+  itkOverrideGetNameOfClassMacro( ImageToImageRegistrationMethod);
 
   itkNewMacro( Self );
 

--- a/src/Registration/itkOptimizedImageToImageRegistrationMethod.hxx
+++ b/src/Registration/itkOptimizedImageToImageRegistrationMethod.hxx
@@ -63,7 +63,7 @@ public:
   typedef Command                 Superclass;
   typedef SmartPointer<Self>      Pointer;
 
-  itkTypeMacro( ImageRegistrationViewer, Command );
+  itkOverrideGetNameOfClassMacro( ImageRegistrationViewer);
 
   itkNewMacro( ImageRegistrationViewer );
 

--- a/src/Registration/itkScaleSkewAngle2DTransform.h
+++ b/src/Registration/itkScaleSkewAngle2DTransform.h
@@ -64,7 +64,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(ScaleSkewAngle2DTransform, Rigid2DTransform);
+  itkOverrideGetNameOfClassMacro(ScaleSkewAngle2DTransform);
 
   /** Dimension of parameters. */
   itkStaticConstMacro(InputSpaceDimension, unsigned int, 2);

--- a/src/Registration/itkSimilarity2DTransform.h
+++ b/src/Registration/itkSimilarity2DTransform.h
@@ -78,7 +78,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(Similarity2DTransform, Rigid2DTransform);
+  itkOverrideGetNameOfClassMacro(Similarity2DTransform);
 
   /** Dimension of parameters. */
   itkStaticConstMacro(SpaceDimension,           unsigned int, 2);

--- a/src/Registration/itktubeMergeAdjacentImagesFilter.h
+++ b/src/Registration/itktubeMergeAdjacentImagesFilter.h
@@ -57,7 +57,7 @@ public:
   itkNewMacro( Self );
 
   /** Run-time type information ( and related methods ). */
-  itkTypeMacro( MergeAdjacentImagesFilter, Object );
+  itkOverrideGetNameOfClassMacro( MergeAdjacentImagesFilter);
 
   itkStaticConstMacro( ImageDimension, unsigned int, TImage::ImageDimension );
 

--- a/src/Registration/itktubeOptimizedSpatialObjectToImageRegistrationMethod.hxx
+++ b/src/Registration/itktubeOptimizedSpatialObjectToImageRegistrationMethod.hxx
@@ -55,7 +55,7 @@ public:
   typedef Command                 Superclass;
   typedef SmartPointer<Self>      Pointer;
 
-  itkTypeMacro( SpatialObjectToImageRegistrationViewer, Command );
+  itkOverrideGetNameOfClassMacro( SpatialObjectToImageRegistrationViewer);
 
   itkNewMacro( SpatialObjectToImageRegistrationViewer );
 

--- a/src/Registration/itktubePointBasedSpatialObjectTransformFilter.h
+++ b/src/Registration/itktubePointBasedSpatialObjectTransformFilter.h
@@ -95,7 +95,7 @@ public:
   itkNewMacro( Self );
 
   /** Run-time type information ( and related methods ). */
-  itkTypeMacro( PointBasedSpatialObjectTransformFilter, SpatialObjectFilter );
+  itkOverrideGetNameOfClassMacro( PointBasedSpatialObjectTransformFilter);
 
   /** Set the Transformation */
   itkSetConstObjectMacro( Transform, TransformType );

--- a/src/Registration/itktubeSpatialObjectToImageMetric.h
+++ b/src/Registration/itktubeSpatialObjectToImageMetric.h
@@ -130,7 +130,7 @@ public:
   using ParametersType = Superclass::ParametersType;
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(SpatialObjectToImageMetric, Object);
+  itkOverrideGetNameOfClassMacro(SpatialObjectToImageMetric);
 
   /** Get/Set the FixedImage. */
   void SetFixedImage( const FixedImageType * fixedImage );

--- a/src/Registration/itktubeSpatialObjectToImageRegistrationHelper.h
+++ b/src/Registration/itktubeSpatialObjectToImageRegistrationHelper.h
@@ -51,7 +51,7 @@ public:
   typedef SmartPointer<Self>                     Pointer;
   typedef SmartPointer<const Self>               ConstPointer;
 
-  itkTypeMacro( SpatialObjectToImageRegistrationHelper, Object );
+  itkOverrideGetNameOfClassMacro( SpatialObjectToImageRegistrationHelper);
 
   itkNewMacro( Self );
 

--- a/src/Registration/itktubeSpatialObjectToImageRegistrationMethod.h
+++ b/src/Registration/itktubeSpatialObjectToImageRegistrationMethod.h
@@ -56,7 +56,7 @@ public:
   typedef SmartPointer<Self>             Pointer;
   typedef SmartPointer<const Self>       ConstPointer;
 
-  itkTypeMacro( SpatialObjectToImageRegistrationMethod, ProcessObject );
+  itkOverrideGetNameOfClassMacro( SpatialObjectToImageRegistrationMethod);
 
   itkNewMacro( Self );
 

--- a/src/Segmentation/itktubePDFSegmenterBase.h
+++ b/src/Segmentation/itktubePDFSegmenterBase.h
@@ -46,7 +46,7 @@ public:
   typedef SmartPointer< Self >                 Pointer;
   typedef SmartPointer< const Self >           ConstPointer;
 
-  itkTypeMacro( PDFSegmenterBase, ProcessObject );
+  itkOverrideGetNameOfClassMacro( PDFSegmenterBase);
 
   itkNewMacro( Self );
 

--- a/src/Segmentation/itktubePDFSegmenterParzen.h
+++ b/src/Segmentation/itktubePDFSegmenterParzen.h
@@ -48,7 +48,7 @@ public:
   typedef SmartPointer< Self >                       Pointer;
   typedef SmartPointer< const Self >                 ConstPointer;
 
-  itkTypeMacro( PDFSegmenterParzen, PDFSegmenterBase );
+  itkOverrideGetNameOfClassMacro( PDFSegmenterParzen);
 
   itkNewMacro( Self );
 

--- a/src/Segmentation/itktubeRadiusExtractor2.h
+++ b/src/Segmentation/itktubeRadiusExtractor2.h
@@ -60,7 +60,7 @@ public:
   typedef SmartPointer< Self >                               Pointer;
   typedef SmartPointer< const Self >                         ConstPointer;
 
-  itkTypeMacro( RadiusExtractor2, Object );
+  itkOverrideGetNameOfClassMacro( RadiusExtractor2);
   itkNewMacro( RadiusExtractor2 );
 
   /**

--- a/src/Segmentation/itktubeRadiusExtractor3.h
+++ b/src/Segmentation/itktubeRadiusExtractor3.h
@@ -60,7 +60,7 @@ public:
   typedef SmartPointer< Self >                               Pointer;
   typedef SmartPointer< const Self >                         ConstPointer;
 
-  itkTypeMacro( RadiusExtractor3, Object );
+  itkOverrideGetNameOfClassMacro( RadiusExtractor3);
   itkNewMacro( RadiusExtractor3 );
 
   /**

--- a/src/Segmentation/itktubeRadiusExtractor3.hxx
+++ b/src/Segmentation/itktubeRadiusExtractor3.hxx
@@ -58,7 +58,7 @@ public:
 
   itkNewMacro(Self);
 
-  itkTypeMacro(ProfileCurve, SingleValuedCostFunction);
+  itkOverrideGetNameOfClassMacro(ProfileCurve);
 
   typedef SingleValuedCostFunction::ParametersType ParametersType;
   typedef SingleValuedCostFunction::DerivativeType DerivativeType;

--- a/src/Segmentation/itktubeRidgeExtractor.h
+++ b/src/Segmentation/itktubeRidgeExtractor.h
@@ -63,7 +63,7 @@ public:
   typedef SmartPointer< Self >       Pointer;
   typedef SmartPointer< const Self > ConstPointer;
 
-  itkTypeMacro( RidgeExtractor, Object );
+  itkOverrideGetNameOfClassMacro( RidgeExtractor);
 
   itkNewMacro( RidgeExtractor );
 

--- a/src/Segmentation/itktubeRidgeSeedFilter.h
+++ b/src/Segmentation/itktubeRidgeSeedFilter.h
@@ -52,7 +52,7 @@ public:
   typedef SmartPointer< Self >                       Pointer;
   typedef SmartPointer< const Self >                 ConstPointer;
 
-  itkTypeMacro( RidgeSeedFilter, ImageToImageFilter );
+  itkOverrideGetNameOfClassMacro( RidgeSeedFilter);
 
   itkNewMacro( Self );
 

--- a/src/Segmentation/itktubeTubeExtractor.h
+++ b/src/Segmentation/itktubeTubeExtractor.h
@@ -62,7 +62,7 @@ public:
 
   /**
    * Run-time type information ( and related methods ). */
-  itkTypeMacro( TubeExtractor, Object );
+  itkOverrideGetNameOfClassMacro( TubeExtractor);
 
   itkNewMacro( TubeExtractor );
 

--- a/test/Numerics/itktubeSingleValuedCostFunctionImageSourceTest.cxx
+++ b/test/Numerics/itktubeSingleValuedCostFunctionImageSourceTest.cxx
@@ -42,7 +42,7 @@ public:
   typedef SmartPointer< const Self >    ConstPointer;
 
   /** Run-time type information ( and related methods ). */
-  itkTypeMacro( ArthurDentCostFunction, SingleValuedCostFunction );
+  itkOverrideGetNameOfClassMacro( ArthurDentCostFunction);
 
   itkNewMacro( Self );
 


### PR DESCRIPTION
Added two new macro's, intended to replace the old 'itkTypeMacro' and
'itkTypeMacroNoParent'.

The main aim is to be clearer about what those macro's do: add a virtual
'GetNameOfClass()' member function and override it. Unlike 'itkTypeMacro',
'itkOverrideGetNameOfClassMacro' does not have a 'superclass' parameter, as it
was not used anyway.

Note that originally 'itkTypeMacro' did not use its 'superclass' parameter
either, looking at commit 699b66cb04d410e555656828e8892107add38ccb, Will
Schroeder, June 27, 2001:
https://github.com/InsightSoftwareConsortium/ITK/blob/699b66cb04d410e555656828e8892107add38ccb/Code/Common/itkMacro.h#L331-L337
