### PR TITLE
COMP: Use the `SpatialObjectType` type alias in function argument

### DIFF
--- a/src/Registration/itkImageRegionMomentsCalculator.h
+++ b/src/Registration/itkImageRegionMomentsCalculator.h
@@ -130,7 +130,7 @@ public:
 
   /** Set the spatial object mask. */
   virtual void SetSpatialObjectMask(
-    const SpatialObject<itkGetStaticConstMacro( ImageDimension )> * so )
+    const SpatialObjectType * so )
     {
     if( m_SpatialObjectMask != so )
       {


### PR DESCRIPTION
Use the `SpatialObjectType` type alias instead of calling a macro in a function argument.

```
src/Registration/itkImageRegionMomentsCalculator.h:133:11: error: invalid template-id
  133 |     const SpatialObject<Self:: ImageDimension )> * so
      |           ^~~~~~~~~~~~~
src/Registration/itkImageRegionMomentsCalculator.h:133:47: error: expected '>' before ')' token
  133 |     const SpatialObject<Self:: ImageDimension )> * so
      |                                               ^

src/Registration/itkImageRegionMomentsCalculator.h:133:5: error: class template placeholder 'itk::SpatialObject' not permitted in this context
  133 |     const SpatialObject<Self:: ImageDimension )> * so
      |     ^~~~~
src/Registration/itkImageRegionMomentsCalculator.h:133:47: error: expected ';' at end of member declaration
  133 |     const SpatialObject<Self:: ImageDimension )> * so
      |                                               ^
      |                                                ;
src/Registration/itkImageRegionMomentsCalculator.h:133:48: error: expected unqualified-id before '>' token
  133 |     const SpatialObject<Self:: ImageDimension )> * so
      |                                                ^
```

raised for example at:
https://open.cdash.org/viewBuildError.php?buildid=10248952