### PR TITLE
STYLE: Prefer C++11 type alias over typedef

### DIFF
--- a/examples/Applications/AtlasBuilderUsingIntensity/AtlasBuilderUsingIntensity.cxx
+++ b/examples/Applications/AtlasBuilderUsingIntensity/AtlasBuilderUsingIntensity.cxx
@@ -29,11 +29,11 @@ limitations under the License.
 
 enum { Dimension = 3 };
 
-typedef itk::Image< float, Dimension > FloatImageType;
+using FloatImageType = itk::Image< float, Dimension >;
 
 void WriteImage( FloatImageType::Pointer i, const std::string & name )
 {
-  typedef itk::ImageFileWriter< FloatImageType > WriterType;
+  using WriterType = itk::ImageFileWriter< FloatImageType >;
   WriterType::Pointer writer  = WriterType::New();
 
   writer->SetInput( i );
@@ -42,11 +42,11 @@ void WriteImage( FloatImageType::Pointer i, const std::string & name )
   writer->Update();
 }
 
-typedef itk::Image< unsigned short, Dimension > UShortImageType;
+using UShortImageType = itk::Image< unsigned short, Dimension >;
 
 void WriteImage( UShortImageType::Pointer i, const std::string & name )
 {
-  typedef itk::ImageFileWriter< UShortImageType > UShortWriterType;
+  using UShortWriterType = itk::ImageFileWriter< UShortImageType >;
   UShortWriterType::Pointer writer  = UShortWriterType::New();
 
   writer->SetInput( i );
@@ -59,12 +59,12 @@ int DoIt( int argc, char * argv[] )
 {
   PARSE_ARGS;
 
-  typedef tube::AtlasSummation                       AtlasSummationType;
-  typedef AtlasSummationType::InputPixelType         InputPixelType;
-  typedef itk::Image< InputPixelType, Dimension >    InputImageType;
-  typedef tube::MetaObjectDocument                   DocumentReaderType;
-  typedef itk::tube::ImageDocument                   ImageDocumentType;
-  typedef DocumentReaderType::ObjectDocumentListType ImageDocumentListType;
+  using AtlasSummationType = tube::AtlasSummation;
+  using InputPixelType = AtlasSummationType::InputPixelType;
+  using InputImageType = itk::Image< InputPixelType, Dimension >;
+  using DocumentReaderType = tube::MetaObjectDocument;
+  using ImageDocumentType = itk::tube::ImageDocument;
+  using ImageDocumentListType = DocumentReaderType::ObjectDocumentListType;
   typedef
     itk::tube::ObjectDocumentToImageFilter< ImageDocumentType, InputImageType >
     DocumentToImageFilter;

--- a/examples/Applications/AtlasBuilderUsingIntensity/itktubeCompleteImageResampleFilter.h
+++ b/examples/Applications/AtlasBuilderUsingIntensity/itktubeCompleteImageResampleFilter.h
@@ -55,17 +55,17 @@ class CompleteImageResampleFilter
 {
 public:
 
-  /** Standard class typedefs. */
-  typedef CompleteImageResampleFilter               Self;
-  typedef ProcessObject                             Superclass;
-  typedef SmartPointer< Self >                      Pointer;
-  typedef SmartPointer< const Self >                ConstPointer;
+  /** Standard class type alias. */
+  using Self = CompleteImageResampleFilter;
+  using Superclass = ProcessObject;
+  using Pointer = SmartPointer< Self >;
+  using ConstPointer = SmartPointer< const Self >;
 
-  typedef TInputImage                               InputImageType;
-  typedef TOutputImage                              OutputImageType;
-  typedef typename InputImageType::ConstPointer     InputImageConstPointer;
-  typedef typename OutputImageType::Pointer         OutputImagePointer;
-  typedef typename InputImageType::RegionType       InputImageRegionType;
+  using InputImageType = TInputImage;
+  using OutputImageType = TOutputImage;
+  using InputImageConstPointer = typename InputImageType::ConstPointer;
+  using OutputImagePointer = typename OutputImageType::Pointer;
+  using InputImageRegionType = typename InputImageType::RegionType;
 
   /** Method for creation through the object factory. */
   itkNewMacro( Self );
@@ -77,45 +77,42 @@ public:
   itkStaticConstMacro( ImageDimension, unsigned int,
                        TOutputImage::ImageDimension );
 
-  /** ResampleImageFilter typedef */
-  typedef ResampleImageFilter< InputImageType,
+  /** ResampleImageFilter type alias */
+  using ResampleImageFilterType = ResampleImageFilter< InputImageType,
                                OutputImageType,
-                               TInterpolatorPrecisionType >
-                                                  ResampleImageFilterType;
+                               TInterpolatorPrecisionType >;
 
-  /** Transform typedef
+  /** Transform type alias
    *
    * Note: The transform needs to have an inverse to determine
    * the proper outcome dimensions
    */
-  typedef TNonSingularTransform                   TransformType;
-  typedef typename TransformType::ConstPointer    TransformPointerType;
+  using TransformType = TNonSingularTransform;
+  using TransformPointerType = typename TransformType::ConstPointer;
 
-  /** Interpolator typedef. */
-  typedef InterpolateImageFunction< InputImageType,
-                                    TInterpolatorPrecisionType>
-                                                  InterpolatorType;
-  typedef typename InterpolatorType::Pointer      InterpolatorPointerType;
+  /** Interpolator type alias. */
+  using InterpolatorType = InterpolateImageFunction< InputImageType,
+                                    TInterpolatorPrecisionType>;
+  using InterpolatorPointerType = typename InterpolatorType::Pointer;
 
-  /** Image size typedef. */
-  typedef Size< itkGetStaticConstMacro( ImageDimension ) >
-                                                  SizeType;
+  /** Image size type alias. */
+  using SizeType = Size< itkGetStaticConstMacro( ImageDimension ) >;
 
-  /** Image index typedef. */
-  typedef typename TOutputImage::IndexType        IndexType;
+  /** Image index type alias. */
+  using IndexType = typename TOutputImage::IndexType;
 
-  /** Image point typedef. */
-  typedef typename InterpolatorType::PointType    PointType;
+  /** Image point type alias. */
+  using PointType = typename InterpolatorType::PointType;
 
-  /** Image pixel value typedef. */
-  typedef typename TOutputImage::PixelType        PixelType;
+  /** Image pixel value type alias. */
+  using PixelType = typename TOutputImage::PixelType;
 
   /** Typedef to describe the output image region type. */
-  typedef typename TOutputImage::RegionType       OutputImageRegionType;
+  using OutputImageRegionType = typename TOutputImage::RegionType;
 
-  /** Image spacing typedef */
-  typedef typename TOutputImage::SpacingType      SpacingType;
-  typedef typename TOutputImage::PointType        OriginPointType;
+  /** Image spacing type alias */
+  using SpacingType = typename TOutputImage::SpacingType;
+  using OriginPointType = typename TOutputImage::PointType;
 
   /*
    * Set the coordinate transformation.

--- a/examples/Applications/AtlasBuilderUsingIntensity/itktubeMeanAndSigmaImageBuilder.h
+++ b/examples/Applications/AtlasBuilderUsingIntensity/itktubeMeanAndSigmaImageBuilder.h
@@ -55,10 +55,10 @@ class MeanAndSigmaImageBuilder : public Object
 {
 public:
 
-  typedef MeanAndSigmaImageBuilder                      Self;
-  typedef Object                                        Superclass;
-  typedef SmartPointer< Self >                          Pointer;
-  typedef SmartPointer< const Self >                    ConstPointer;
+  using Self = MeanAndSigmaImageBuilder;
+  using Superclass = Object;
+  using Pointer = SmartPointer< Self >;
+  using ConstPointer = SmartPointer< const Self >;
 
   itkStaticConstMacro( ImageDimension, unsigned int,
                        TInputImageType::ImageDimension );
@@ -66,29 +66,28 @@ public:
   itkNewMacro( Self );
   itkTypeMacro( MeanAndSigmaImageBuilder, Object );
 
-  typedef TInputImageType                               InputImageType;
-  typedef TOutputMeanImageType                          OutputMeanImageType;
-  typedef TOutputSigmaImageType                         OutputSigmaImageType;
-  typedef Image<
-    float, itkGetStaticConstMacro( ImageDimension )>           CountImageType;
+  using InputImageType = TInputImageType;
+  using OutputMeanImageType = TOutputMeanImageType;
+  using OutputSigmaImageType = TOutputSigmaImageType;
+  using CountImageType = Image<
+    float, itkGetStaticConstMacro( ImageDimension )>;
 
-  typedef typename InputImageType::PixelType            InputPixelType;
-  typedef typename OutputMeanImageType::PixelType       OutputMeanPixelType;
-  typedef typename OutputSigmaImageType::PixelType      OutputSigmaPixelType;
-  typedef typename CountImageType::PixelType            CountPixelType;
+  using InputPixelType = typename InputImageType::PixelType;
+  using OutputMeanPixelType = typename OutputMeanImageType::PixelType;
+  using OutputSigmaPixelType = typename OutputSigmaImageType::PixelType;
+  using CountPixelType = typename CountImageType::PixelType;
 
-  typedef typename InputImageType::Pointer              InputImagePointer;
-  typedef typename OutputMeanImageType::Pointer         OutputMeanImagePointer;
-  typedef typename OutputSigmaImageType::Pointer        OutputSigmaImagePointer;
-  typedef typename CountImageType::Pointer              CountImagePointer;
+  using InputImagePointer = typename InputImageType::Pointer;
+  using OutputMeanImagePointer = typename OutputMeanImageType::Pointer;
+  using OutputSigmaImagePointer = typename OutputSigmaImageType::Pointer;
+  using CountImagePointer = typename CountImageType::Pointer;
 
-  typedef typename InputImageType::RegionType           RegionType;
-  typedef typename InputImageType::SizeType             SizeType;
-  typedef typename InputImageType::SpacingType          SpacingType;
-  typedef typename InputImageType::PointType            PointType;
+  using RegionType = typename InputImageType::RegionType;
+  using SizeType = typename InputImageType::SizeType;
+  using SpacingType = typename InputImageType::SpacingType;
+  using PointType = typename InputImageType::PointType;
 
-  typedef Image< float, itkGetStaticConstMacro( ImageDimension ) >
-    ProcessImageType;
+  using ProcessImageType = Image< float, itkGetStaticConstMacro( ImageDimension ) >;
 
   /**
    * Add an image to the group being summed.
@@ -222,16 +221,16 @@ protected:
   ~MeanAndSigmaImageBuilder( void ) {}
 
   /** Processing image types */
-  typedef typename ProcessImageType::PixelType         ProcessPixelType;
-  typedef typename ProcessImageType::Pointer           ProcessImagePointer;
+  using ProcessPixelType = typename ProcessImageType::PixelType;
+  using ProcessImagePointer = typename ProcessImageType::Pointer;
 
-  typedef ImageRegionConstIterator< InputImageType >   InputConstIteratorType;
-  typedef ImageRegionConstIterator< ProcessImageType > ProcessConstIteratorType;
-  typedef ImageRegionIterator< ProcessImageType >      ProcessIteratorType;
-  typedef ImageRegionConstIterator< CountImageType >   CountConstIteratorType;
-  typedef ImageRegionIterator< CountImageType >        CountIteratorType;
-  typedef ImageRegionIterator< OutputMeanImageType >   OutputMeanIteratorType;
-  typedef ImageRegionIterator< OutputSigmaImageType >  OutputSigmaIteratorType;
+  using InputConstIteratorType = ImageRegionConstIterator< InputImageType >;
+  using ProcessConstIteratorType = ImageRegionConstIterator< ProcessImageType >;
+  using ProcessIteratorType = ImageRegionIterator< ProcessImageType >;
+  using CountConstIteratorType = ImageRegionConstIterator< CountImageType >;
+  using CountIteratorType = ImageRegionIterator< CountImageType >;
+  using OutputMeanIteratorType = ImageRegionIterator< OutputMeanImageType >;
+  using OutputSigmaIteratorType = ImageRegionIterator< OutputSigmaImageType >;
 
   itkSetObjectMacro( SumImage, ProcessImageType );
 

--- a/examples/Applications/AtlasBuilderUsingIntensity/itktubeMeanAndSigmaImageBuilder.hxx
+++ b/examples/Applications/AtlasBuilderUsingIntensity/itktubeMeanAndSigmaImageBuilder.hxx
@@ -264,8 +264,7 @@ MeanAndSigmaImageBuilder< TInputImageType, TOutputMeanImageType,
   ProcessImagePointer sumSquareImage  = this->GetSumSquareImage();
   CountImagePointer   validImage      = this->GetValidCountImage();
 
-  typedef ResampleImageFilter< ProcessImageType, ProcessImageType >
-    ResampleProcessImageType;
+  using ResampleProcessImageType = ResampleImageFilter< ProcessImageType, ProcessImageType >;
   typename ResampleProcessImageType::Pointer processFilter =
     ResampleProcessImageType::New();
 
@@ -291,8 +290,7 @@ MeanAndSigmaImageBuilder< TInputImageType, TOutputMeanImageType,
   this->SetSumSquareImage( processFilter2->GetOutput() );
 
 
-  typedef ResampleImageFilter<CountImageType, CountImageType>
-    ResampleCountImageType;
+  using ResampleCountImageType = ResampleImageFilter<CountImageType, CountImageType>;
   typename ResampleCountImageType::Pointer countFilter =
     ResampleCountImageType::New();
 

--- a/examples/Applications/AtlasBuilderUsingIntensity/itktubeMinimizeImageSizeFilter.h
+++ b/examples/Applications/AtlasBuilderUsingIntensity/itktubeMinimizeImageSizeFilter.h
@@ -51,26 +51,26 @@ class MinimizeImageSizeFilter
 {
 public:
 
-  typedef MinimizeImageSizeFilter                          Self;
-  typedef ImageToImageFilter< TInputImage, TInputImage >   Superclass;
+  using Self = MinimizeImageSizeFilter;
+  using Superclass = ImageToImageFilter< TInputImage, TInputImage >;
 
-  typedef SmartPointer< Self >                    Pointer;
-  typedef SmartPointer< const Self >              ConstPointer;
+  using Pointer = SmartPointer< Self >;
+  using ConstPointer = SmartPointer< const Self >;
 
   itkNewMacro( Self );
   itkTypeMacro( MinimizeImageSizeFilter, ImageToImageFilter );
 
-  typedef TInputImage                             InputImageType;
-  typedef typename InputImageType::PixelType      InputPixelType;
+  using InputImageType = TInputImage;
+  using InputPixelType = typename InputImageType::PixelType;
 
-  typedef TInputImage                             OutputImageType;
-  typedef typename InputImageType::ConstPointer   InputImageConstPointer;
-  typedef typename OutputImageType::Pointer       OutputImagePointer;
+  using OutputImageType = TInputImage;
+  using InputImageConstPointer = typename InputImageType::ConstPointer;
+  using OutputImagePointer = typename OutputImageType::Pointer;
 
-  typedef typename InputImageType::RegionType     RegionType;
-  typedef typename InputImageType::SizeType       SizeType;
-  typedef typename InputImageType::IndexType      IndexType;
-  typedef typename InputImageType::PointType      PointType;
+  using RegionType = typename InputImageType::RegionType;
+  using SizeType = typename InputImageType::SizeType;
+  using IndexType = typename InputImageType::IndexType;
+  using PointType = typename InputImageType::PointType;
 
   /** Number of dimensions. */
   itkStaticConstMacro( ImageDimension, unsigned int,

--- a/examples/Applications/AtlasBuilderUsingIntensity/itktubeMinimizeImageSizeFilter.hxx
+++ b/examples/Applications/AtlasBuilderUsingIntensity/itktubeMinimizeImageSizeFilter.hxx
@@ -107,8 +107,7 @@ MinimizeImageSizeFilter<TInputImage>
     }
 
   // resample image to given region parameters
-  typedef ResampleImageFilter< InputImageType, OutputImageType >
-    ResampleFilterType;
+  using ResampleFilterType = ResampleImageFilter< InputImageType, OutputImageType >;
   typename ResampleFilterType::Pointer resampleFilter =
     ResampleFilterType::New();
 
@@ -134,8 +133,7 @@ MinimizeImageSizeFilter< TInputImage >
   InputPixelType  threshold = GetThresholdValue();
   bool            isThresAbove = this->GetThresholdAbove();
 
-  typedef ImageSliceConstIteratorWithIndex< InputImageType >
-    ImageSliceConstIteratorType;
+  using ImageSliceConstIteratorType = ImageSliceConstIteratorWithIndex< InputImageType >;
   SizeType  size = region.GetSize();
 
   // Run sweep for back end
@@ -203,8 +201,7 @@ MinimizeImageSizeFilter< TInputImage >
   InputPixelType  threshold = GetThresholdValue();
   bool            isThresAbove = this->GetThresholdAbove();
 
-  typedef ImageSliceConstIteratorWithIndex< InputImageType>
-    ImageSliceConstIteratorType;
+  using ImageSliceConstIteratorType = ImageSliceConstIteratorWithIndex< InputImageType>;
   IndexType index = region.GetIndex();
   SizeType  size = region.GetSize();
 

--- a/examples/Applications/AtlasBuilderUsingIntensity/itktubeRobustMeanAndSigmaImageBuilder.h
+++ b/examples/Applications/AtlasBuilderUsingIntensity/itktubeRobustMeanAndSigmaImageBuilder.h
@@ -56,32 +56,32 @@ class RobustMeanAndSigmaImageBuilder
 {
 public:
 
-  typedef RobustMeanAndSigmaImageBuilder                    Self;
-  typedef MeanAndSigmaImageBuilder< TInputImageType, TOutputMeanImageType,
-    TOutputSigmaImageType>                                  Superclass;
+  using Self = RobustMeanAndSigmaImageBuilder;
+  using Superclass = MeanAndSigmaImageBuilder< TInputImageType, TOutputMeanImageType,
+    TOutputSigmaImageType>;
 
-  typedef SmartPointer< Self >                              Pointer;
-  typedef SmartPointer< const Self >                        ConstPointer;
+  using Pointer = SmartPointer< Self >;
+  using ConstPointer = SmartPointer< const Self >;
 
   itkNewMacro( Self );
   itkTypeMacro( RobustMeanAndSigmaImageBuilder, MeanAndSigmaImageBuilder );
 
-  typedef TInputImageType                              InputImageType;
-  typedef TOutputMeanImageType                         OutputMeanImageType;
-  typedef TOutputSigmaImageType                        OutputSigmaImageType;
+  using InputImageType = TInputImageType;
+  using OutputMeanImageType = TOutputMeanImageType;
+  using OutputSigmaImageType = TOutputSigmaImageType;
 
-  typedef typename Superclass::InputPixelType          InputPixelType;
-  typedef typename Superclass::OutputMeanPixelType     OutputMeanPixelType;
-  typedef typename Superclass::OutputSigmaPixelType    OutputSigmaPixelType;
+  using InputPixelType = typename Superclass::InputPixelType;
+  using OutputMeanPixelType = typename Superclass::OutputMeanPixelType;
+  using OutputSigmaPixelType = typename Superclass::OutputSigmaPixelType;
 
-  typedef typename Superclass::InputImagePointer       InputImagePointer;
-  typedef typename Superclass::OutputMeanImagePointer  OutputMeanImagePointer;
-  typedef typename Superclass::OutputSigmaImagePointer OutputSigmaImagePointer;
+  using InputImagePointer = typename Superclass::InputImagePointer;
+  using OutputMeanImagePointer = typename Superclass::OutputMeanImagePointer;
+  using OutputSigmaImagePointer = typename Superclass::OutputSigmaImagePointer;
 
-  typedef typename Superclass::RegionType              RegionType;
-  typedef typename Superclass::SpacingType             SpacingType;
-  typedef typename Superclass::PointType               PointType;
-  typedef typename Superclass::SizeType                SizeType;
+  using RegionType = typename Superclass::RegionType;
+  using SpacingType = typename Superclass::SpacingType;
+  using PointType = typename Superclass::PointType;
+  using SizeType = typename Superclass::SizeType;
 
   /**
    * Add an image to the group being summed. No check is made to insure
@@ -138,16 +138,16 @@ protected:
   ~RobustMeanAndSigmaImageBuilder( void ) {}
 
   /** Processing image types */
-  typedef typename Superclass::ProcessImageType         ProcessImageType;
-  typedef typename Superclass::CountImageType           CountImageType;
+  using ProcessImageType = typename Superclass::ProcessImageType;
+  using CountImageType = typename Superclass::CountImageType;
 
-  typedef typename Superclass::ProcessPixelType         ProcessPixelType;
-  typedef typename Superclass::CountPixelType           CountPixelType;
+  using ProcessPixelType = typename Superclass::ProcessPixelType;
+  using CountPixelType = typename Superclass::CountPixelType;
 
-  typedef typename Superclass::ProcessImagePointer      ProcessImagePointer;
-  typedef typename Superclass::CountImagePointer        CountImagePointer;
+  using ProcessImagePointer = typename Superclass::ProcessImagePointer;
+  using CountImagePointer = typename Superclass::CountImagePointer;
 
-  typedef ImageRegionIterator<InputImageType>           InputIteratorType;
+  using InputIteratorType = ImageRegionIterator<InputImageType>;
 
   typedef typename Superclass::InputConstIteratorType
     InputConstIteratorType;
@@ -164,7 +164,7 @@ protected:
   typedef typename Superclass::OutputSigmaIteratorType
     OutputSigmaIteratorType;
 
-  typedef typename std::vector<InputImagePointer>       InputImageListType;
+  using InputImageListType = typename std::vector<InputImagePointer>;
 
   /**
    * Build new processing images ( i.e., sumImage, sumSquareImage,

--- a/examples/Applications/AtlasBuilderUsingIntensity/itktubeRobustMeanAndSigmaImageBuilder.hxx
+++ b/examples/Applications/AtlasBuilderUsingIntensity/itktubeRobustMeanAndSigmaImageBuilder.hxx
@@ -400,8 +400,7 @@ RobustMeanAndSigmaImageBuilder< TInputImageType, TOutputMeanImageType,
 
   Superclass::UpdateOutputImageSize( inputSize );
 
-  typedef ResampleImageFilter<InputImageType, InputImageType>
-    ResampleInputImageType;
+  using ResampleInputImageType = ResampleImageFilter<InputImageType, InputImageType>;
 
   InputImageListType  lowerList = this->GetLowerOutlierImages();
 

--- a/examples/Applications/AtlasBuilderUsingIntensity/tubeAtlasSummation.cxx
+++ b/examples/Applications/AtlasBuilderUsingIntensity/tubeAtlasSummation.cxx
@@ -129,8 +129,7 @@ AtlasSummation::InputImagePointer AtlasSummation
 {
   // Realign image to the base Image specifications. If no adjustments
   // are done to the image, then add the transform to the filter as well
-  typedef itk::ResampleImageFilter< InputImageType, InputImageType >
-               ResampleFilterType;
+  using ResampleFilterType = itk::ResampleImageFilter< InputImageType, InputImageType >;
 
   ResampleFilterType::Pointer transfilter = ResampleFilterType::New();
   transfilter->SetInput( image );
@@ -162,8 +161,8 @@ AtlasSummation::InputImagePointer AtlasSummation
 {
   // The filter does only require output spacing ( not size or origin )
   // to run the resampling
-  typedef itk::tube::CompleteImageResampleFilter<
-    InputImageType, InputImageType, TransformType> ResampleImageFilterType;
+  using ResampleImageFilterType = itk::tube::CompleteImageResampleFilter<
+    InputImageType, InputImageType, TransformType>;
 
   TransformType::Pointer inverse = TransformType::New();
   t->GetInverse( inverse );
@@ -177,8 +176,7 @@ AtlasSummation::InputImagePointer AtlasSummation
   resampleFilter->Update();
 
   // Minimize the image to fit the parameters
-  typedef itk::tube::MinimizeImageSizeFilter<InputImageType>
-    MinImageSizeFilterType;
+  using MinImageSizeFilterType = itk::tube::MinimizeImageSizeFilter<InputImageType>;
 
   MinImageSizeFilterType::Pointer minFilter = MinImageSizeFilterType::New();
   minFilter->SetInput( resampleFilter->GetOutput() );
@@ -235,7 +233,7 @@ void AtlasSummation
 void AtlasSummation
 ::WriteImage( MeanImageType::Pointer image, const std::string & file )
 {
-  typedef itk::ImageFileWriter< MeanImageType > FileWriterType;
+  using FileWriterType = itk::ImageFileWriter< MeanImageType >;
   ++m_Count;
   std::stringstream file1;
   file1 << file << m_Count << ".mhd";
@@ -257,7 +255,7 @@ void AtlasSummation
 void AtlasSummation
 ::WriteImage( ProcessImagePointer image, const std::string & file )
 {
-  typedef itk::ImageFileWriter< ProcessImageType > FileWriterType;
+  using FileWriterType = itk::ImageFileWriter< ProcessImageType >;
 
   try
     {

--- a/examples/Applications/AtlasBuilderUsingIntensity/tubeAtlasSummation.h
+++ b/examples/Applications/AtlasBuilderUsingIntensity/tubeAtlasSummation.h
@@ -47,48 +47,47 @@ public:
    */
   enum { Dimension = 3, DEFAULT_PIXEL_FILL = 0 };
 
-  typedef float                                      InputPixelType;
-  typedef float                                      CountPixelType;
-  typedef float                                      OutputPixelType;
-  typedef float                                      MeanPixelType;
-  typedef float                                      VariancePixelType;
+  using InputPixelType = float;
+  using CountPixelType = float;
+  using OutputPixelType = float;
+  using MeanPixelType = float;
+  using VariancePixelType = float;
 
-  typedef itk::Image< InputPixelType, Dimension >    InputImageType;
-  typedef itk::Image< MeanPixelType, Dimension >     MeanImageType;
-  typedef itk::Image< VariancePixelType, Dimension > VarianceImageType;
-  typedef itk::Image< CountPixelType, Dimension >    CountImageType;
-  typedef itk::AffineTransform<>                     TransformType;
+  using InputImageType = itk::Image< InputPixelType, Dimension >;
+  using MeanImageType = itk::Image< MeanPixelType, Dimension >;
+  using VarianceImageType = itk::Image< VariancePixelType, Dimension >;
+  using CountImageType = itk::Image< CountPixelType, Dimension >;
+  using TransformType = itk::AffineTransform<>;
 
-  typedef InputImageType::Pointer                    InputImagePointer;
-  typedef InputImageType::ConstPointer               InputImageConstPointer;
-  typedef MeanImageType::Pointer                     MeanImagePointer;
-  typedef VarianceImageType::Pointer                 VarianceImagePointer;
-  typedef TransformType::Pointer                     TransformPointer;
+  using InputImagePointer = InputImageType::Pointer;
+  using InputImageConstPointer = InputImageType::ConstPointer;
+  using MeanImagePointer = MeanImageType::Pointer;
+  using VarianceImagePointer = VarianceImageType::Pointer;
+  using TransformPointer = TransformType::Pointer;
 
-  typedef InputImageType::SpacingType                SpacingType;
-  typedef InputImageType::SizeType                   SizeType;
-  typedef InputImageType::PointType                  PointType;
+  using SpacingType = InputImageType::SpacingType;
+  using SizeType = InputImageType::SizeType;
+  using PointType = InputImageType::PointType;
 
 private:
 
   /** Pixel and Image Type for processing transition images */
-  typedef double                                     ProcessPixelType;
-  typedef itk::Image< ProcessPixelType, Dimension >  ProcessImageType;
-  typedef ProcessImageType::Pointer                  ProcessImagePointer;
+  using ProcessPixelType = double;
+  using ProcessImageType = itk::Image< ProcessPixelType, Dimension >;
+  using ProcessImagePointer = ProcessImageType::Pointer;
 
-  typedef itk::ImageRegionConstIterator< InputImageType >
-    InputConstIteratorType;
+  using InputConstIteratorType = itk::ImageRegionConstIterator< InputImageType >;
 
-  typedef itk::ImageRegionIterator< InputImageType >    InputIteratorType;
-  typedef itk::ImageRegionIterator< ProcessImageType >  ProcessIteratorType;
-  typedef itk::ImageRegionIterator< MeanImageType >     MeanIteratorType;
-  typedef itk::ImageRegionIterator< VarianceImageType > VarianceIteratorType;
-  typedef itk::ImageRegionIterator< CountImageType >    CountIteratorType;
+  using InputIteratorType = itk::ImageRegionIterator< InputImageType >;
+  using ProcessIteratorType = itk::ImageRegionIterator< ProcessImageType >;
+  using MeanIteratorType = itk::ImageRegionIterator< MeanImageType >;
+  using VarianceIteratorType = itk::ImageRegionIterator< VarianceImageType >;
+  using CountIteratorType = itk::ImageRegionIterator< CountImageType >;
 
-  typedef std::vector<InputImagePointer>                MedianImageListType;
+  using MedianImageListType = std::vector<InputImagePointer>;
 
-  typedef itk::tube::MeanAndSigmaImageBuilder< InputImageType,
-    MeanImageType, VarianceImageType >               RobustMeanBuilderType;
+  using RobustMeanBuilderType = itk::tube::MeanAndSigmaImageBuilder< InputImageType,
+    MeanImageType, VarianceImageType >;
 
 public:
 

--- a/examples/Applications/CLI/tubeCLIHelperFunctions.h
+++ b/examples/Applications/CLI/tubeCLIHelperFunctions.h
@@ -39,8 +39,8 @@ void GetImageInformation( const std::string & fileName,
                           itk::ImageIOBase::IOComponentEnum & componentType,
                           unsigned int & dimension )
 {
-  typedef itk::ImageIOBase     ImageIOType;
-  typedef itk::ImageIOFactory  ImageIOFactoryType;
+  using ImageIOType = itk::ImageIOBase;
+  using ImageIOFactoryType = itk::ImageIOFactory;
 
   ImageIOType::Pointer imageIO =
     ImageIOFactoryType::CreateImageIO( fileName.c_str(),

--- a/examples/Applications/ComputeBinaryImageSimilarityMetrics/ComputeBinaryImageSimilarityMetrics.cxx
+++ b/examples/Applications/ComputeBinaryImageSimilarityMetrics/ComputeBinaryImageSimilarityMetrics.cxx
@@ -39,9 +39,9 @@ int DoIt( int argc, char * argv[] )
 {
   PARSE_ARGS;
 
-  typedef TPixel                                              PixelType;
-  typedef itk::Image< PixelType, VDimension >                 ImageType;
-  typedef itk::ImageFileReader< ImageType >                   ReaderType;
+  using PixelType = TPixel;
+  using ImageType = itk::Image< PixelType, VDimension >;
+  using ReaderType = itk::ImageFileReader< ImageType >;
 
   typename ReaderType::Pointer reader1 = ReaderType::New();
   typename ReaderType::Pointer reader2 = ReaderType::New();
@@ -75,8 +75,7 @@ int DoIt( int argc, char * argv[] )
   typename ImageType::Pointer image1 = reader1->GetOutput();
   typename ImageType::Pointer image2 = reader2->GetOutput();
 
-  typedef tube::ComputeBinaryImageSimilarityMetrics< ImageType >
-    MetricFilterType;
+  using MetricFilterType = tube::ComputeBinaryImageSimilarityMetrics< ImageType >;
 
   typename MetricFilterType::Pointer metric = MetricFilterType::New();
   metric->SetSourceImage( image1 );

--- a/examples/Applications/ComputeImageSimilarityMetrics/ComputeImageSimilarityMetrics.cxx
+++ b/examples/Applications/ComputeImageSimilarityMetrics/ComputeImageSimilarityMetrics.cxx
@@ -43,11 +43,11 @@ int DoIt( int argc, char * argv[] )
 {
   PARSE_ARGS;
 
-  // typedefs
-  typedef TPixel                                              PixelType;
-  typedef itk::Image< PixelType, VDimension >                 ImageType;
-  typedef itk::ImageFileReader< ImageType >                   ReaderType;
-  typedef tube::ComputeImageSimilarityMetrics< ImageType >    FilterType;
+  // type alias
+  using PixelType = TPixel;
+  using ImageType = itk::Image< PixelType, VDimension >;
+  using ReaderType = itk::ImageFileReader< ImageType >;
+  using FilterType = tube::ComputeImageSimilarityMetrics< ImageType >;
 
   // read input image 1
   typename ReaderType::Pointer reader1 = ReaderType::New();

--- a/examples/Applications/ComputeImageStatistics/ComputeImageStatistics.cxx
+++ b/examples/Applications/ComputeImageStatistics/ComputeImageStatistics.cxx
@@ -57,10 +57,10 @@ int DoIt( int argc, char * argv[] )
                                                  CLPProcessInformation );
   progressReporter.Start();
 
-  typedef itk::Image< TPixel, VDimension >         MaskType;
-  typedef itk::Image< float, VDimension >          VolumeType;
-  typedef itk::ImageFileReader< VolumeType >       VolumeReaderType;
-  typedef itk::ImageFileReader< MaskType >         MaskReaderType;
+  using MaskType = itk::Image< TPixel, VDimension >;
+  using VolumeType = itk::Image< float, VDimension >;
+  using VolumeReaderType = itk::ImageFileReader< VolumeType >;
+  using MaskReaderType = itk::ImageFileReader< MaskType >;
 
   // Load mask
   timeCollector.Start( "Load mask" );
@@ -103,8 +103,7 @@ int DoIt( int argc, char * argv[] )
   // Compute statistics
   timeCollector.Start( "Connected Components" );
 
-  typedef itk::tube::ComputeImageStatistics< TPixel, VDimension >
-    FilterType;
+  using FilterType = itk::tube::ComputeImageStatistics< TPixel, VDimension >;
   typename FilterType::Pointer statisticsCalculator = FilterType::New();
   statisticsCalculator->SetInput( volumeReader->GetOutput() );
   statisticsCalculator->SetInputMask( maskReader->GetOutput() );
@@ -118,7 +117,7 @@ int DoIt( int argc, char * argv[] )
 
   timeCollector.Stop( "Connected Components" );
 
-  typedef itk::ImageFileWriter< VolumeType  >   ImageWriterType;
+  using ImageWriterType = itk::ImageFileWriter< VolumeType  >;
   //Write output
   timeCollector.Start( "Save data" );
   typename ImageWriterType::Pointer writer = ImageWriterType::New();

--- a/examples/Applications/ComputeRegionSignatures/ComputeRegionSignatures.cxx
+++ b/examples/Applications/ComputeRegionSignatures/ComputeRegionSignatures.cxx
@@ -187,7 +187,7 @@ void CreateEmptyImage( typename ImageT::Pointer & outImage,
  */
 bool IsDiscrete( const std::string & fileName )
 {
-  typedef itk::ImageIOBase::IOComponentType ScalarPixelType;
+  using ScalarPixelType = itk::ImageIOBase::IOComponentType;
 
   itk::ImageIOBase::Pointer imageIO = itk::ImageIOFactory::CreateImageIO(
     fileName.c_str(), itk::ImageIOFactory::ReadMode );
@@ -230,22 +230,20 @@ int DoIt( int argc, char **argv )
   PARSE_ARGS;
 
   // Commonly-used types
-  typedef TPixel                                          InputPixelType;
-  typedef itk::Image< InputPixelType, VImageDimension >   InputImageType;
+  using InputPixelType = TPixel;
+  using InputImageType = itk::Image< InputPixelType, VImageDimension >;
 
-  typedef InputPixelType                                  OutputPixelType;
-  typedef itk::Image< OutputPixelType, VImageDimension >  OutputImageType;
+  using OutputPixelType = InputPixelType;
+  using OutputImageType = itk::Image< OutputPixelType, VImageDimension >;
 
-  typedef itk::ImageFileReader< InputImageType >          InputReaderType;
-  typedef itk::ImageFileWriter< OutputImageType >         OutputWriterType;
+  using InputReaderType = itk::ImageFileReader< InputImageType >;
+  using OutputWriterType = itk::ImageFileWriter< OutputImageType >;
 
-  typedef itk::ImageRegionIteratorWithIndex< InputImageType >
-    ImageIteratorType;
+  using ImageIteratorType = itk::ImageRegionIteratorWithIndex< InputImageType >;
 
-  typedef std::vector< typename InputImageType::IndexType >
-    InputIndexVectorType;
+  using InputIndexVectorType = std::vector< typename InputImageType::IndexType >;
 
-  typedef std::map< TPixel, InputIndexVectorType >    IdToIndexVectorType;
+  using IdToIndexVectorType = std::map< TPixel, InputIndexVectorType >;
 
 
   // Read segmenation image and image of Central-Voronoi-Tesellation ( CVT )
@@ -516,9 +514,9 @@ int DoIt( int argc, char **argv )
         outImage->SetPixel( indices[v], 1 );
         }
 
-      typedef typename itk::DanielssonDistanceMapImageFilter<
+      using DistanceMapType = typename itk::DanielssonDistanceMapImageFilter<
         InputImageType,
-        OutputImageType > DistanceMapType;
+        OutputImageType >;
 
       typename DistanceMapType::Pointer distanceMap =
         DistanceMapType::New();
@@ -569,8 +567,8 @@ int DoIt( int argc, char **argv )
       case SIGNATURE_CVT_MIN:
         {
         namespace acc = boost::accumulators;
-        typedef acc::stats< acc::tag::min >               StatsType;
-        typedef acc::accumulator_set< TPixel, StatsType > AccumulatorType;
+        using StatsType = acc::stats< acc::tag::min >;
+        using AccumulatorType = acc::accumulator_set< TPixel, StatsType >;
 
         typename IdToIndexVectorType::iterator cvtToIndexVectorIt =
           cvtToIndexVector.begin();

--- a/examples/Applications/ComputeTrainingMask/ComputeTrainingMask.cxx
+++ b/examples/Applications/ComputeTrainingMask/ComputeTrainingMask.cxx
@@ -56,8 +56,8 @@ int DoIt( int argc, char * argv[] )
     return EXIT_FAILURE;
     }
 
-  typedef itk::Image< TPixel, VDimension >            ImageType;
-  typedef itk::ImageFileReader< ImageType >           ImageReaderType;
+  using ImageType = itk::Image< TPixel, VDimension >;
+  using ImageReaderType = itk::ImageFileReader< ImageType >;
 
   // The timeCollector to perform basic profiling of algorithmic components
   itk::TimeProbesCollectorBase timeCollector;
@@ -90,7 +90,7 @@ int DoIt( int argc, char * argv[] )
   progressReporter.Report( progress );
   timeCollector.Start( "Compute training mask" );
   tube::InfoMessage( "Compute training mask..." );
-  typedef tube::ComputeTrainingMask<ImageType> ComputeTrainingMaskType;
+  using ComputeTrainingMaskType = tube::ComputeTrainingMask<ImageType>;
   typename ComputeTrainingMaskType::Pointer filter =
     ComputeTrainingMaskType::New();
   filter->SetInput( imReader->GetOutput() );
@@ -101,8 +101,8 @@ int DoIt( int argc, char * argv[] )
   progress = 0.65;
   progressReporter.Report( progress );
   timeCollector.Stop( "Compute training mask" );
-  typedef typename ComputeTrainingMaskType::LabelMapType   LabelMapType;
-  typedef itk::ImageFileWriter<LabelMapType>               VolumeWriterType;
+  using LabelMapType = typename ComputeTrainingMaskType::LabelMapType;
+  using VolumeWriterType = itk::ImageFileWriter<LabelMapType>;
 
   typename VolumeWriterType::Pointer writer = VolumeWriterType::New();
   if( !objectMask.empty() )

--- a/examples/Applications/ComputeTubeFlyThroughImage/ComputeTubeFlyThroughImage.cxx
+++ b/examples/Applications/ComputeTubeFlyThroughImage/ComputeTubeFlyThroughImage.cxx
@@ -72,8 +72,8 @@ int DoIt( int argc, char * argv[] )
   // Load Input Image
   //std::cout << "Loading Input Image" << std::endl;
 
-  typedef itk::Image< TPixel, VDimension >              ImageType;
-  typedef itk::ImageFileReader< ImageType >             ImageReaderType;
+  using ImageType = itk::Image< TPixel, VDimension >;
+  using ImageReaderType = itk::ImageFileReader< ImageType >;
 
   timeCollector.Start( "Loading input image" );
 
@@ -99,7 +99,7 @@ int DoIt( int argc, char * argv[] )
   // Load TRE File
   //std::cout << "Loading TRE File" << std::endl;
 
-  typedef itk::SpatialObjectReader< VDimension >        TubesReaderType;
+  using TubesReaderType = itk::SpatialObjectReader< VDimension >;
 
   timeCollector.Start( "Loading input TRE file" );
 
@@ -123,8 +123,7 @@ int DoIt( int argc, char * argv[] )
   progressReporter.Report( progress );
 
   // call ComputeTubeFlyThroughImage
-  typedef tube::ComputeTubeFlyThroughImage< TPixel, VDimension >
-    ComputeFlyThroughImageFilterType;
+  using ComputeFlyThroughImageFilterType = tube::ComputeTubeFlyThroughImage< TPixel, VDimension >;
 
   timeCollector.Start( "Computing tube fly through images" );
 
@@ -141,7 +140,7 @@ int DoIt( int argc, char * argv[] )
   progressReporter.Report( progress );
 
   // Write fly through image
-  typedef itk::ImageFileWriter< ImageType > ImageWriterType;
+  using ImageWriterType = itk::ImageFileWriter< ImageType >;
 
   timeCollector.Start( "Writing tube fly through image" );
 
@@ -168,8 +167,7 @@ int DoIt( int argc, char * argv[] )
   // Write tube mask fly through image
   typedef typename ComputeFlyThroughImageFilterType::OutputMaskType
     MaskType;
-  typedef itk::ImageFileWriter< MaskType >
-    MaskWriterType;
+  using MaskWriterType = itk::ImageFileWriter< MaskType >;
 
   timeCollector.Start( "Writing tube mask fly through image" );
 

--- a/examples/Applications/ComputeTubeGraphSimilarityKernelMatrix/GraphKernel.h
+++ b/examples/Applications/ComputeTubeGraphSimilarityKernelMatrix/GraphKernel.h
@@ -64,12 +64,12 @@ public:
     }; // End struct nodeInfoType
 
   /** The graph type */
-  typedef boost::adjacency_list< boost::listS,
+  using GraphType = boost::adjacency_list< boost::listS,
                                  boost::vecS,
                                  boost::undirectedS,
                                  nodeInfoType,
                                  boost::property< boost::edge_weight_t,
-                                                  double> > GraphType;
+                                                  double> >;
   /** Access vertex index information */
   typedef boost::property_map<
     GraphType, boost::vertex_index_t>::type     IndexMapType;
@@ -78,14 +78,14 @@ public:
   typedef boost::graph_traits<GraphType>
     ::adjacency_iterator                        AdjacencyIteratorType;
 
-  typedef std::pair< AdjacencyIteratorType,
-                     AdjacencyIteratorType>     VertexNeighborType;
+  using VertexNeighborType = std::pair< AdjacencyIteratorType,
+                     AdjacencyIteratorType>;
 
   /** Access to shortest-path information */
-  typedef boost::exterior_vertex_property<
-    GraphType, double>                          DistancePropertyType;
-  typedef DistancePropertyType::matrix_type     DistanceMatrixType;
-  typedef DistancePropertyType::matrix_map_type DistanceMatrixMapType;
+  using DistancePropertyType = boost::exterior_vertex_property<
+    GraphType, double>;
+  using DistanceMatrixType = DistancePropertyType::matrix_type;
+  using DistanceMatrixMapType = DistancePropertyType::matrix_map_type;
 
   /** Vertex descriptor and vertex iterator */
   typedef boost::graph_traits<

--- a/examples/Applications/ComputeTubeGraphSimilarityKernelMatrix/tubeWLSubtreeKernel.h
+++ b/examples/Applications/ComputeTubeGraphSimilarityKernelMatrix/tubeWLSubtreeKernel.h
@@ -58,8 +58,8 @@ class WLSubtreeKernel : public GraphKernel
 {
 public:
 
-  typedef std::map<std::string, int>  LabelMapType;
-  typedef std::vector<LabelMapType>   LabelMapVectorType;
+  using LabelMapType = std::map<std::string, int>;
+  using LabelMapVectorType = std::vector<LabelMapType>;
 
   /** CTOR - Variant with no vertex label information */
   WLSubtreeKernel( const GraphType &G0,

--- a/examples/Applications/ComputeTubeMeasures/ComputeTubeMeasures.cxx
+++ b/examples/Applications/ComputeTubeMeasures/ComputeTubeMeasures.cxx
@@ -57,16 +57,16 @@ int DoIt( int argc, char * argv[] )
     CLPProcessInformation );
   progressReporter.Start();
 
-  typedef TPixel                                       InputPixelType;
+  using InputPixelType = TPixel;
 
-  typedef tube::ComputeTubeMeasures
-  < InputPixelType, VDimension > FilterType;
+  using FilterType = tube::ComputeTubeMeasures
+  < InputPixelType, VDimension >;
   typename FilterType::Pointer filter = FilterType::New();
 
-  typedef typename FilterType::InputImageType       InputImageType;
-  typedef itk::ImageFileReader< InputImageType >    ReaderType;
-  typedef typename FilterType::OutputImageType      OutputImageType;
-  typedef itk::ImageFileWriter< OutputImageType  >  WriterType;
+  using InputImageType = typename FilterType::InputImageType;
+  using ReaderType = itk::ImageFileReader< InputImageType >;
+  using OutputImageType = typename FilterType::OutputImageType;
+  using WriterType = itk::ImageFileWriter< OutputImageType  >;
 
   timeCollector.Start( "Load data" );
   typename ReaderType::Pointer reader = ReaderType::New();

--- a/examples/Applications/ComputeTubeProbability/ComputeTubeProbability.cxx
+++ b/examples/Applications/ComputeTubeProbability/ComputeTubeProbability.cxx
@@ -40,12 +40,12 @@ int DoIt( int argc, char * argv[] )
 {
   PARSE_ARGS;
 
-  typedef itk::Image< TPixel, VDimension >            ImageType;
-  typedef itk::GroupSpatialObject< VDimension >       GroupType;
-  typedef itk::ImageFileReader< ImageType >           ImageReaderType;
-  typedef itk::SpatialObjectReader< VDimension >      SOReaderType;
-  typedef itk::TubeSpatialObject< VDimension >        TubeType;
-  typedef typename TubeType::TubePointType            TubePointType;
+  using ImageType = itk::Image< TPixel, VDimension >;
+  using GroupType = itk::GroupSpatialObject< VDimension >;
+  using ImageReaderType = itk::ImageFileReader< ImageType >;
+  using SOReaderType = itk::SpatialObjectReader< VDimension >;
+  using TubeType = itk::TubeSpatialObject< VDimension >;
+  using TubePointType = typename TubeType::TubePointType;
 
 
   tube::CLIProgressReporter progressReporter( "tubeDensityProbability",

--- a/examples/Applications/ComputeTubeTortuosityMeasures/ComputeTubeTortuosityMeasures.cxx
+++ b/examples/Applications/ComputeTubeTortuosityMeasures/ComputeTubeTortuosityMeasures.cxx
@@ -70,14 +70,13 @@ int DoIt( int argc, char * argv[] )
   // The timeCollector to perform basic profiling of algorithmic components
   itk::TimeProbesCollectorBase timeCollector;
 
-  // typedefs
-  typedef itk::TubeSpatialObject< VDimension >        TubeType;
-  typedef itk::SpatialObjectReader< VDimension >      TubesReaderType;
-  typedef itk::GroupSpatialObject< VDimension >       TubeGroupType;
-  typedef typename TubeGroupType::ChildrenListPointer TubeListPointerType;
+  // type alias
+  using TubeType = itk::TubeSpatialObject< VDimension >;
+  using TubesReaderType = itk::SpatialObjectReader< VDimension >;
+  using TubeGroupType = itk::GroupSpatialObject< VDimension >;
+  using TubeListPointerType = typename TubeGroupType::ChildrenListPointer;
 
-  typedef itk::tube::TortuositySpatialObjectFilter< TubeType >
-    TortuosityFilterType;
+  using TortuosityFilterType = itk::tube::TortuositySpatialObjectFilter< TubeType >;
 
   // Load TRE File
   timeCollector.Start( "Loading Input TRE File" );

--- a/examples/Applications/Convert3DImagesTo4DImage/Convert3DImagesTo4DImage.cxx
+++ b/examples/Applications/Convert3DImagesTo4DImage/Convert3DImagesTo4DImage.cxx
@@ -52,11 +52,11 @@ int DoIt( int argc, char * argv[] )
     CLPProcessInformation );
   progressReporter.Start();
 
-  typedef TPixel                                    InputPixelType;
-  typedef itk::Image< InputPixelType, 3 >           InputImageType;
-  typedef itk::ImageFileReader< InputImageType >    ReaderType;
+  using InputPixelType = TPixel;
+  using InputImageType = itk::Image< InputPixelType, 3 >;
+  using ReaderType = itk::ImageFileReader< InputImageType >;
 
-  typedef tube::Write4DImageFrom3DImages< InputImageType > FilterType;
+  using FilterType = tube::Write4DImageFrom3DImages< InputImageType >;
 
   typename FilterType::Pointer filter = FilterType::New();
   unsigned int num3DImages = argc-2;
@@ -107,8 +107,8 @@ void GetImageInformation( const std::string & fileName,
                           itk::ImageIOBase::IOComponentEnum & componentType,
                           unsigned int & dimension )
 {
-  typedef itk::ImageIOBase     ImageIOType;
-  typedef itk::ImageIOFactory  ImageIOFactoryType;
+  using ImageIOType = itk::ImageIOBase;
+  using ImageIOFactoryType = itk::ImageIOFactory;
 
   ImageIOType::Pointer imageIO =
     ImageIOFactoryType::CreateImageIO( fileName.c_str(),
@@ -136,8 +136,8 @@ int main( int argc, char * argv[] )
 {
   PARSE_ARGS;
 
-  typedef itk::ImageIOBase              ImageIOType;
-  typedef ImageIOType::IOComponentEnum  IOComponentType;
+  using ImageIOType = itk::ImageIOBase;
+  using IOComponentType = ImageIOType::IOComponentEnum;
 
   IOComponentType componentType = IOComponentType::UNKNOWNCOMPONENTTYPE;
   unsigned int dimension = 0;

--- a/examples/Applications/Convert4DImageTo3DImages/Convert4DImageTo3DImages.cxx
+++ b/examples/Applications/Convert4DImageTo3DImages/Convert4DImageTo3DImages.cxx
@@ -51,16 +51,15 @@ int DoIt( int argc, char * argv[] )
     CLPProcessInformation );
   progressReporter.Start();
 
-  typedef TPixel                                    InputPixelType;
-  typedef itk::Image< InputPixelType, VDimension >  InputImageType;
-  typedef itk::ImageFileReader< InputImageType >    ReaderType;
+  using InputPixelType = TPixel;
+  using InputImageType = itk::Image< InputPixelType, VDimension >;
+  using ReaderType = itk::ImageFileReader< InputImageType >;
 
-  typedef TPixel                                    OutputPixelType;
-  typedef itk::Image< OutputPixelType, 3 >          OutputImageType;
-  typedef itk::ImageFileWriter< OutputImageType  >  WriterType;
+  using OutputPixelType = TPixel;
+  using OutputImageType = itk::Image< OutputPixelType, 3 >;
+  using WriterType = itk::ImageFileWriter< OutputImageType  >;
 
-  typedef itk::ExtractImageFilter< InputImageType, OutputImageType  >
-                                                    FilterType;
+  using FilterType = itk::ExtractImageFilter< InputImageType, OutputImageType  >;
 
   timeCollector.Start( "Load data" );
   typename ReaderType::Pointer reader = ReaderType::New();
@@ -155,8 +154,8 @@ void GetImageInformation( const std::string & fileName,
                           itk::ImageIOBase::IOComponentEnum & componentType,
                           unsigned int & dimension )
 {
-  typedef itk::ImageIOBase     ImageIOType;
-  typedef itk::ImageIOFactory  ImageIOFactoryType;
+  using ImageIOType = itk::ImageIOBase;
+  using ImageIOFactoryType = itk::ImageIOFactory;
 
   ImageIOType::Pointer imageIO =
     ImageIOFactoryType::CreateImageIO( fileName.c_str(),
@@ -184,8 +183,8 @@ int main( int argc, char * argv[] )
 {
   PARSE_ARGS;
 
-  typedef itk::ImageIOBase              ImageIOType;
-  typedef ImageIOType::IOComponentEnum  IOComponentType;
+  using ImageIOType = itk::ImageIOBase;
+  using IOComponentType = ImageIOType::IOComponentEnum;
 
   IOComponentType componentType = IOComponentType::UNKNOWNCOMPONENTTYPE;
   unsigned int dimension = 0;

--- a/examples/Applications/ConvertCSVToImages/ConvertCSVToImages.cxx
+++ b/examples/Applications/ConvertCSVToImages/ConvertCSVToImages.cxx
@@ -52,9 +52,9 @@ int DoIt( int argc, char * argv[] )
 {
   PARSE_ARGS;
 
-  typedef float                                     InputPixelType;
-  typedef itk::Image< InputPixelType, VDimension >  InputImageType;
-  typedef itk::ImageFileReader< InputImageType >    ReaderType;
+  using InputPixelType = float;
+  using InputImageType = itk::Image< InputPixelType, VDimension >;
+  using ReaderType = itk::ImageFileReader< InputImageType >;
 
   typename ReaderType::Pointer reader = ReaderType::New();
   reader->SetFileName( inputImageFileName );
@@ -90,7 +90,7 @@ int DoIt( int argc, char * argv[] )
     imageList[i]->FillBuffer( 0 );
     }
 
-  typedef typename itk::ImageRegionIterator< InputImageType > ImageIterType;
+  using ImageIterType = typename itk::ImageRegionIterator< InputImageType >;
   std::vector< ImageIterType * > imageIter;
   imageIter.resize( numImages );
   for( unsigned int i = 0; i < numImages; ++i )
@@ -132,7 +132,7 @@ int DoIt( int argc, char * argv[] )
       }
     }
 
-  typedef itk::ImageFileWriter< InputImageType > WriterType;
+  using WriterType = itk::ImageFileWriter< InputImageType >;
   typename WriterType::Pointer writer = WriterType::New();
   for( unsigned int i=0; i<imageIter.size(); ++i )
     {

--- a/examples/Applications/ConvertImagesToCSV/ConvertImagesToCSV.cxx
+++ b/examples/Applications/ConvertImagesToCSV/ConvertImagesToCSV.cxx
@@ -54,16 +54,15 @@ template< class TPixel, unsigned int VDimension >
 int DoIt( int argc, char * argv[] )
 {
   PARSE_ARGS;
-  typedef float                                     InputPixelType;
-  typedef itk::Image< InputPixelType, VDimension >  InputImageType;
-  typedef itk::ImageFileReader< InputImageType >    ReaderType;
+  using InputPixelType = float;
+  using InputImageType = itk::Image< InputPixelType, VDimension >;
+  using ReaderType = itk::ImageFileReader< InputImageType >;
 
-  typedef float                                     MaskPixelType;
-  typedef itk::Image< MaskPixelType, VDimension >   InputMaskType;
-  typedef itk::ImageFileReader< InputMaskType >     MaskReaderType;
+  using MaskPixelType = float;
+  using InputMaskType = itk::Image< MaskPixelType, VDimension >;
+  using MaskReaderType = itk::ImageFileReader< InputMaskType >;
 
-  typedef tube::ConvertImagesToCSV< InputImageType, InputMaskType >
-    ConvertImagesToCSVFilterType;
+  using ConvertImagesToCSVFilterType = tube::ConvertImagesToCSV< InputImageType, InputMaskType >;
   typename ConvertImagesToCSVFilterType::Pointer filter
           = ConvertImagesToCSVFilterType::New();
 
@@ -119,7 +118,7 @@ int DoIt( int argc, char * argv[] )
     ++numImages;
     }
 
-  typedef vnl_matrix<InputPixelType> MatrixType;
+  using MatrixType = vnl_matrix<InputPixelType>;
   const unsigned int ARows =
     inputMask->GetLargestPossibleRegion().GetNumberOfPixels() / stride;
   const unsigned int ACols = imageFileNameList.size() + 1;
@@ -137,7 +136,7 @@ int DoIt( int argc, char * argv[] )
   MatrixType submatrix = matrix.extract( numberRows, ACols );
 
   // write out the vnl_matrix object
-  typedef itk::CSVNumericObjectFileWriter<InputPixelType> WriterType;
+  using WriterType = itk::CSVNumericObjectFileWriter<InputPixelType>;
   WriterType::Pointer writer = WriterType::New();
 
   writer->SetFieldDelimiterCharacter( ',' );

--- a/examples/Applications/ConvertShrunkenSeedImageToList/ConvertShrunkenSeedImageToList.cxx
+++ b/examples/Applications/ConvertShrunkenSeedImageToList/ConvertShrunkenSeedImageToList.cxx
@@ -60,16 +60,16 @@ int DoIt( int argc, char * argv[] )
     CLPProcessInformation );
   progressReporter.Start();
 
-  typedef float                                     PixelType;
-  typedef itk::Image< PixelType, VDimension >       ImageType;
-  typedef itk::ImageFileReader< ImageType >         ImageReaderType;
+  using PixelType = float;
+  using ImageType = itk::Image< PixelType, VDimension >;
+  using ImageReaderType = itk::ImageFileReader< ImageType >;
 
-  typedef itk::Vector< float, VDimension >          PointsPixelType;
-  typedef itk::Image< PointsPixelType, VDimension > PointsImageType;
-  typedef itk::ImageFileReader< PointsImageType >   PointsImageReaderType;
+  using PointsPixelType = itk::Vector< float, VDimension >;
+  using PointsImageType = itk::Image< PointsPixelType, VDimension >;
+  using PointsImageReaderType = itk::ImageFileReader< PointsImageType >;
 
-  typedef tube::ConvertShrunkenSeedImageToList
-    < ImageType, PointsImageType > ConvertShrunkenSeedImageToListFilterType;
+  using ConvertShrunkenSeedImageToListFilterType = tube::ConvertShrunkenSeedImageToList
+    < ImageType, PointsImageType >;
   typename ConvertShrunkenSeedImageToListFilterType::Pointer filter
     = ConvertShrunkenSeedImageToListFilterType::New();
 
@@ -149,7 +149,7 @@ int DoIt( int argc, char * argv[] )
 
   filter->Update();
 
-  typedef vnl_matrix<PixelType> MatrixType;
+  using MatrixType = vnl_matrix<PixelType>;
   const unsigned int ARows =
     inImage->GetLargestPossibleRegion().GetNumberOfPixels();
   const unsigned int ACols = VDimension + 1;
@@ -158,7 +158,7 @@ int DoIt( int argc, char * argv[] )
   matrix = filter->GetOutput();
 
   // write out the vnl_matrix object
-  typedef itk::CSVNumericObjectFileWriter<PixelType> WriterType;
+  using WriterType = itk::CSVNumericObjectFileWriter<PixelType>;
   WriterType::Pointer writer = WriterType::New();
 
   writer->SetFieldDelimiterCharacter( ',' );

--- a/examples/Applications/ConvertSpatialGraphToImage/ConvertSpatialGraphToImage.cxx
+++ b/examples/Applications/ConvertSpatialGraphToImage/ConvertSpatialGraphToImage.cxx
@@ -50,12 +50,11 @@ int DoIt( int argc, char * argv[] )
 
   std::stringstream logMsg;
 
-  typedef itk::Image< float, VDimension >       ImageType;
-  typedef itk::Image< TPixel, VDimension >      CVTImageType;
-  typedef itk::ImageFileReader< CVTImageType >  ImageReaderType;
+  using ImageType = itk::Image< float, VDimension >;
+  using CVTImageType = itk::Image< TPixel, VDimension >;
+  using ImageReaderType = itk::ImageFileReader< CVTImageType >;
 
-  typedef tube::ConvertSpatialGraphToImage< CVTImageType, ImageType >
-    ConvertSpatialGraphToImageFilterType;
+  using ConvertSpatialGraphToImageFilterType = tube::ConvertSpatialGraphToImage< CVTImageType, ImageType >;
   typename ConvertSpatialGraphToImageFilterType::Pointer filter =
     ConvertSpatialGraphToImageFilterType::New();
 
@@ -182,7 +181,7 @@ int DoIt( int argc, char * argv[] )
 
   filter->Update();
 
-  typedef itk::ImageFileWriter< ImageType > ImageWriterType;
+  using ImageWriterType = itk::ImageFileWriter< ImageType >;
   typename ImageWriterType::Pointer imageWriter;
   std::string filename;
 

--- a/examples/Applications/ConvertTRE/ConvertTRE.cxx
+++ b/examples/Applications/ConvertTRE/ConvertTRE.cxx
@@ -39,14 +39,14 @@ int main( int argc, char * argv[] )
 {
   PARSE_ARGS;
 
-  typedef itk::tube::TubeXIO< 3 >       TubeXIOType;
-  typedef itk::SpatialObjectReader< 3 > SOReaderType;
-  typedef itk::SpatialObjectWriter< 3 > SOWriterType;
+  using TubeXIOType = itk::tube::TubeXIO< 3 >;
+  using SOReaderType = itk::SpatialObjectReader< 3 >;
+  using SOWriterType = itk::SpatialObjectWriter< 3 >;
 
   // The image type does not matter. We're only interested in the image size.
-  typedef itk::Image< float, 3 >            ImageType;
-  typedef itk::ImageFileReader< ImageType > ImageReaderType;
-  typedef TubeXIOType::SizeType             SizeType;
+  using ImageType = itk::Image< float, 3 >;
+  using ImageReaderType = itk::ImageFileReader< ImageType >;
+  using SizeType = TubeXIOType::SizeType;
 
 
   // The timeCollector is used to perform basic profiling of the components

--- a/examples/Applications/ConvertTubesToDensityImage/ConvertTubesToDensityImage.cxx
+++ b/examples/Applications/ConvertTubesToDensityImage/ConvertTubesToDensityImage.cxx
@@ -39,21 +39,21 @@ int DoIt( int argc, char * argv[] )
   PARSE_ARGS;
 
   /*Typedefs..*/
-  typedef float                                         TPixel;
-  typedef itk::Vector< TPixel, Dimension >              TangentPixelType;
-  typedef itk::Image< TPixel, Dimension >               DensityImageType;
-  typedef itk::Image< TPixel, Dimension >               RadiusImageType;
-  typedef itk::Image< TangentPixelType, Dimension >     TangentImageType;
-  typedef itk::Image< unsigned char, Dimension >        TemplateImageType;
-  typedef itk::ImageFileReader< TemplateImageType >     TemplateImageReaderType;
+  using TPixel = float;
+  using TangentPixelType = itk::Vector< TPixel, Dimension >;
+  using DensityImageType = itk::Image< TPixel, Dimension >;
+  using RadiusImageType = itk::Image< TPixel, Dimension >;
+  using TangentImageType = itk::Image< TangentPixelType, Dimension >;
+  using TemplateImageType = itk::Image< unsigned char, Dimension >;
+  using TemplateImageReaderType = itk::ImageFileReader< TemplateImageType >;
 
   /** Max Intensity value */
   TPixel   max_densityIntensity = 2048;
 
-  typedef tube::ConvertTubesToDensityImage<
-  TPixel, Dimension > TubeToDensityImageBuilderType;
+  using TubeToDensityImageBuilderType = tube::ConvertTubesToDensityImage<
+  TPixel, Dimension >;
 
-  typedef itk::SpatialObjectReader< Dimension >         TubesReaderType;
+  using TubesReaderType = itk::SpatialObjectReader< Dimension >;
 
 
   double progress = 0.0;

--- a/examples/Applications/ConvertTubesToImage/ConvertTubesToImage.cxx
+++ b/examples/Applications/ConvertTubesToImage/ConvertTubesToImage.cxx
@@ -60,7 +60,7 @@ int DoIt( int argc, char * argv[] )
   progressReporter.Report( progress );
 
   // read tubes
-  typedef itk::SpatialObjectReader< Dimension > TubesReaderType;
+  using TubesReaderType = itk::SpatialObjectReader< Dimension >;
 
   timeCollector.Start( "Reading tubes file" );
 
@@ -82,8 +82,8 @@ int DoIt( int argc, char * argv[] )
   progressReporter.Report( progress );
 
   // read template image
-  typedef itk::Image< TPixel, Dimension >            TemplateImageType;
-  typedef itk::ImageFileReader< TemplateImageType >  TemplateImageReaderType;
+  using TemplateImageType = itk::Image< TPixel, Dimension >;
+  using TemplateImageReaderType = itk::ImageFileReader< TemplateImageType >;
 
   timeCollector.Start( "Reading template image" );
 
@@ -106,7 +106,7 @@ int DoIt( int argc, char * argv[] )
   progressReporter.Report( progress );
 
   // call TubesToImageFilter
-  typedef tube::ConvertTubesToImage< TemplateImageType > TubesToImageFilterType;
+  using TubesToImageFilterType = tube::ConvertTubesToImage< TemplateImageType >;
 
   timeCollector.Start( "Converting Tubes To Image" );
 
@@ -125,7 +125,7 @@ int DoIt( int argc, char * argv[] )
   // write tube image to file
   timeCollector.Start( "Writing tube image to file" );
 
-  typedef itk::ImageFileWriter< TemplateImageType > TubeImageWriterType;
+  using TubeImageWriterType = itk::ImageFileWriter< TemplateImageType >;
   typename TubeImageWriterType::Pointer tubeImageWriter =
     TubeImageWriterType::New();
 

--- a/examples/Applications/ConvertTubesToTubeGraph/ConvertTubesToTubeGraph.cxx
+++ b/examples/Applications/ConvertTubesToTubeGraph/ConvertTubesToTubeGraph.cxx
@@ -43,13 +43,12 @@ int DoIt( int argc, char * argv[] )
 {
   enum { Dimension = 3 };
 
-  typedef short                                      PixelType;
-  typedef itk::Image< PixelType, Dimension >         ImageType;
-  typedef itk::ImageFileReader< ImageType >          ImageReaderType;
-  typedef itk::SpatialObjectReader< >                SpatialObjectReaderType;
+  using PixelType = short;
+  using ImageType = itk::Image< PixelType, Dimension >;
+  using ImageReaderType = itk::ImageFileReader< ImageType >;
+  using SpatialObjectReaderType = itk::SpatialObjectReader< >;
 
-  typedef tube::ConvertTubesToTubeGraph< PixelType, Dimension >
-    FilterType;
+  using FilterType = tube::ConvertTubesToTubeGraph< PixelType, Dimension >;
   FilterType::Pointer filter = FilterType::New();
   PARSE_ARGS;
 

--- a/examples/Applications/ConvertTubesToTubeTree/ConvertTubesToTubeTree.cxx
+++ b/examples/Applications/ConvertTubesToTubeTree/ConvertTubesToTubeTree.cxx
@@ -69,8 +69,8 @@ int DoIt( int argc, char * argv[] )
   // Load TRE File
   tubeStandardOutputMacro( << "\n>> Loading TRE File" );
 
-  typedef itk::SpatialObjectReader< VDimension > TubesReaderType;
-  typedef itk::GroupSpatialObject< VDimension >  TubeGroupType;
+  using TubesReaderType = itk::SpatialObjectReader< VDimension >;
+  using TubeGroupType = itk::GroupSpatialObject< VDimension >;
 
   timeCollector.Start( "Loading Input TRE File" );
 
@@ -98,8 +98,7 @@ int DoIt( int argc, char * argv[] )
 
   timeCollector.Start( "Running vessel connectivity filter" );
 
-  typedef itk::tube::MinimumSpanningTreeVesselConnectivityFilter< VDimension >
-  VesselConnectivityFilterType;
+  using VesselConnectivityFilterType = itk::tube::MinimumSpanningTreeVesselConnectivityFilter< VDimension >;
   typename VesselConnectivityFilterType::Pointer vesselConnectivityFilter =
   VesselConnectivityFilterType::New();
 
@@ -127,7 +126,7 @@ int DoIt( int argc, char * argv[] )
 
   timeCollector.Start( "Writing TRE file with connectivity information" );
 
-  typedef itk::SpatialObjectWriter< VDimension > TubeWriterType;
+  using TubeWriterType = itk::SpatialObjectWriter< VDimension >;
   typename TubeWriterType::Pointer tubeWriter = TubeWriterType::New();
 
   try

--- a/examples/Applications/CropImage/CropImage.cxx
+++ b/examples/Applications/CropImage/CropImage.cxx
@@ -58,9 +58,9 @@ int DoIt( int argc, char * argv[] )
                                                  CLPProcessInformation );
   progressReporter.Start();
 
-  typedef TPixel                               PixelType;
-  typedef itk::Image< PixelType, VDimension >  ImageType;
-  typedef itk::ImageFileReader< ImageType >    ReaderType;
+  using PixelType = TPixel;
+  using ImageType = itk::Image< PixelType, VDimension >;
+  using ReaderType = itk::ImageFileReader< ImageType >;
 
   timeCollector.Start( "Load data" );
   typename ReaderType::Pointer reader = ReaderType::New();
@@ -100,7 +100,7 @@ int DoIt( int argc, char * argv[] )
 
     timeCollector.Start( "CropFilter" );
 
-    typedef tube::CropImage< ImageType, ImageType > CropFilterType;
+    using CropFilterType = tube::CropImage< ImageType, ImageType >;
     typename CropFilterType::Pointer cropFilter = CropFilterType::New();
 
     cropFilter->SetInput( reader->GetOutput() );
@@ -209,7 +209,7 @@ int DoIt( int argc, char * argv[] )
     progressReporter.Report( 0.8 );
     timeCollector.Start( "Save data" );
 
-    typedef itk::ImageFileWriter< ImageType  >   ImageWriterType;
+    using ImageWriterType = itk::ImageFileWriter< ImageType  >;
 
     typename ImageWriterType::Pointer writer = ImageWriterType::New();
     writer->SetFileName( outputVolume.c_str() );
@@ -246,7 +246,7 @@ int DoIt( int argc, char * argv[] )
       {
       //Create new instance of cropFilter each time we extract a portion of
       // the image to reset parameters
-      typedef tube::CropImage<ImageType, ImageType> CropFilterType;
+      using CropFilterType = tube::CropImage<ImageType, ImageType>;
       typename CropFilterType::Pointer cropFilter = CropFilterType::New();
       cropFilter->SetInput( inputImage );
 
@@ -298,7 +298,7 @@ int DoIt( int argc, char * argv[] )
       progressReporter.Report( 0.8 );
       timeCollector.Start( "Save data" );
 
-      typedef itk::ImageFileWriter< ImageType  >   ImageWriterType;
+      using ImageWriterType = itk::ImageFileWriter< ImageType  >;
       typename ImageWriterType::Pointer writer = ImageWriterType::New();
 
       std::stringstream out;

--- a/examples/Applications/CropTubes/CropTubes.cxx
+++ b/examples/Applications/CropTubes/CropTubes.cxx
@@ -55,16 +55,16 @@ int DoIt ( int argc, char * argv[] )
   // Load TRE File
   tubeStandardOutputMacro( << "\n>> Loading TRE File" );
 
-  typedef itk::SpatialObjectReader< DimensionT >          TubesReaderType;
-  typedef double                                          PixelType;
-  typedef itk::Image< PixelType, DimensionT >             ImageType;
-  typedef itk::ImageFileReader< ImageType >               ImageReaderType;
-  typedef itk::Vector< double, DimensionT >               VectorType;
-  typedef itk::Point< double, DimensionT >                PointType;
+  using TubesReaderType = itk::SpatialObjectReader< DimensionT >;
+  using PixelType = double;
+  using ImageType = itk::Image< PixelType, DimensionT >;
+  using ImageReaderType = itk::ImageFileReader< ImageType >;
+  using VectorType = itk::Vector< double, DimensionT >;
+  using PointType = itk::Point< double, DimensionT >;
 
   timeCollector.Start( "Loading Input TRE File" );
 
-  typedef tube::CropTubes< DimensionT > FilterType;
+  using FilterType = tube::CropTubes< DimensionT >;
   typename FilterType::Pointer filter = FilterType::New();
 
   typename TubesReaderType::Pointer tubeFileReader = TubesReaderType::New();
@@ -144,7 +144,7 @@ int DoIt ( int argc, char * argv[] )
 
   timeCollector.Start( "Writing output TRE file" );
 
-  typedef itk::SpatialObjectWriter< DimensionT > TubeWriterType;
+  using TubeWriterType = itk::SpatialObjectWriter< DimensionT >;
   typename TubeWriterType::Pointer tubeWriter = TubeWriterType::New();
 
   try

--- a/examples/Applications/DICOMSeriesConverter/DICOMSeriesConverter.cxx
+++ b/examples/Applications/DICOMSeriesConverter/DICOMSeriesConverter.cxx
@@ -46,20 +46,20 @@ int main(int argc, char *argv[]) {
     return EXIT_FAILURE;
   }
 
-  typedef signed short PixelType;
+  using PixelType = signed short;
   const unsigned int Dimension = 3;
 
-  typedef itk::Image<PixelType, Dimension> ImageType;
+  using ImageType = itk::Image<PixelType, Dimension>;
 
-  typedef itk::ImageFileReader<ImageType> Reader2DType;
-  typedef itk::ImageSeriesReader<ImageType> ReaderType;
-  typedef itk::GDCMImageIO ImageIOType;
+  using Reader2DType = itk::ImageFileReader<ImageType>;
+  using ReaderType = itk::ImageSeriesReader<ImageType>;
+  using ImageIOType = itk::GDCMImageIO;
 
-  typedef std::vector<std::string> SeriesIdContainer;
-  typedef std::vector<std::string> FileNamesContainer;
-  typedef itk::ImageFileWriter<ImageType> WriterType;
+  using SeriesIdContainer = std::vector<std::string>;
+  using FileNamesContainer = std::vector<std::string>;
+  using WriterType = itk::ImageFileWriter<ImageType>;
 
-  typedef itk::GDCMSeriesFileNames NamesGeneratorType;
+  using NamesGeneratorType = itk::GDCMSeriesFileNames;
 
   ReaderType::Pointer reader;
   ImageIOType::Pointer dicomIO;

--- a/examples/Applications/DeblendTomosynthesisSlicesUsingPrior/DeblendTomosynthesisSlicesUsingPrior.cxx
+++ b/examples/Applications/DeblendTomosynthesisSlicesUsingPrior/DeblendTomosynthesisSlicesUsingPrior.cxx
@@ -51,19 +51,19 @@ class BlendCostFunction : public SingleValuedCostFunction
 {
 public:
 
-  typedef BlendCostFunction                       Self;
-  typedef SingleValuedCostFunction                Superclass;
-  typedef SmartPointer< Self >                    Pointer;
-  typedef SmartPointer< const Self >              ConstPointer;
+  using Self = BlendCostFunction;
+  using Superclass = SingleValuedCostFunction;
+  using Pointer = SmartPointer< Self >;
+  using ConstPointer = SmartPointer< const Self >;
 
   itkTypeMacro( BlendCostFunction, SingleValuedCostFunction );
 
   itkNewMacro( Self );
 
-  typedef Superclass::MeasureType         MeasureType;
-  typedef Superclass::ParametersType      ParametersType;
-  typedef Superclass::DerivativeType      DerivativeType;
-  typedef itk::Image<TPixel, VDimension>  ImageType;
+  using MeasureType = Superclass::MeasureType;
+  using ParametersType = Superclass::ParametersType;
+  using DerivativeType = Superclass::DerivativeType;
+  using ImageType = itk::Image<TPixel, VDimension>;
 
   unsigned int GetNumberOfParameters( void ) const override
     {
@@ -128,10 +128,8 @@ public:
 
   MeasureType GetValue( const ParametersType & params ) const override
     {
-    typedef itk::ImageRegionConstIterator< ImageType >
-      ConstImageIteratorType;
-    typedef itk::ImageRegionIterator< ImageType >
-      ImageIteratorType;
+    using ConstImageIteratorType = itk::ImageRegionConstIterator< ImageType >;
+    using ImageIteratorType = itk::ImageRegionIterator< ImageType >;
 
     double result = 0;
     double sum255 = 0;
@@ -256,22 +254,22 @@ class BlendScaleCostFunction : public SingleValuedCostFunction
 {
 public:
 
-  typedef BlendScaleCostFunction                  Self;
-  typedef SingleValuedCostFunction                Superclass;
-  typedef SmartPointer< Self >                    Pointer;
-  typedef SmartPointer< const Self >              ConstPointer;
+  using Self = BlendScaleCostFunction;
+  using Superclass = SingleValuedCostFunction;
+  using Pointer = SmartPointer< Self >;
+  using ConstPointer = SmartPointer< const Self >;
 
   itkTypeMacro( BlendScaleCostFunction, SingleValuedCostFunction );
 
   itkNewMacro( Self );
 
-  typedef Superclass::MeasureType         MeasureType;
-  typedef Superclass::ParametersType      ParametersType;
-  typedef Superclass::DerivativeType      DerivativeType;
-  typedef itk::Image<TPixel, VDimension>  ImageType;
+  using MeasureType = Superclass::MeasureType;
+  using ParametersType = Superclass::ParametersType;
+  using DerivativeType = Superclass::DerivativeType;
+  using ImageType = itk::Image<TPixel, VDimension>;
 
-  typedef itk::tube::SmoothingRecursiveGaussianImageFilter< ImageType,
-    ImageType >                           BlurFilterType;
+  using BlurFilterType = itk::tube::SmoothingRecursiveGaussianImageFilter< ImageType,
+    ImageType >;
 
   unsigned int GetNumberOfParameters( void ) const override
     {
@@ -336,10 +334,8 @@ public:
 
   MeasureType GetValue( const ParametersType & params ) const override
     {
-    typedef itk::ImageRegionConstIterator< ImageType >
-      ConstImageIteratorType;
-    typedef itk::ImageRegionIterator< ImageType >
-      ImageIteratorType;
+    using ConstImageIteratorType = itk::ImageRegionConstIterator< ImageType >;
+    using ImageIteratorType = itk::ImageRegionIterator< ImageType >;
 
     typename BlurFilterType::Pointer filterBottom = BlurFilterType::New();
     filterBottom->SetInput( m_ImageBottom );
@@ -497,8 +493,8 @@ int DoIt( int argc, char * argv[] )
                                                  CLPProcessInformation );
   progressReporter.Start();
 
-  typedef float                                PixelType;
-  typedef itk::Image< PixelType, VDimension >  ImageType;
+  using PixelType = float;
+  using ImageType = itk::Image< PixelType, VDimension >;
 
   /** Read input images */
   typename ImageType::Pointer imageBottom;
@@ -508,7 +504,7 @@ int DoIt( int argc, char * argv[] )
 
   timeCollector.Start( "Read" );
     {
-    typedef itk::ImageFileReader< ImageType >   ReaderType;
+    using ReaderType = itk::ImageFileReader< ImageType >;
 
     typename ReaderType::Pointer readerBottom = ReaderType::New();
     typename ReaderType::Pointer readerMiddle = ReaderType::New();
@@ -591,10 +587,9 @@ int DoIt( int argc, char * argv[] )
   blendParams[2] = offset;
   if( 1 )
     {
-    typedef itk::tube::BlendCostFunction< PixelType, VDimension >
-                                                  BlendCostFunctionType;
-    typedef itk::OnePlusOneEvolutionaryOptimizer  InitialOptimizerType;
-    typedef itk::FRPROptimizer                    OptimizerType;
+    using BlendCostFunctionType = itk::tube::BlendCostFunction< PixelType, VDimension >;
+    using InitialOptimizerType = itk::OnePlusOneEvolutionaryOptimizer;
+    using OptimizerType = itk::FRPROptimizer;
 
     typename BlendCostFunctionType::Pointer costFunc =
       BlendCostFunctionType::New();
@@ -605,7 +600,7 @@ int DoIt( int argc, char * argv[] )
 
     if( metricMask.size() > 0 )
       {
-      typedef itk::ImageFileReader< ImageType >   ReaderType;
+      using ReaderType = itk::ImageFileReader< ImageType >;
       typename ReaderType::Pointer readerMask = ReaderType::New();
       readerMask->SetFileName( metricMask.c_str() );
       readerMask->Update();
@@ -688,10 +683,9 @@ int DoIt( int argc, char * argv[] )
   blendScaleParams[3] = sigma;
   if( 1 )
     {
-    typedef itk::tube::BlendScaleCostFunction< PixelType, VDimension >
-                                                  BlendScaleCostFunctionType;
-    typedef itk::OnePlusOneEvolutionaryOptimizer  InitialOptimizerType;
-    typedef itk::FRPROptimizer                    OptimizerType;
+    using BlendScaleCostFunctionType = itk::tube::BlendScaleCostFunction< PixelType, VDimension >;
+    using InitialOptimizerType = itk::OnePlusOneEvolutionaryOptimizer;
+    using OptimizerType = itk::FRPROptimizer;
 
     typename BlendScaleCostFunctionType::Pointer costFunc =
       BlendScaleCostFunctionType::New();
@@ -702,7 +696,7 @@ int DoIt( int argc, char * argv[] )
 
     if( metricMask.size() > 0 )
       {
-      typedef itk::ImageFileReader< ImageType >   ReaderType;
+      using ReaderType = itk::ImageFileReader< ImageType >;
       typename ReaderType::Pointer readerMask = ReaderType::New();
       readerMask->SetFileName( metricMask.c_str() );
       readerMask->Update();
@@ -780,7 +774,7 @@ int DoIt( int argc, char * argv[] )
               << " Result = " << result << std::endl;
     }
 
-  typedef itk::ImageFileWriter< ImageType  >   ImageWriterType;
+  using ImageWriterType = itk::ImageFileWriter< ImageType  >;
   typename ImageWriterType::Pointer writer = ImageWriterType::New();
 
   writer->SetFileName( outputMiddle.c_str() );

--- a/examples/Applications/EnhanceCoherenceAndEdgesUsingDiffusion/EnhanceCoherenceAndEdgesUsingDiffusion.cxx
+++ b/examples/Applications/EnhanceCoherenceAndEdgesUsingDiffusion/EnhanceCoherenceAndEdgesUsingDiffusion.cxx
@@ -58,16 +58,16 @@ int DoIt( int argc, char * argv[] )
   // but use double for the filter to avoid rounding off errors in the
   // filter's floating point operations
   enum { Dimension = 3 };
-  typedef TPixel                                   ImagePixelType;
-  typedef itk::Image< ImagePixelType, Dimension >  InputImageType;
-  typedef itk::Image< ImagePixelType, Dimension >  OutputImageType;
-  typedef double                                   FilterPixelType;
-  typedef itk::Image< FilterPixelType, Dimension > FilterInputImageType;
-  typedef itk::Image< FilterPixelType, Dimension > FilterOutputImageType;
+  using ImagePixelType = TPixel;
+  using InputImageType = itk::Image< ImagePixelType, Dimension >;
+  using OutputImageType = itk::Image< ImagePixelType, Dimension >;
+  using FilterPixelType = double;
+  using FilterInputImageType = itk::Image< FilterPixelType, Dimension >;
+  using FilterOutputImageType = itk::Image< FilterPixelType, Dimension >;
 
   // Read the input volume
   timeCollector.Start( "Load data" );
-  typedef itk::ImageFileReader< InputImageType  >  ImageReaderType;
+  using ImageReaderType = itk::ImageFileReader< InputImageType  >;
   typename ImageReaderType::Pointer   reader = ImageReaderType::New();
   reader->SetFileName( inputVolume.c_str() );
   try
@@ -86,16 +86,14 @@ int DoIt( int argc, char * argv[] )
   progressReporter.Report( progress );
 
   // C-style cast from input image type to type 'double'
-  typedef itk::CastImageFilter< InputImageType, FilterInputImageType >
-    CastInputImageFilterType;
+  using CastInputImageFilterType = itk::CastImageFilter< InputImageType, FilterInputImageType >;
   typename CastInputImageFilterType::Pointer castInputImageFilter =
     CastInputImageFilterType::New();
   castInputImageFilter->SetInput( reader->GetOutput() );
 
   // Reorient to axial because the anisotropic diffusion tensor function does
   // not handle direction
-  typedef itk::OrientImageFilter< FilterInputImageType, FilterInputImageType >
-      OrientInputFilterType;
+  using OrientInputFilterType = itk::OrientImageFilter< FilterInputImageType, FilterInputImageType >;
   typename OrientInputFilterType::Pointer orientInputFilter
       = OrientInputFilterType::New();
   orientInputFilter->UseImageDirectionOn();
@@ -106,8 +104,8 @@ int DoIt( int argc, char * argv[] )
   timeCollector.Start( "Hybrid enhancing anisotropic diffusion" );
 
   // Declare the anisotropic diffusion hybrid enhancing filter
-  typedef itk::tube::AnisotropicHybridDiffusionImageFilter<
-    FilterInputImageType, FilterOutputImageType>  HybridEnhancingFilterType;
+  using HybridEnhancingFilterType = itk::tube::AnisotropicHybridDiffusionImageFilter<
+    FilterInputImageType, FilterOutputImageType>;
 
   // Create a hybrid enhancing Filter
   typename HybridEnhancingFilterType::Pointer HybridEnhancingFilter =
@@ -150,15 +148,13 @@ int DoIt( int argc, char * argv[] )
   progressReporter.Report( progress );
 
   // C-style cast from double to output image type
-  typedef itk::CastImageFilter< FilterOutputImageType, OutputImageType >
-    CastOutputImageFilterType;
+  using CastOutputImageFilterType = itk::CastImageFilter< FilterOutputImageType, OutputImageType >;
   typename CastOutputImageFilterType::Pointer castOutputImageFilter =
     CastOutputImageFilterType::New();
   castOutputImageFilter->SetInput( HybridEnhancingFilter->GetOutput() );
 
   // Reorient back from axial to whatever direction we had before
-  typedef itk::OrientImageFilter< OutputImageType, OutputImageType >
-      OrientOutputFilterType;
+  using OrientOutputFilterType = itk::OrientImageFilter< OutputImageType, OutputImageType >;
   typename OrientOutputFilterType::Pointer orientOutputFilter
       = OrientOutputFilterType::New();
   orientOutputFilter->UseImageDirectionOn();
@@ -168,7 +164,7 @@ int DoIt( int argc, char * argv[] )
 
   // Save output data
   timeCollector.Start( "Save data" );
-  typedef itk::ImageFileWriter< OutputImageType  >      ImageWriterType;
+  using ImageWriterType = itk::ImageFileWriter< OutputImageType  >;
   typename ImageWriterType::Pointer writer = ImageWriterType::New();
   writer->SetFileName( outputVolume.c_str() );
   writer->SetInput( orientOutputFilter->GetOutput() );

--- a/examples/Applications/EnhanceCoherenceUsingDiffusion/EnhanceCoherenceUsingDiffusion.cxx
+++ b/examples/Applications/EnhanceCoherenceUsingDiffusion/EnhanceCoherenceUsingDiffusion.cxx
@@ -57,16 +57,16 @@ int DoIt( int argc, char * argv[] )
   // but use double for the filter to avoid rounding off errors in the
   // filter's floating point operations
   enum { Dimension = 3 };
-  typedef TPixel                                   ImagePixelType;
-  typedef itk::Image< ImagePixelType, Dimension >  InputImageType;
-  typedef itk::Image< ImagePixelType, Dimension >  OutputImageType;
-  typedef double                                   FilterPixelType;
-  typedef itk::Image< FilterPixelType, Dimension > FilterInputImageType;
-  typedef itk::Image< FilterPixelType, Dimension > FilterOutputImageType;
+  using ImagePixelType = TPixel;
+  using InputImageType = itk::Image< ImagePixelType, Dimension >;
+  using OutputImageType = itk::Image< ImagePixelType, Dimension >;
+  using FilterPixelType = double;
+  using FilterInputImageType = itk::Image< FilterPixelType, Dimension >;
+  using FilterOutputImageType = itk::Image< FilterPixelType, Dimension >;
 
   // Read the input volume
   timeCollector.Start( "Load data" );
-  typedef itk::ImageFileReader< InputImageType  >  ImageReaderType;
+  using ImageReaderType = itk::ImageFileReader< InputImageType  >;
   typename ImageReaderType::Pointer reader = ImageReaderType::New();
   reader->SetFileName( inputVolume.c_str() );
   try
@@ -85,16 +85,14 @@ int DoIt( int argc, char * argv[] )
   progressReporter.Report( progress );
 
   // C-style cast from input image type to type 'double'
-  typedef itk::CastImageFilter< InputImageType, FilterInputImageType >
-    CastInputImageFilterType;
+  using CastInputImageFilterType = itk::CastImageFilter< InputImageType, FilterInputImageType >;
   typename CastInputImageFilterType::Pointer castInputImageFilter =
     CastInputImageFilterType::New();
   castInputImageFilter->SetInput( reader->GetOutput() );
 
   // Reorient to axial because the anisotropic diffusion tensor function does
   // not handle direction
-  typedef itk::OrientImageFilter< FilterInputImageType, FilterInputImageType >
-      OrientInputFilterType;
+  using OrientInputFilterType = itk::OrientImageFilter< FilterInputImageType, FilterInputImageType >;
   typename OrientInputFilterType::Pointer orientInputFilter
       = OrientInputFilterType::New();
   orientInputFilter->UseImageDirectionOn();
@@ -105,9 +103,8 @@ int DoIt( int argc, char * argv[] )
   timeCollector.Start( "Coherence enhancing anisotropic diffusion" );
 
   // Declare the anisotropic diffusion coherence enhancing filter
-  typedef itk::tube::AnisotropicCoherenceEnhancingDiffusionImageFilter<
-    FilterInputImageType, FilterOutputImageType>
-    CoherenceEnhancingFilterType;
+  using CoherenceEnhancingFilterType = itk::tube::AnisotropicCoherenceEnhancingDiffusionImageFilter<
+    FilterInputImageType, FilterOutputImageType>;
 
   // Create a coherence enhancing filter
   typename CoherenceEnhancingFilterType::Pointer CoherenceEnhancingFilter =
@@ -146,15 +143,13 @@ int DoIt( int argc, char * argv[] )
   progressReporter.Report( progress );
 
   // C-style cast from double to output image type
-  typedef itk::CastImageFilter< FilterOutputImageType, OutputImageType >
-    CastOutputImageFilterType;
+  using CastOutputImageFilterType = itk::CastImageFilter< FilterOutputImageType, OutputImageType >;
   typename CastOutputImageFilterType::Pointer castOutputImageFilter =
     CastOutputImageFilterType::New();
   castOutputImageFilter->SetInput( CoherenceEnhancingFilter->GetOutput() );
 
   // Reorient back from axial to whatever direction we had before
-  typedef itk::OrientImageFilter< OutputImageType, OutputImageType >
-      OrientOutputFilterType;
+  using OrientOutputFilterType = itk::OrientImageFilter< OutputImageType, OutputImageType >;
   typename OrientOutputFilterType::Pointer orientOutputFilter
       = OrientOutputFilterType::New();
   orientOutputFilter->UseImageDirectionOn();
@@ -164,7 +159,7 @@ int DoIt( int argc, char * argv[] )
 
   // Save output data
   timeCollector.Start( "Save data" );
-  typedef itk::ImageFileWriter< OutputImageType  >      ImageWriterType;
+  using ImageWriterType = itk::ImageFileWriter< OutputImageType  >;
   typename ImageWriterType::Pointer writer = ImageWriterType::New();
   writer->SetFileName( outputVolume.c_str() );
   writer->SetUseCompression( true );

--- a/examples/Applications/EnhanceContrastUsingAHE/EnhanceContrastUsingAHE.cxx
+++ b/examples/Applications/EnhanceContrastUsingAHE/EnhanceContrastUsingAHE.cxx
@@ -53,10 +53,9 @@ int DoIt( int argc, char * argv[] )
     "ContrastImage", CLPProcessInformation );
   progressReporter.Start();
 
-  typedef float                                PixelType;
-  typedef itk::Image< PixelType, VDimension >  ImageType;
-  typedef itk::AdaptiveHistogramEqualizationImageFilter< ImageType >
-                                               FilterType;
+  using PixelType = float;
+  using ImageType = itk::Image< PixelType, VDimension >;
+  using FilterType = itk::AdaptiveHistogramEqualizationImageFilter< ImageType >;
 
   typename FilterType::Pointer filter = FilterType::New();
 
@@ -65,7 +64,7 @@ int DoIt( int argc, char * argv[] )
 
   timeCollector.Start( "Read" );
     {
-    typedef itk::ImageFileReader< ImageType >   ReaderType;
+    using ReaderType = itk::ImageFileReader< ImageType >;
 
     typename ReaderType::Pointer readerInputImage = ReaderType::New();
 
@@ -102,7 +101,7 @@ int DoIt( int argc, char * argv[] )
   timeCollector.Stop( "Run Filter" );
   progressReporter.Report( 0.8 );
 
-  typedef itk::ImageFileWriter< ImageType  >   ImageWriterType;
+  using ImageWriterType = itk::ImageFileWriter< ImageType  >;
   typename ImageWriterType::Pointer writer = ImageWriterType::New();
 
   writer->SetFileName( outputImageName.c_str() );

--- a/examples/Applications/EnhanceContrastUsingPrior/EnhanceContrastUsingPrior.cxx
+++ b/examples/Applications/EnhanceContrastUsingPrior/EnhanceContrastUsingPrior.cxx
@@ -52,13 +52,13 @@ int DoIt( int argc, char * argv[] )
     "ContrastImage", CLPProcessInformation );
   progressReporter.Start();
 
-  typedef float                                PixelType;
+  using PixelType = float;
 
-  typedef tube::EnhanceContrastUsingPrior
-    < PixelType, VDimension >                  FilterType;
+  using FilterType = tube::EnhanceContrastUsingPrior
+    < PixelType, VDimension >;
   typename FilterType::Pointer filter = FilterType::New();
 
-  typedef typename FilterType::ImageType       ImageType;
+  using ImageType = typename FilterType::ImageType;
 
   /** Read input images */
   typename ImageType::Pointer inputImage;
@@ -66,7 +66,7 @@ int DoIt( int argc, char * argv[] )
 
   timeCollector.Start( "Read" );
     {
-    typedef itk::ImageFileReader< ImageType >   ReaderType;
+    using ReaderType = itk::ImageFileReader< ImageType >;
 
     typename ReaderType::Pointer readerInputImage = ReaderType::New();
     typename ReaderType::Pointer readerInputMask = ReaderType::New();
@@ -118,7 +118,7 @@ int DoIt( int argc, char * argv[] )
   timeCollector.Stop( "Run Filter" );
   progressReporter.Report( 0.8 );
 
-  typedef itk::ImageFileWriter< ImageType  >   ImageWriterType;
+  using ImageWriterType = itk::ImageFileWriter< ImageType  >;
   typename ImageWriterType::Pointer writer = ImageWriterType::New();
 
   writer->SetFileName( outputImageName.c_str() );

--- a/examples/Applications/EnhanceEdgesUsingDiffusion/EnhanceEdgesUsingDiffusion.cxx
+++ b/examples/Applications/EnhanceEdgesUsingDiffusion/EnhanceEdgesUsingDiffusion.cxx
@@ -58,16 +58,16 @@ int DoIt( int argc, char * argv[] )
   // but use double for the filter to avoid rounding off errors in the
   // filter's floating point operations
   enum { Dimension = 3 };
-  typedef TPixel                                   ImagePixelType;
-  typedef itk::Image< ImagePixelType, Dimension >  InputImageType;
-  typedef itk::Image< ImagePixelType, Dimension >  OutputImageType;
-  typedef double                                   FilterPixelType;
-  typedef itk::Image< FilterPixelType, Dimension > FilterInputImageType;
-  typedef itk::Image< FilterPixelType, Dimension > FilterOutputImageType;
+  using ImagePixelType = TPixel;
+  using InputImageType = itk::Image< ImagePixelType, Dimension >;
+  using OutputImageType = itk::Image< ImagePixelType, Dimension >;
+  using FilterPixelType = double;
+  using FilterInputImageType = itk::Image< FilterPixelType, Dimension >;
+  using FilterOutputImageType = itk::Image< FilterPixelType, Dimension >;
 
   // Read the input volume
   timeCollector.Start( "Load data" );
-  typedef itk::ImageFileReader< InputImageType  >  ImageReaderType;
+  using ImageReaderType = itk::ImageFileReader< InputImageType  >;
   typename ImageReaderType::Pointer   reader = ImageReaderType::New();
   reader->SetFileName( inputVolume.c_str() );
   try
@@ -86,8 +86,7 @@ int DoIt( int argc, char * argv[] )
   progressReporter.Report( progress );
 
   // C-style cast from input image type to type 'double'
-  typedef itk::CastImageFilter< InputImageType, FilterInputImageType >
-    CastInputImageFilterType;
+  using CastInputImageFilterType = itk::CastImageFilter< InputImageType, FilterInputImageType >;
   typename CastInputImageFilterType::Pointer castInputImageFilter =
     CastInputImageFilterType::New();
   castInputImageFilter->SetInput( reader->GetOutput() );
@@ -95,8 +94,7 @@ int DoIt( int argc, char * argv[] )
 
   // Reorient to axial because the anisotropic diffusion tensor function does
   // not handle direction
-  typedef itk::OrientImageFilter< FilterInputImageType, FilterInputImageType >
-      OrientInputFilterType;
+  using OrientInputFilterType = itk::OrientImageFilter< FilterInputImageType, FilterInputImageType >;
   typename OrientInputFilterType::Pointer orientInputFilter
       = OrientInputFilterType::New();
   orientInputFilter->UseImageDirectionOn();
@@ -108,8 +106,8 @@ int DoIt( int argc, char * argv[] )
   timeCollector.Start( "Edge enhancing anisotropic diffusion" );
 
   // Declare the anisotropic diffusion edge enhancement filter
-  typedef tube::EnhanceEdgesUsingDiffusion<
-    FilterInputImageType, FilterOutputImageType>  EdgeEnhancementFilterType;
+  using EdgeEnhancementFilterType = tube::EnhanceEdgesUsingDiffusion<
+    FilterInputImageType, FilterOutputImageType>;
 
   // Create a edge enhancement Filter
   typename EdgeEnhancementFilterType::Pointer EdgeEnhancementFilter =
@@ -146,16 +144,14 @@ int DoIt( int argc, char * argv[] )
   progressReporter.Report( progress );
 
   // C-style cast from double to output image type
-  typedef itk::CastImageFilter< FilterOutputImageType, OutputImageType >
-    CastOutputImageFilterType;
+  using CastOutputImageFilterType = itk::CastImageFilter< FilterOutputImageType, OutputImageType >;
   typename CastOutputImageFilterType::Pointer castOutputImageFilter =
     CastOutputImageFilterType::New();
   castOutputImageFilter->SetInput( EdgeEnhancementFilter->GetOutput() );
   castOutputImageFilter->Update();
 
   // Reorient back from axial to whatever direction we had before
-  typedef itk::OrientImageFilter< OutputImageType, OutputImageType >
-      OrientOutputFilterType;
+  using OrientOutputFilterType = itk::OrientImageFilter< OutputImageType, OutputImageType >;
   typename OrientOutputFilterType::Pointer orientOutputFilter
       = OrientOutputFilterType::New();
   orientOutputFilter->UseImageDirectionOn();
@@ -166,7 +162,7 @@ int DoIt( int argc, char * argv[] )
 
   // Save output data
   timeCollector.Start( "Save data" );
-  typedef itk::ImageFileWriter< OutputImageType  >      ImageWriterType;
+  using ImageWriterType = itk::ImageFileWriter< OutputImageType  >;
   typename ImageWriterType::Pointer writer = ImageWriterType::New();
   writer->SetFileName( outputVolume.c_str() );
   writer->SetInput ( orientOutputFilter->GetOutput() );

--- a/examples/Applications/EnhanceTubesUsingDiffusion/EnhanceTubesUsingDiffusion.cxx
+++ b/examples/Applications/EnhanceTubesUsingDiffusion/EnhanceTubesUsingDiffusion.cxx
@@ -43,11 +43,11 @@ int DoIt( int argc, char * argv[] )
 {
   PARSE_ARGS;
 
-  typedef TPixel                                           PixelType;
-  typedef itk::Image< PixelType, VDimension  >             ImageType;
-  typedef itk::ImageFileReader< ImageType >                ReaderType;
-  typedef tube::EnhanceTubesUsingDiffusion< PixelType,
-    VDimension >                                           FilterType;
+  using PixelType = TPixel;
+  using ImageType = itk::Image< PixelType, VDimension  >;
+  using ReaderType = itk::ImageFileReader< ImageType >;
+  using FilterType = tube::EnhanceTubesUsingDiffusion< PixelType,
+    VDimension >;
 
   // read input image
   typename ReaderType::Pointer reader = ReaderType::New();
@@ -84,7 +84,7 @@ int DoIt( int argc, char * argv[] )
   filter->Update();
 
   // write output image
-  typedef itk::ImageFileWriter< ImageType  >   ImageWriterType;
+  using ImageWriterType = itk::ImageFileWriter< ImageType  >;
   typename ImageWriterType::Pointer writer = ImageWriterType::New();
 
   try

--- a/examples/Applications/EnhanceTubesUsingDiscriminantAnalysis/EnhanceTubesUsingDiscriminantAnalysis.cxx
+++ b/examples/Applications/EnhanceTubesUsingDiscriminantAnalysis/EnhanceTubesUsingDiscriminantAnalysis.cxx
@@ -37,7 +37,7 @@ template< class TImage >
 void WriteImageInSequence( const typename TImage::Pointer & img,
   const std::string & base, const std::string & ext, int num )
 {
-  typedef itk::ImageFileWriter< TImage >     ImageWriterType;
+  using ImageWriterType = itk::ImageFileWriter< TImage >;
 
   typename ImageWriterType::Pointer rsImageWriter = ImageWriterType::New();
   std::string fname = base;
@@ -54,7 +54,7 @@ template< class TImage >
 void WriteImage( const typename TImage::Pointer & img,
   const std::string & str )
 {
-  typedef itk::ImageFileWriter< TImage >     ImageWriterType;
+  using ImageWriterType = itk::ImageFileWriter< TImage >;
 
   typename ImageWriterType::Pointer rsImageWriter = ImageWriterType::New();
   rsImageWriter->SetUseCompression( true );
@@ -74,24 +74,22 @@ int DoIt( int argc, char * argv[] )
 
   itk::TimeProbesCollectorBase timeCollector;
 
-  typedef TPixel                                    InputPixelType;
-  typedef itk::Image< InputPixelType, TDimension >  InputImageType;
-  typedef itk::ImageFileReader< InputImageType >    InputImageReaderType;
+  using InputPixelType = TPixel;
+  using InputImageType = itk::Image< InputPixelType, TDimension >;
+  using InputImageReaderType = itk::ImageFileReader< InputImageType >;
 
-  typedef itk::Image< unsigned short, TDimension >  LabelmapType;
-  typedef itk::ImageFileReader< LabelmapType >      LabelmapReaderType;
+  using LabelmapType = itk::Image< unsigned short, TDimension >;
+  using LabelmapReaderType = itk::ImageFileReader< LabelmapType >;
 
-  typedef itk::tube::RidgeSeedFilterIO< InputImageType, LabelmapType >
-                                                    RidgeSeedFilterIOType;
+  using RidgeSeedFilterIOType = itk::tube::RidgeSeedFilterIO< InputImageType, LabelmapType >;
 
-  typedef itk::tube::RidgeSeedFilter< InputImageType, LabelmapType >
-                                                    RidgeSeedFilterType;
+  using RidgeSeedFilterType = itk::tube::RidgeSeedFilter< InputImageType, LabelmapType >;
 
   typedef typename RidgeSeedFilterType::ProbabilityImageType
                                                     OutputImageType;
-  typedef itk::ImageFileWriter< OutputImageType >   OutputImageWriterType;
+  using OutputImageWriterType = itk::ImageFileWriter< OutputImageType >;
 
-  typedef itk::Image< float, TDimension >           RidgeSeedImageType;
+  using RidgeSeedImageType = itk::Image< float, TDimension >;
 
   typename RidgeSeedFilterType::Pointer tubeFilter =
     RidgeSeedFilterType::New();

--- a/examples/Applications/EnhanceUsingDiscriminantAnalysis/EnhanceUsingDiscriminantAnalysis.cxx
+++ b/examples/Applications/EnhanceUsingDiscriminantAnalysis/EnhanceUsingDiscriminantAnalysis.cxx
@@ -54,21 +54,19 @@ int DoIt( int argc, char * argv[] )
   //   of this algorithm.
   itk::TimeProbesCollectorBase timeCollector;
 
-  typedef TPixel                                   InputPixelType;
-  typedef itk::Image< InputPixelType, VDimension > InputImageType;
-  typedef itk::Image< unsigned short, VDimension > MaskImageType;
-  typedef itk::Image< float, VDimension >          BasisImageType;
+  using InputPixelType = TPixel;
+  using InputImageType = itk::Image< InputPixelType, VDimension >;
+  using MaskImageType = itk::Image< unsigned short, VDimension >;
+  using BasisImageType = itk::Image< float, VDimension >;
 
-  typedef itk::ImageFileReader< InputImageType >   ImageReaderType;
-  typedef itk::ImageFileReader< MaskImageType >    MaskReaderType;
-  typedef itk::ImageFileWriter< BasisImageType >   BasisImageWriterType;
+  using ImageReaderType = itk::ImageFileReader< InputImageType >;
+  using MaskReaderType = itk::ImageFileReader< MaskImageType >;
+  using BasisImageWriterType = itk::ImageFileWriter< BasisImageType >;
 
-  typedef itk::tube::FeatureVectorGenerator< InputImageType >
-    FeatureVectorGeneratorType;
+  using FeatureVectorGeneratorType = itk::tube::FeatureVectorGenerator< InputImageType >;
 
-  typedef itk::tube::BasisFeatureVectorGenerator< InputImageType,
-    MaskImageType >
-      BasisFeatureVectorGeneratorType;
+  using BasisFeatureVectorGeneratorType = itk::tube::BasisFeatureVectorGenerator< InputImageType,
+    MaskImageType >;
 
   typename FeatureVectorGeneratorType::Pointer fvGenerator =
     FeatureVectorGeneratorType::New();

--- a/examples/Applications/EnhanceUsingNJetDiscriminantAnalysis/EnhanceUsingNJetDiscriminantAnalysis.cxx
+++ b/examples/Applications/EnhanceUsingNJetDiscriminantAnalysis/EnhanceUsingNJetDiscriminantAnalysis.cxx
@@ -47,7 +47,7 @@ template< class TImage >
 void WriteBasis( const typename TImage::Pointer & img,
   std::string base, std::string ext, int num )
 {
-  typedef itk::ImageFileWriter< TImage >     BasisImageWriterType;
+  using BasisImageWriterType = itk::ImageFileWriter< TImage >;
 
   typename BasisImageWriterType::Pointer basisImageWriter =
     BasisImageWriterType::New();
@@ -74,24 +74,21 @@ int DoIt( int argc, char * argv[] )
   //   of your algorithm.
   itk::TimeProbesCollectorBase timeCollector;
 
-  typedef TPixel                                   InputPixelType;
-  typedef itk::Image< InputPixelType, VDimension > InputImageType;
-  typedef itk::Image< unsigned short, VDimension > MaskImageType;
-  typedef itk::Image< float, VDimension >          BasisImageType;
+  using InputPixelType = TPixel;
+  using InputImageType = itk::Image< InputPixelType, VDimension >;
+  using MaskImageType = itk::Image< unsigned short, VDimension >;
+  using BasisImageType = itk::Image< float, VDimension >;
 
-  typedef itk::ImageFileReader< InputImageType >   ImageReaderType;
-  typedef itk::ImageFileReader< MaskImageType >    MaskReaderType;
-  typedef itk::ImageFileWriter< BasisImageType >   BasisImageWriterType;
+  using ImageReaderType = itk::ImageFileReader< InputImageType >;
+  using MaskReaderType = itk::ImageFileReader< MaskImageType >;
+  using BasisImageWriterType = itk::ImageFileWriter< BasisImageType >;
 
-  typedef itk::tube::NJetFeatureVectorGenerator< InputImageType >
-    NJetFeatureVectorGeneratorType;
+  using NJetFeatureVectorGeneratorType = itk::tube::NJetFeatureVectorGenerator< InputImageType >;
 
-  typedef itk::tube::FeatureVectorGenerator< InputImageType >
-    FeatureVectorGeneratorType;
+  using FeatureVectorGeneratorType = itk::tube::FeatureVectorGenerator< InputImageType >;
 
-  typedef itk::tube::BasisFeatureVectorGenerator< InputImageType,
-    MaskImageType >
-      BasisFeatureVectorGeneratorType;
+  using BasisFeatureVectorGeneratorType = itk::tube::BasisFeatureVectorGenerator< InputImageType,
+    MaskImageType >;
 
   typename NJetFeatureVectorGeneratorType::Pointer fvGenerator =
     NJetFeatureVectorGeneratorType::New();

--- a/examples/Applications/ImageMath/ImageMath.cxx
+++ b/examples/Applications/ImageMath/ImageMath.cxx
@@ -101,8 +101,8 @@ template< class TPixel=float, int VDimension=3 >
 itk::Image< TPixel, VDimension > *
 ReadImage( std::string filename )
 {
-  typedef itk::Image< TPixel, VDimension >      ImageType;
-  typedef itk::ImageFileReader< ImageType >     VolumeReaderType;
+  using ImageType = itk::Image< TPixel, VDimension >;
+  using VolumeReaderType = itk::ImageFileReader< ImageType >;
 
   typename VolumeReaderType::Pointer reader = VolumeReaderType::New();
 
@@ -127,11 +127,11 @@ ReadImage( std::string filename )
 template< class TPixel, unsigned int VDimension >
 int DoIt( MetaCommand & command )
 {
-  typedef float                                    PixelType;
-  typedef itk::Image< PixelType, VDimension >      ImageType;
-  typedef itk::Image< unsigned char, VDimension >  ImageTypeUChar;
-  typedef itk::Image< unsigned short, VDimension > ImageTypeUShort;
-  typedef itk::Image< short, VDimension >          ImageTypeShort;
+  using PixelType = float;
+  using ImageType = itk::Image< PixelType, VDimension >;
+  using ImageTypeUChar = itk::Image< unsigned char, VDimension >;
+  using ImageTypeUShort = itk::Image< unsigned short, VDimension >;
+  using ImageTypeShort = itk::Image< short, VDimension >;
 
   MetaCommand::OptionVector parsed = command.GetParsedOptions();
 
@@ -152,7 +152,7 @@ int DoIt( MetaCommand & command )
         command.GetValueAsString( *it, "filename" );
       std::cout << "Writing output1 ( " << outFilename.c_str()
                 << " )" << std::endl;
-      typedef itk::ImageFileWriter< ImageType > VolumeWriterType;
+      using VolumeWriterType = itk::ImageFileWriter< ImageType >;
       typename VolumeWriterType::Pointer writer = VolumeWriterType::New();
       writer->SetFileName( outFilename.c_str() );
       writer->SetInput( imFilters.GetOutput() );
@@ -180,14 +180,12 @@ int DoIt( MetaCommand & command )
         case 0:
         case 4:
           {
-          typedef itk::CastImageFilter< ImageType, ImageTypeUChar>
-            CastFilterType;
+          using CastFilterType = itk::CastImageFilter< ImageType, ImageTypeUChar>;
           typename CastFilterType::Pointer castFilter =
             CastFilterType::New();
           castFilter->SetInput( imFilters.GetOutput() );
 
-          typedef itk::ImageFileWriter< ImageTypeUChar >
-            VolumeWriterType;
+          using VolumeWriterType = itk::ImageFileWriter< ImageTypeUChar >;
           typename VolumeWriterType::Pointer writer =
             VolumeWriterType::New();
           writer->SetFileName( outFilename.c_str() );
@@ -202,14 +200,12 @@ int DoIt( MetaCommand & command )
         case 1:
         case 5:
           {
-          typedef itk::CastImageFilter< ImageType, ImageTypeUShort>
-            CastFilterType;
+          using CastFilterType = itk::CastImageFilter< ImageType, ImageTypeUShort>;
           typename CastFilterType::Pointer castFilter =
             CastFilterType::New();
           castFilter->SetInput( imFilters.GetOutput() );
 
-          typedef itk::ImageFileWriter< ImageTypeUShort >
-            VolumeWriterType;
+          using VolumeWriterType = itk::ImageFileWriter< ImageTypeUShort >;
           typename VolumeWriterType::Pointer writer =
             VolumeWriterType::New();
           writer->SetFileName( outFilename.c_str() );
@@ -224,14 +220,12 @@ int DoIt( MetaCommand & command )
         case 2:
         case 6:
           {
-          typedef itk::CastImageFilter< ImageType, ImageTypeShort>
-            CastFilterType;
+          using CastFilterType = itk::CastImageFilter< ImageType, ImageTypeShort>;
           typename CastFilterType::Pointer castFilter =
             CastFilterType::New();
           castFilter->SetInput( imFilters.GetOutput() );
 
-          typedef itk::ImageFileWriter< ImageTypeShort >
-            VolumeWriterType;
+          using VolumeWriterType = itk::ImageFileWriter< ImageTypeShort >;
           typename VolumeWriterType::Pointer writer =
             VolumeWriterType::New();
           writer->SetFileName( outFilename.c_str() );
@@ -245,14 +239,12 @@ int DoIt( MetaCommand & command )
           }
         case 3:
           {
-          typedef itk::CastImageFilter< ImageType, ImageTypeShort>
-            CastFilterType;
+          using CastFilterType = itk::CastImageFilter< ImageType, ImageTypeShort>;
           typename CastFilterType::Pointer castFilter =
             CastFilterType::New();
           castFilter->SetInput( imFilters.GetOutput() );
 
-          typedef itk::ImageFileWriter< ImageTypeShort >
-            VolumeWriterType;
+          using VolumeWriterType = itk::ImageFileWriter< ImageTypeShort >;
           typename VolumeWriterType::Pointer writer =
             VolumeWriterType::New();
 
@@ -278,7 +270,7 @@ int DoIt( MetaCommand & command )
           }
         case 7:
           {
-          typedef itk::ImageFileWriter< ImageType > VolumeWriterType;
+          using VolumeWriterType = itk::ImageFileWriter< ImageType >;
           typename VolumeWriterType::Pointer writer =
             VolumeWriterType::New();
           writer->SetFileName( outFilename.c_str() );
@@ -752,7 +744,7 @@ int main( int argc, char * argv[] )
     "Correction", "referenceVolume", MetaCommand::STRING, true );
 
   command.SetOption( "Normalize", "d", false,
-    "Normalize: 0 = mean/std; 1 = FWHM ; 2 = FWHM mean ( shift ) only" );
+    "Normalize: 0 = mean/std; 1 = FWHM; 2 = FWHM mean ( shift ) only" );
   command.AddOptionField( "Normalize", "type", MetaCommand::INT, true );
 
   command.SetOption( "Fuse", "f", false,

--- a/examples/Applications/MergeAdjacentImages/MergeAdjacentImages.cxx
+++ b/examples/Applications/MergeAdjacentImages/MergeAdjacentImages.cxx
@@ -61,10 +61,10 @@ int DoIt( int argc, char * argv[] )
   itk::TimeProbesCollectorBase timeCollector;
 
   // define types
-  typedef TPixel                                        PixelType;
-  typedef itk::Image< PixelType, VDimension >           ImageType;
-  typedef itk::ImageFileReader< ImageType >             ReaderType;
-  typedef itk::ImageFileWriter< ImageType  >            WriterType;
+  using PixelType = TPixel;
+  using ImageType = itk::Image< PixelType, VDimension >;
+  using ReaderType = itk::ImageFileReader< ImageType >;
+  using WriterType = itk::ImageFileWriter< ImageType  >;
 
   // Load input image 1
   timeCollector.Start( "Loading input image 1" );
@@ -113,8 +113,7 @@ int DoIt( int argc, char * argv[] )
   // Perform merging
   timeCollector.Start( "Merging images" );
 
-  typedef tube::MergeAdjacentImages< ImageType >
-    MergeAdjacentImagesFilterType;
+  using MergeAdjacentImagesFilterType = tube::MergeAdjacentImages< ImageType >;
 
   typename MergeAdjacentImagesFilterType::Pointer filter =
     MergeAdjacentImagesFilterType::New();

--- a/examples/Applications/MergeTubeGraphs/MergeTubeGraphs.cxx
+++ b/examples/Applications/MergeTubeGraphs/MergeTubeGraphs.cxx
@@ -46,8 +46,8 @@ int DoIt( int argc, char * argv[] )
   // Generic stream for log messages
   std::stringstream logMsg;
 
-  typedef MetaObjectDocument                          DocumentReaderType;
-  typedef DocumentReaderType::ObjectDocumentListType  DocumentListType;
+  using DocumentReaderType = MetaObjectDocument;
+  using DocumentListType = DocumentReaderType::ObjectDocumentListType;
 
   int numberOfCentroids = nCentroids;
   assert( numberOfCentroids > 0 );

--- a/examples/Applications/RegisterImages/RegisterImages.cxx
+++ b/examples/Applications/RegisterImages/RegisterImages.cxx
@@ -48,10 +48,9 @@ int DoIt( int argc, char * argv[] )
     verbosity = VERBOSE;
     }
 
-  typedef typename itk::Image< TPixelType, TDimension > ImageType;
+  using ImageType = typename itk::Image< TPixelType, TDimension >;
 
-  typedef typename itk::ImageToImageRegistrationHelper< ImageType >
-    RegistrationType;
+  using RegistrationType = typename itk::ImageToImageRegistrationHelper< ImageType >;
 
   typename RegistrationType::Pointer reger = RegistrationType::New();
 
@@ -296,10 +295,9 @@ int DoIt( int argc, char * argv[] )
     std::cout << "###sampleFromOverlap: " << sampleFromOverlap << std::endl;
     }
 
-  typedef typename itk::ImageFileReader<
-    itk::Image< unsigned char, TDimension > > ImageReader;
-  typedef typename itk::ImageMaskSpatialObject< TDimension >
-    ImageMaskSpatialObject;
+  using ImageReader = typename itk::ImageFileReader<
+    itk::Image< unsigned char, TDimension > >;
+  using ImageMaskSpatialObject = typename itk::ImageMaskSpatialObject< TDimension >;
 
   if( fixedImageMask != "" )
     {

--- a/examples/Applications/RegisterSpatialObjectsToImage/RegisterSpatialObjectsToImage.cxx
+++ b/examples/Applications/RegisterSpatialObjectsToImage/RegisterSpatialObjectsToImage.cxx
@@ -55,17 +55,17 @@ int DoIt( int argc, char * argv[] )
     verbosity = VERBOSE;
     }
 
-  typedef typename itk::Image< TPixelType, TDimension > ImageType;
+  using ImageType = typename itk::Image< TPixelType, TDimension >;
 
-  typedef itk::ImageFileReader< ImageType  > ImageReaderType;
-  typedef itk::SpatialObjectReader< TDimension, float > SpatialObjectReaderType;
+  using ImageReaderType = itk::ImageFileReader< ImageType  >;
+  using SpatialObjectReaderType = itk::SpatialObjectReader< TDimension, float >;
 
-  typedef typename itk::tube::SpatialObjectToImageRegistrationHelper<
-    TDimension, ImageType > RegistrationType;
+  using RegistrationType = typename itk::tube::SpatialObjectToImageRegistrationHelper<
+    TDimension, ImageType >;
 
   typename RegistrationType::Pointer reger = RegistrationType::New();
 
-  typedef typename RegistrationType::SpatialObjectType SpatialObjectType;
+  using SpatialObjectType = typename RegistrationType::SpatialObjectType;
 
   reger->SetReportProgress( true );
 
@@ -236,10 +236,9 @@ int DoIt( int argc, char * argv[] )
                                       ::IMAGE_INTENSITY_METRIC );
     }
 
-  typedef typename itk::ImageFileReader<
-    itk::Image< unsigned char, TDimension > > ImageReader;
-  typedef typename itk::ImageMaskSpatialObject< TDimension >
-    ImageMaskSpatialObject;
+  using ImageReader = typename itk::ImageFileReader<
+    itk::Image< unsigned char, TDimension > >;
+  using ImageMaskSpatialObject = typename itk::ImageMaskSpatialObject< TDimension >;
 
   if( fixedImageMask != "" )
     {
@@ -425,7 +424,7 @@ int DoIt( int argc, char * argv[] )
 
     try
       {
-      typedef itk::SpatialObjectWriter< TDimension > SOWriterType;
+      using SOWriterType = itk::SpatialObjectWriter< TDimension >;
       typename SOWriterType::Pointer soWriter =
         SOWriterType::New();
       soWriter->SetFileName( resampledSpatialObject );

--- a/examples/Applications/ResampleImage/ResampleImage.cxx
+++ b/examples/Applications/ResampleImage/ResampleImage.cxx
@@ -44,15 +44,15 @@ int DoIt( int argc, char * argv[] )
 {
   PARSE_ARGS;
 
-  typedef itk::Image< TPixel, DimensionI >            ImageType;
+  using ImageType = itk::Image< TPixel, DimensionI >;
 
-  typedef typename tube::ResampleImage< ImageType >   FilterType;
+  using FilterType = typename tube::ResampleImage< ImageType >;
   typename FilterType::Pointer filter = FilterType::New();
 
-  typedef typename FilterType::TransformType     TransformType;
+  using TransformType = typename FilterType::TransformType;
 
-  typedef  itk::ImageFileReader< ImageType >     InputReaderType;
-  typedef  itk::ImageFileWriter< ImageType >     OutputWriterType;
+  using InputReaderType = itk::ImageFileReader< ImageType >;
+  using OutputWriterType = itk::ImageFileWriter< ImageType >;
 
   itk::TimeProbesCollectorBase timeCollector;
 

--- a/examples/Applications/ResampleTubes/ResampleTubes.cxx
+++ b/examples/Applications/ResampleTubes/ResampleTubes.cxx
@@ -41,7 +41,7 @@ template< unsigned int Dimension >
 void WriteOutput( const itk::SpatialObject<Dimension> * soOutputP,
  const char * fileName )
 {
-  typedef itk::SpatialObjectWriter< Dimension > SpatialObjectWriterType;
+  using SpatialObjectWriterType = itk::SpatialObjectWriter< Dimension >;
 
   typename itk::SpatialObject<Dimension>::ConstPointer soOutput = soOutputP;
 
@@ -57,8 +57,8 @@ int DoIt( int argc, char * argv[] )
 {
   PARSE_ARGS;
 
-  typedef itk::tube::ResampleTubesFilter<Dimension> FilterType;
-  typedef itk::GroupSpatialObject<Dimension> GroupType;
+  using FilterType = itk::tube::ResampleTubesFilter<Dimension>;
+  using GroupType = itk::GroupSpatialObject<Dimension>;
 
   typename FilterType::Pointer filter = FilterType::New();
 
@@ -74,7 +74,7 @@ int DoIt( int argc, char * argv[] )
   timeCollector.Start( "Read tubes" );
   typename GroupType::Pointer inputGroup = GroupType::New();
 
-  typedef itk::SpatialObjectReader< Dimension > SpatialObjectReaderType;
+  using SpatialObjectReaderType = itk::SpatialObjectReader< Dimension >;
   typename SpatialObjectReaderType::Pointer reader =
     SpatialObjectReaderType::New();
   reader->SetFileName( inputTubeFile.c_str() );
@@ -102,8 +102,8 @@ int DoIt( int argc, char * argv[] )
 
   if( !matchImage.empty() )
     {
-    typedef itk::Image< char, Dimension >         MatchImageType;
-    typedef itk::ImageFileReader< MatchImageType> MatchImageReaderType;
+    using MatchImageType = itk::Image< char, Dimension >;
+    using MatchImageReaderType = itk::ImageFileReader< MatchImageType>;
 
     typename MatchImageReaderType::Pointer matchReader =
       MatchImageReaderType::New();
@@ -114,9 +114,8 @@ int DoIt( int argc, char * argv[] )
 
   if( !loadDisplacementField.empty() )
     {
-    typedef typename FilterType::DisplacementFieldType DisplacementFieldType;
-    typedef typename itk::ImageFileReader< DisplacementFieldType >
-      DisplacementFieldReaderType;
+    using DisplacementFieldType = typename FilterType::DisplacementFieldType;
+    using DisplacementFieldReaderType = typename itk::ImageFileReader< DisplacementFieldType >;
 
     // Read the displacement field
     typename DisplacementFieldReaderType::Pointer dfReader =

--- a/examples/Applications/SampleCLIApplication/SampleCLIApplication.cxx
+++ b/examples/Applications/SampleCLIApplication/SampleCLIApplication.cxx
@@ -56,16 +56,16 @@ int DoIt( int argc, char * argv[] )
     CLPProcessInformation );
   progressReporter.Start();
 
-  typedef TPixel                                    InputPixelType;
-  typedef itk::Image< InputPixelType, VDimension >  InputImageType;
-  typedef itk::ImageFileReader< InputImageType >    ReaderType;
+  using InputPixelType = TPixel;
+  using InputImageType = itk::Image< InputPixelType, VDimension >;
+  using ReaderType = itk::ImageFileReader< InputImageType >;
 
-  typedef float                                     OutputPixelType;
-  typedef itk::Image< OutputPixelType, VDimension > OutputImageType;
-  typedef itk::ImageFileWriter< OutputImageType  >  WriterType;
+  using OutputPixelType = float;
+  using OutputImageType = itk::Image< OutputPixelType, VDimension >;
+  using WriterType = itk::ImageFileWriter< OutputImageType  >;
 
-  typedef itk::DiscreteGaussianImageFilter< InputImageType,
-    OutputImageType > FilterType;
+  using FilterType = itk::DiscreteGaussianImageFilter< InputImageType,
+    OutputImageType >;
 
   timeCollector.Start( "Load data" );
   typename ReaderType::Pointer reader = ReaderType::New();

--- a/examples/Applications/SegmentBinaryImageSkeleton3D/SegmentBinaryImageSkeleton3D.cxx
+++ b/examples/Applications/SegmentBinaryImageSkeleton3D/SegmentBinaryImageSkeleton3D.cxx
@@ -56,9 +56,9 @@ int DoIt( int argc, char * argv[] )
                                                  CLPProcessInformation );
   progressReporter.Start();
 
-  typedef unsigned char                         PixelType;
-  typedef itk::Image< PixelType, 3 >   ImageType;
-  typedef itk::ImageFileReader< ImageType >     ReaderType;
+  using PixelType = unsigned char;
+  using ImageType = itk::Image< PixelType, 3 >;
+  using ReaderType = itk::ImageFileReader< ImageType >;
 
   timeCollector.Start( "Load data" );
   typename ReaderType::Pointer reader = ReaderType::New();
@@ -83,8 +83,7 @@ int DoIt( int argc, char * argv[] )
   // Progress per iteration
   double progressFraction = 0.8/3;
 
-  typedef itk::tube::BinaryThinningImageFilter3D<ImageType,ImageType>
-    FilterType;
+  using FilterType = itk::tube::BinaryThinningImageFilter3D<ImageType,ImageType>;
   typename FilterType::Pointer filter = FilterType::New();
   filter->SetInput( reader->GetOutput() );
   tube::CLIFilterWatcher watcher( filter,
@@ -97,7 +96,7 @@ int DoIt( int argc, char * argv[] )
   timeCollector.Stop( "Binary Thinning" );
 
 
-  typedef itk::ImageFileWriter< ImageType  >   ImageWriterType;
+  using ImageWriterType = itk::ImageFileWriter< ImageType  >;
 
   timeCollector.Start( "Save data" );
   typename ImageWriterType::Pointer writer = ImageWriterType::New();

--- a/examples/Applications/SegmentConnectedComponents/SegmentConnectedComponents.cxx
+++ b/examples/Applications/SegmentConnectedComponents/SegmentConnectedComponents.cxx
@@ -53,8 +53,8 @@ int DoIt( int argc, char * argv[] )
                                                  CLPProcessInformation );
   progressReporter.Start();
 
-  typedef itk::Image< TPixel, VDimension >         MaskType;
-  typedef itk::ImageFileReader< MaskType >         MaskReaderType;
+  using MaskType = itk::Image< TPixel, VDimension >;
+  using MaskReaderType = itk::ImageFileReader< MaskType >;
 
   //
   //
@@ -84,8 +84,7 @@ int DoIt( int argc, char * argv[] )
   //
   timeCollector.Start( "Connected Components" );
 
-  typedef tube::SegmentConnectedComponents< MaskType, MaskType >
-    FilterType;
+  using FilterType = tube::SegmentConnectedComponents< MaskType, MaskType >;
   typename FilterType::Pointer filter;
 
   filter = FilterType::New();
@@ -116,7 +115,7 @@ int DoIt( int argc, char * argv[] )
 
   filter->Update();
 
-  typedef itk::ImageFileWriter< MaskType  >   ImageWriterType;
+  using ImageWriterType = itk::ImageFileWriter< MaskType  >;
 
   timeCollector.Start( "Save data" );
   typename ImageWriterType::Pointer writer = ImageWriterType::New();

--- a/examples/Applications/SegmentConnectedComponentsUsingParzenPDFs/SegmentConnectedComponentsUsingParzenPDFs.cxx
+++ b/examples/Applications/SegmentConnectedComponentsUsingParzenPDFs/SegmentConnectedComponentsUsingParzenPDFs.cxx
@@ -32,8 +32,8 @@ void GetImageInformation( const std::string & fileName,
                           itk::ImageIOBase::IOComponentEnum & componentType,
                           unsigned int & dimension )
 {
-  typedef itk::ImageIOBase     ImageIOType;
-  typedef itk::ImageIOFactory  ImageIOFactoryType;
+  using ImageIOType = itk::ImageIOBase;
+  using ImageIOFactoryType = itk::ImageIOFactory;
 
   ImageIOType::Pointer imageIO =
     ImageIOFactoryType::CreateImageIO( fileName.c_str(),
@@ -82,24 +82,23 @@ int DoIt( int argc, char * argv[] )
 
   itk::TimeProbesCollectorBase timeCollector;
 
-  typedef T                                            InputImagePixelType;
-  typedef itk::Image< InputImagePixelType, dimension > InputImageType;
-  typedef itk::Image< float, dimension >               ProbImageType;
-  typedef unsigned short                               LabelMapPixelType;
-  typedef itk::Image< LabelMapPixelType, dimension >   LabelMapType;
+  using InputImagePixelType = T;
+  using InputImageType = itk::Image< InputImagePixelType, dimension >;
+  using ProbImageType = itk::Image< float, dimension >;
+  using LabelMapPixelType = unsigned short;
+  using LabelMapType = itk::Image< LabelMapPixelType, dimension >;
 
-  typedef tube::SegmentConnectedComponentsUsingParzenPDFs< InputImageType,
-    LabelMapType >                                     PDFSegmenterType;
+  using PDFSegmenterType = tube::SegmentConnectedComponentsUsingParzenPDFs< InputImageType,
+    LabelMapType >;
 
-  typedef itk::Image< float, PARZEN_MAX_NUMBER_OF_FEATURES >
-                                                   PDFImageType;
+  using PDFImageType = itk::Image< float, PARZEN_MAX_NUMBER_OF_FEATURES >;
 
-  typedef itk::ImageFileReader< InputImageType >   ImageReaderType;
-  typedef itk::ImageFileReader< LabelMapType >     LabelMapReaderType;
-  typedef itk::ImageFileWriter< LabelMapType >     LabelMapWriterType;
-  typedef itk::ImageFileWriter< ProbImageType >    ProbImageWriterType;
-  typedef itk::ImageFileWriter< PDFImageType >     PDFImageWriterType;
-  typedef itk::ImageFileReader< PDFImageType >     PDFImageReaderType;
+  using ImageReaderType = itk::ImageFileReader< InputImageType >;
+  using LabelMapReaderType = itk::ImageFileReader< LabelMapType >;
+  using LabelMapWriterType = itk::ImageFileWriter< LabelMapType >;
+  using ProbImageWriterType = itk::ImageFileWriter< ProbImageType >;
+  using PDFImageWriterType = itk::ImageFileWriter< PDFImageType >;
+  using PDFImageReaderType = itk::ImageFileReader< PDFImageType >;
 
   typename PDFSegmenterType::Pointer pdfSegmenter =
     PDFSegmenterType::New();

--- a/examples/Applications/SegmentTubeUsingMinimalPath/SegmentTubeUsingMinimalPath.cxx
+++ b/examples/Applications/SegmentTubeUsingMinimalPath/SegmentTubeUsingMinimalPath.cxx
@@ -56,16 +56,15 @@ int DoIt( int argc, char * argv[] )
     CLPProcessInformation );
   progressReporter.Start();
 
-  typedef TPixel                                           PixelType;
-  typedef itk::Image< PixelType, DimensionT >              ImageType;
-  typedef itk::ImageFileReader< ImageType >                ReaderType;
-  typedef itk::SpatialObjectReader< DimensionT >           TubesReaderType;
-  typedef itk::Point< double, DimensionT >                 PointType;
+  using PixelType = TPixel;
+  using ImageType = itk::Image< PixelType, DimensionT >;
+  using ReaderType = itk::ImageFileReader< ImageType >;
+  using TubesReaderType = itk::SpatialObjectReader< DimensionT >;
+  using PointType = itk::Point< double, DimensionT >;
 
   timeCollector.Start( "Load data" );
 
-  typedef tube::SegmentTubeUsingMinimalPath< DimensionT, PixelType >
-                                                         FilterType;
+  using FilterType = tube::SegmentTubeUsingMinimalPath< DimensionT, PixelType >;
   typename FilterType::Pointer filter = FilterType::New();
 
   //Read input Image
@@ -219,7 +218,7 @@ int DoIt( int argc, char * argv[] )
   timeCollector.Start( "Write output data" );
 
   // Write output TRE file
-  typedef itk::SpatialObjectWriter< DimensionT > TubeWriterType;
+  using TubeWriterType = itk::SpatialObjectWriter< DimensionT >;
   typename TubeWriterType::Pointer tubeWriter = TubeWriterType::New();
   try
     {

--- a/examples/Applications/SegmentTubes/SegmentTubes.cxx
+++ b/examples/Applications/SegmentTubes/SegmentTubes.cxx
@@ -60,29 +60,29 @@ int DoIt( int argc, char * argv[] )
     CLPProcessInformation );
   progressReporter.Start();
 
-  typedef TPixel                                     PixelType;
-  typedef itk::Image< PixelType, VDimension >        ImageType;
-  typedef itk::ImageFileReader< ImageType >          ReaderType;
+  using PixelType = TPixel;
+  using ImageType = itk::Image< PixelType, VDimension >;
+  using ReaderType = itk::ImageFileReader< ImageType >;
 
-  typedef tube::SegmentTubes< ImageType >            SegmentTubesFilterType;
+  using SegmentTubesFilterType = tube::SegmentTubes< ImageType >;
 
   typedef typename SegmentTubesFilterType::TubeMaskImageType
     MaskImageType;
 
-  typedef itk::ImageFileReader< MaskImageType >      MaskReaderType;
-  typedef itk::ImageFileWriter< MaskImageType >      MaskWriterType;
+  using MaskReaderType = itk::ImageFileReader< MaskImageType >;
+  using MaskWriterType = itk::ImageFileWriter< MaskImageType >;
 
-  typedef typename ImageType::PointType              PointType;
+  using PointType = typename ImageType::PointType;
 
   typedef typename SegmentTubesFilterType::ContinuousIndexType
     IndexType;
 
-  typedef std::vector< IndexType >                   IndexListType;
-  typedef std::vector< double >                      RadiusListType;
-  typedef std::vector< PointType >                   PointListType;
+  using IndexListType = std::vector< IndexType >;
+  using RadiusListType = std::vector< double >;
+  using PointListType = std::vector< PointType >;
 
-  typedef itk::SpatialObjectWriter< VDimension >     TubesWriterType;
-  typedef itk::SpatialObjectReader< VDimension >     TubesReaderType;
+  using TubesWriterType = itk::SpatialObjectWriter< VDimension >;
+  using TubesReaderType = itk::SpatialObjectReader< VDimension >;
 
   timeCollector.Start( "Load data" );
   typename ReaderType::Pointer reader = ReaderType::New();

--- a/examples/Applications/SegmentUsingOtsuThreshold/SegmentUsingOtsuThreshold.cxx
+++ b/examples/Applications/SegmentUsingOtsuThreshold/SegmentUsingOtsuThreshold.cxx
@@ -57,16 +57,16 @@ int DoIt( int argc, char * argv[] )
   // The timeCollector to perform basic profiling of algorithmic components
   itk::TimeProbesCollectorBase timeCollector;
 
-  // typedefs
-  typedef itk::Image< TPixel, VDimension > ImageType;
+  // type alias
+  using ImageType = itk::Image< TPixel, VDimension >;
 
-  typedef tube::SegmentUsingOtsuThreshold< ImageType > FilterType;
+  using FilterType = tube::SegmentUsingOtsuThreshold< ImageType >;
 
   // Load input image
   timeCollector.Start( "Load data" );
 
-  typedef typename FilterType::InputImageType     InputImageType;
-  typedef itk::ImageFileReader< InputImageType >  ImageReaderType;
+  using InputImageType = typename FilterType::InputImageType;
+  using ImageReaderType = itk::ImageFileReader< InputImageType >;
 
   typename ImageReaderType::Pointer inputReader = ImageReaderType::New();
 
@@ -84,8 +84,8 @@ int DoIt( int argc, char * argv[] )
     }
 
   // Load mask image if provided
-  typedef typename FilterType::MaskImageType     MaskImageType;
-  typedef itk::ImageFileReader< MaskImageType >  MaskReaderType;
+  using MaskImageType = typename FilterType::MaskImageType;
+  using MaskReaderType = itk::ImageFileReader< MaskImageType >;
 
   typename MaskReaderType::Pointer maskReader = MaskReaderType::New();
 
@@ -131,8 +131,8 @@ int DoIt( int argc, char * argv[] )
   progressReporter.Report( progress );
 
   // write output
-  typedef typename FilterType::OutputImageType      OutputImageType;
-  typedef itk::ImageFileWriter< OutputImageType >   OutputWriterType;
+  using OutputImageType = typename FilterType::OutputImageType;
+  using OutputWriterType = itk::ImageFileWriter< OutputImageType >;
 
   timeCollector.Start( "Write segmentation mask" );
 

--- a/examples/Applications/SegmentUsingQuantileThreshold/SegmentUsingQuantileThreshold.cxx
+++ b/examples/Applications/SegmentUsingQuantileThreshold/SegmentUsingQuantileThreshold.cxx
@@ -51,9 +51,9 @@ int DoIt( int argc, char * argv[] )
     "SegmentUsingQuantileThreshold", CLPProcessInformation );
   progressReporter.Start();
 
-  typedef TPixel                                PixelType;
-  typedef itk::Image< PixelType, VDimension >   ImageType;
-  typedef itk::ImageFileReader< ImageType >     ReaderType;
+  using PixelType = TPixel;
+  using ImageType = itk::Image< PixelType, VDimension >;
+  using ReaderType = itk::ImageFileReader< ImageType >;
 
   timeCollector.Start( "Load data" );
   typename ReaderType::Pointer reader = ReaderType::New();
@@ -103,12 +103,10 @@ int DoIt( int argc, char * argv[] )
     {
     timeCollector.Start( "Boost accumulate" );
 
-    typedef boost::accumulators::accumulator_set< PixelType,
+    using QuantileAccumulatorType = boost::accumulators::accumulator_set< PixelType,
       boost::accumulators::stats<
-        boost::accumulators::tag::p_square_quantile > >
-      QuantileAccumulatorType;
-    typedef itk::ImageRegionConstIterator< ImageType >
-      ImageIteratorType;
+        boost::accumulators::tag::p_square_quantile > >;
+    using ImageIteratorType = itk::ImageRegionConstIterator< ImageType >;
 
     /*
      * Create a and configure a vector of length N of pointers
@@ -153,8 +151,7 @@ int DoIt( int argc, char * argv[] )
 
     PixelType qVal = boost::accumulators::p_square_quantile( acc );
 
-    typedef itk::BinaryThresholdImageFilter< ImageType, ImageType >
-      FilterType;
+    using FilterType = itk::BinaryThresholdImageFilter< ImageType, ImageType >;
     typename FilterType::Pointer filter = FilterType::New();
 
     filter->SetInput( image );
@@ -169,7 +166,7 @@ int DoIt( int argc, char * argv[] )
     timeCollector.Stop( "Boost accumulate" );
     }
 
-  typedef itk::ImageFileWriter< ImageType  >   ImageWriterType;
+  using ImageWriterType = itk::ImageFileWriter< ImageType  >;
 
   timeCollector.Start( "Save data" );
   typename ImageWriterType::Pointer writer = ImageWriterType::New();

--- a/examples/Applications/ShrinkImageWithBlending/ShrinkImageWithBlending.cxx
+++ b/examples/Applications/ShrinkImageWithBlending/ShrinkImageWithBlending.cxx
@@ -57,20 +57,20 @@ int DoIt( int argc, char * argv[] )
     CLPProcessInformation );
   progressReporter.Start();
 
-  typedef float                                 PixelType;
-  typedef itk::Image< PixelType, VDimension >   InputImageType;
-  typedef itk::Image< PixelType, VDimension >   OutputImageType;
+  using PixelType = float;
+  using InputImageType = itk::Image< PixelType, VDimension >;
+  using OutputImageType = itk::Image< PixelType, VDimension >;
 
-  typedef itk::ImageFileReader< InputImageType >   ImageReaderType;
-  typedef itk::ImageFileWriter< OutputImageType  > ImageWriterType;
+  using ImageReaderType = itk::ImageFileReader< InputImageType >;
+  using ImageWriterType = itk::ImageFileWriter< OutputImageType  >;
 
-  typedef itk::Vector< float, VDimension >         PointPixelType;
-  typedef itk::Image< PointPixelType, VDimension > PointImageType;
-  typedef itk::ImageFileWriter< PointImageType >   PointImageWriterType;
-  typedef itk::ImageFileReader< PointImageType >   PointImageReaderType;
+  using PointPixelType = itk::Vector< float, VDimension >;
+  using PointImageType = itk::Image< PointPixelType, VDimension >;
+  using PointImageWriterType = itk::ImageFileWriter< PointImageType >;
+  using PointImageReaderType = itk::ImageFileReader< PointImageType >;
 
-  typedef tube::ShrinkImageWithBlending< InputImageType,
-    OutputImageType > FilterType;
+  using FilterType = tube::ShrinkImageWithBlending< InputImageType,
+    OutputImageType >;
 
   timeCollector.Start( "Load data" );
   typename ImageReaderType::Pointer reader = ImageReaderType::New();

--- a/examples/Applications/SimulateAcquisitionArtifactsUsingPrior/SimulateAcquisitionArtifactsUsingPrior.cxx
+++ b/examples/Applications/SimulateAcquisitionArtifactsUsingPrior/SimulateAcquisitionArtifactsUsingPrior.cxx
@@ -44,7 +44,7 @@ class MyMIWPFunc : public tube::UserFunction< vnl_vector< int >, double >
 {
 public:
 
-  typedef tube::CompareImageWithPrior< TPixel, VDimension > ImageEvalType;
+  using ImageEvalType = tube::CompareImageWithPrior< TPixel, VDimension >;
   MyMIWPFunc( ImageEvalType & eval ) : m_Eval( eval ), m_GoF( 0 )
     {
     }
@@ -80,8 +80,8 @@ int DoIt( int argc, char * argv[] )
                                                  CLPProcessInformation );
   progressReporter.Start();
 
-  typedef float                                PixelType;
-  typedef itk::Image< PixelType, VDimension >  ImageType;
+  using PixelType = float;
+  using ImageType = itk::Image< PixelType, VDimension >;
 
   /** Read input images */
   typename ImageType::Pointer inVolume;
@@ -89,7 +89,7 @@ int DoIt( int argc, char * argv[] )
 
   timeCollector.Start( "Read" );
     {
-    typedef itk::ImageFileReader< ImageType >   ReaderType;
+    using ReaderType = itk::ImageFileReader< ImageType >;
 
     typename ReaderType::Pointer readerVolume = ReaderType::New();
     typename ReaderType::Pointer readerMask = ReaderType::New();
@@ -131,7 +131,7 @@ int DoIt( int argc, char * argv[] )
   typename ImageType::Pointer metricMaskImage = nullptr;
   if( metricMask.size() != 0 )
     {
-    typedef itk::ImageFileReader< ImageType >   ReaderType;
+    using ReaderType = itk::ImageFileReader< ImageType >;
     typename ReaderType::Pointer readerMetricMask = ReaderType::New();
     readerMetricMask->SetFileName( metricMask.c_str() );
     readerMetricMask->Update();
@@ -139,7 +139,7 @@ int DoIt( int argc, char * argv[] )
     }
   progressReporter.Report( 0.2 );
 
-  typedef tube::CompareImageWithPrior< TPixel, VDimension > ImageEvalType;
+  using ImageEvalType = tube::CompareImageWithPrior< TPixel, VDimension >;
   ImageEvalType eval;
   eval.SetInput( inVolume );
   eval.SetMaskImage( inMask );
@@ -280,7 +280,7 @@ int DoIt( int argc, char * argv[] )
 
   progressReporter.Report( 0.9 );
 
-  typedef itk::ImageFileWriter< ImageType  >   ImageWriterType;
+  using ImageWriterType = itk::ImageFileWriter< ImageType  >;
   typename ImageWriterType::Pointer writerVolume = ImageWriterType::New();
   typename ImageWriterType::Pointer writerMask = ImageWriterType::New();
 

--- a/examples/Applications/SimulateAcquisitionArtifactsUsingPrior/tubeCompareImageWithPrior.h
+++ b/examples/Applications/SimulateAcquisitionArtifactsUsingPrior/tubeCompareImageWithPrior.h
@@ -38,11 +38,10 @@ class CompareImageWithPrior
 {
 public:
 
-  typedef float                                 PixelType;
-  typedef itk::Image< PixelType, VDimension >   ImageType;
+  using PixelType = float;
+  using ImageType = itk::Image< PixelType, VDimension >;
 
-  typedef itk::RigidImageToImageRegistrationMethod< ImageType >
-                                                    RegistrationMethodType;
+  using RegistrationMethodType = itk::RigidImageToImageRegistrationMethod< ImageType >;
 
   CompareImageWithPrior( void );
   ~CompareImageWithPrior( void );

--- a/examples/Applications/SimulateAcquisitionArtifactsUsingPrior/tubeCompareImageWithPrior.hxx
+++ b/examples/Applications/SimulateAcquisitionArtifactsUsingPrior/tubeCompareImageWithPrior.hxx
@@ -336,14 +336,12 @@ CompareImageWithPrior< TPixel, TDimension>
       m_ProgressReporter->Report( m_ProgressStart );
       }
 
-    typedef itk::BinaryBallStructuringElement< PixelType, TDimension >
-      BallType;
+    using BallType = itk::BinaryBallStructuringElement< PixelType, TDimension >;
     BallType ball;
     ball.SetRadius( 1 );
     ball.CreateStructuringElement();
 
-    typedef itk::BinaryErodeImageFilter< ImageType, ImageType, BallType >
-      ErodeFilterType;
+    using ErodeFilterType = itk::BinaryErodeImageFilter< ImageType, ImageType, BallType >;
 
     for( int r=0; r<m_Erode; r++ )
       {
@@ -381,14 +379,12 @@ CompareImageWithPrior< TPixel, TDimension>
       m_ProgressReporter->Report( m_ProgressStart );
       }
 
-    typedef itk::BinaryBallStructuringElement< PixelType, TDimension >
-      BallType;
+    using BallType = itk::BinaryBallStructuringElement< PixelType, TDimension >;
     BallType ball;
     ball.SetRadius( 1 );
     ball.CreateStructuringElement();
 
-    typedef itk::BinaryDilateImageFilter< ImageType, ImageType, BallType >
-      DilateFilterType;
+    using DilateFilterType = itk::BinaryDilateImageFilter< ImageType, ImageType, BallType >;
 
     for( int r=0; r<m_Dilate; r++ )
       {
@@ -421,8 +417,7 @@ CompareImageWithPrior< TPixel, TDimension>
       m_TimeCollector->Start( "Blur" );
       }
 
-    typedef itk::RecursiveGaussianImageFilter< ImageType, ImageType >
-      FilterType;
+    using FilterType = itk::RecursiveGaussianImageFilter< ImageType, ImageType >;
     typename FilterType::Pointer filter = FilterType::New();
 
     for( unsigned int i=0; i<TDimension; i++ )
@@ -458,8 +453,7 @@ CompareImageWithPrior< TPixel, TDimension>
 
     if( m_UseRegistrationOptimization )
       {
-      typedef itk::NormalizeImageFilter< ImageType, ImageType >
-        NormFilterType;
+      using NormFilterType = itk::NormalizeImageFilter< ImageType, ImageType >;
 
       typename NormFilterType::Pointer norm1 = NormFilterType::New();
       norm1->SetInput( m_OutputVolImage );
@@ -543,12 +537,10 @@ CompareImageWithPrior< TPixel, TDimension>
         }
       }
 
-    typedef itk::ResampleImageFilter< ImageType, ImageType, double >
-      ResamplerType;
+    using ResamplerType = itk::ResampleImageFilter< ImageType, ImageType, double >;
     typename ResamplerType::Pointer resampler = ResamplerType::New();
 
-    typedef itk::LinearInterpolateImageFunction< ImageType, double >
-      InterpolatorType;
+    using InterpolatorType = itk::LinearInterpolateImageFunction< ImageType, double >;
     typename InterpolatorType::Pointer interpolator =
       InterpolatorType::New();
     interpolator->SetInputImage( m_OutputMaskImage );
@@ -560,8 +552,8 @@ CompareImageWithPrior< TPixel, TDimension>
     resampler->Update();
     m_OutputMaskImage = resampler->GetOutput();
 
-    typedef itk::NearestNeighborInterpolateImageFunction< ImageType,
-      double > NNInterpolatorType;
+    using NNInterpolatorType = itk::NearestNeighborInterpolateImageFunction< ImageType,
+      double >;
     typename ResamplerType::Pointer orgResampler =
       ResamplerType::New();
     typename NNInterpolatorType::Pointer orgInterpolator =
@@ -617,7 +609,7 @@ CompareImageWithPrior< TPixel, TDimension>
         }
       }
 
-    typedef itk::CropImageFilter< ImageType, ImageType > CropFilterType;
+    using CropFilterType = itk::CropImageFilter< ImageType, ImageType >;
     typename CropFilterType::Pointer cropInputFilter =
       CropFilterType::New();
     typename CropFilterType::Pointer cropMaskFilter =
@@ -662,7 +654,7 @@ CompareImageWithPrior< TPixel, TDimension>
       m_TimeCollector->Start( "Normalize" );
       }
 
-    typedef itk::ImageRegionIterator< ImageType > IterType;
+    using IterType = itk::ImageRegionIterator< ImageType >;
     IterType volIter( m_OutputVolImage,
       m_OutputVolImage->GetLargestPossibleRegion() );
     IterType maskIter( m_OutputMaskImage,
@@ -729,8 +721,7 @@ CompareImageWithPrior< TPixel, TDimension>
     double scale = ( meanVolFg - meanVolBg ) / ( meanMaskFg - meanMaskBg );
     double shift = meanVolBg/scale - meanMaskBg;
 
-     typedef itk::ShiftScaleImageFilter< ImageType, ImageType >
-      FilterType;
+     using FilterType = itk::ShiftScaleImageFilter< ImageType, ImageType >;
     typename FilterType::Pointer filter = FilterType::New();
     filter->SetInput( m_OutputMaskImage );
     filter->SetShift( shift );

--- a/examples/Applications/TransferLabelsToRegions/TransferLabelsToRegions.cxx
+++ b/examples/Applications/TransferLabelsToRegions/TransferLabelsToRegions.cxx
@@ -50,7 +50,7 @@ int main( int argc, char * argv[] )
  */
 bool IsDiscrete( const std::string & fileName )
 {
-  typedef itk::ImageIOBase::IOComponentType ScalarPixelType;
+  using ScalarPixelType = itk::ImageIOBase::IOComponentType;
 
   itk::ImageIOBase::Pointer imageIO = itk::ImageIOFactory::CreateImageIO(
     fileName.c_str(), itk::ImageIOFactory::ReadMode );
@@ -196,19 +196,19 @@ int DoIt( int argc, char * argv[] )
 {
   PARSE_ARGS;
 
-  // Some typedefs - Our input image type equals the output image type, since
+  // Some type alias - Our input image type equals the output image type, since
   // the images are essentially the same, except that the voxel values
   // represent different entities.
-  typedef TPixel                                          InputPixelType;
-  typedef itk::Image< InputPixelType, VImageDimension >   InputImageType;
+  using InputPixelType = TPixel;
+  using InputImageType = itk::Image< InputPixelType, VImageDimension >;
 
-  typedef InputPixelType                                  OutputPixelType;
-  typedef itk::Image< OutputPixelType, VImageDimension >  OutputImageType;
+  using OutputPixelType = InputPixelType;
+  using OutputImageType = itk::Image< OutputPixelType, VImageDimension >;
 
-  typedef itk::ImageFileReader< InputImageType >          InputReaderType;
-  typedef itk::ImageFileWriter< OutputImageType >         OutputWriterType;
+  using InputReaderType = itk::ImageFileReader< InputImageType >;
+  using OutputWriterType = itk::ImageFileWriter< OutputImageType >;
 
-  typedef itk::ImageIOBase::IOComponentType               ScalarPixelType;
+  using ScalarPixelType = itk::ImageIOBase::IOComponentType;
 
   // Check input images's type ( we assume discrete valued images )
   if( !IsDiscrete( argInImageFileName ) ||
@@ -304,8 +304,8 @@ int DoIt( int argc, char * argv[] )
 
   // Create a mapping from CVT cell ID to the vector of corresponding
   // voxel indices.
-  typedef typename InputImageType::IndexType                    IndexType;
-  typedef typename std::map< TPixel, std::vector< IndexType > > MapType;
+  using IndexType = typename InputImageType::IndexType;
+  using MapType = typename std::map< TPixel, std::vector< IndexType > >;
 
   MapType cvtToIndex;
 

--- a/examples/Applications/TubeMath/TubeMath.cxx
+++ b/examples/Applications/TubeMath/TubeMath.cxx
@@ -42,7 +42,7 @@ template< unsigned int DimensionT >
 typename itk::GroupSpatialObject< DimensionT >::Pointer
 ReadTubeFile( const char * fileName )
 {
-  typedef itk::SpatialObjectReader< DimensionT > SpatialObjectReaderType;
+  using SpatialObjectReaderType = itk::SpatialObjectReader< DimensionT >;
 
   typename SpatialObjectReaderType::Pointer reader =
     SpatialObjectReaderType::New();
@@ -78,7 +78,7 @@ void WriteTubeFile( typename itk::GroupSpatialObject< DimensionT >::Pointer
   object, const char * fileName )
 {
   std::cout << "Writing" << std::endl;
-  typedef itk::SpatialObjectWriter< DimensionT > SpatialObjectWriterType;
+  using SpatialObjectWriterType = itk::SpatialObjectWriter< DimensionT >;
 
   typename SpatialObjectWriterType::Pointer writer =
     SpatialObjectWriterType::New();
@@ -109,8 +109,8 @@ template< class PixelT, unsigned int DimensionT >
 typename itk::Image< PixelT, DimensionT >::Pointer
 ReadImageFile( const char * fileName )
 {
-  typedef itk::Image< PixelT, DimensionT >  ImageType;
-  typedef itk::ImageFileReader< ImageType > ImageReaderType;
+  using ImageType = itk::Image< PixelT, DimensionT >;
+  using ImageReaderType = itk::ImageFileReader< ImageType >;
 
   typename ImageReaderType::Pointer reader = ImageReaderType::New();
   reader->SetFileName( fileName );
@@ -174,7 +174,7 @@ int DoIt( MetaCommand & command )
     else if( it->name == "LoadPointValuesFromImage" )
       {
       std::cout << "Load Point Values From Image" << std::endl;
-      typedef itk::Image< float, DimensionT > ImageType;
+      using ImageType = itk::Image< float, DimensionT >;
       typename ImageType::Pointer ridgeImage = ReadImageFile< float,
         DimensionT >( command.GetValueAsString( *it, "filename" ).c_str() );
       double blend = command.GetValueAsFloat( *it, "BlendFactor" );
@@ -185,7 +185,7 @@ int DoIt( MetaCommand & command )
     else if( it->name == "LoadPointValuesFromImageMean" )
       {
       std::cout << "Load Value From Image Mean" << std::endl;
-      typedef itk::Image< float, DimensionT > ImageType;
+      using ImageType = itk::Image< float, DimensionT >;
       typename ImageType::Pointer ridgeImage = ReadImageFile< float,
         DimensionT >( command.GetValueAsString( *it, "filename" ).c_str() );
       filter.SetPointValuesFromImageMean( ridgeImage,
@@ -196,7 +196,7 @@ int DoIt( MetaCommand & command )
       {
       static bool first = true;
       std::cout << "Load Values From Regions" << std::endl;
-      typedef itk::Image< float, DimensionT > ImageType;
+      using ImageType = itk::Image< float, DimensionT >;
       typename ImageType::Pointer valueImage = ReadImageFile< float,
         DimensionT >( command.GetValueAsString( *it, "filename" ).c_str() );
       if( first )
@@ -214,7 +214,7 @@ int DoIt( MetaCommand & command )
       {
       static bool first = true;
       std::cout << "Load Values From Radius" << std::endl;
-      typedef itk::Image< float, DimensionT > ImageType;
+      using ImageType = itk::Image< float, DimensionT >;
       typename ImageType::Pointer valueImage = ReadImageFile< float,
         DimensionT >( command.GetValueAsString( *it, "filename" ).c_str() );
       if( first )
@@ -246,7 +246,7 @@ int DoIt( MetaCommand & command )
     else if( it->name == "ComputeTangentsAndNormals" )
       {
       ::tube::Message( "Compute Tangents and Normals" );
-      typedef itk::TubeSpatialObject< DimensionT >  TubeType;
+      using TubeType = itk::TubeSpatialObject< DimensionT >;
 
       typename TubeType::ChildrenListType::iterator tubeIterator;
 
@@ -295,7 +295,7 @@ int DoIt( MetaCommand & command )
     else if( it->name == "MarkAsArtery" )
       {
       ::tube::Message( "Mark as Artery" );
-      typedef itk::TubeSpatialObject< DimensionT >  TubeType;
+      using TubeType = itk::TubeSpatialObject< DimensionT >;
 
       typename TubeType::ChildrenListType::iterator tubeIterator;
 
@@ -330,7 +330,7 @@ int DoIt( MetaCommand & command )
     else if( it->name == "MarkAsRoot" )
       {
       ::tube::Message( "Mark as Root" );
-      typedef itk::TubeSpatialObject< DimensionT >  TubeType;
+      using TubeType = itk::TubeSpatialObject< DimensionT >;
 
       typename TubeType::ChildrenListType::iterator tubeIterator;
 
@@ -356,7 +356,7 @@ int DoIt( MetaCommand & command )
     else if( it->name == "UniqueIDs" )
       {
       ::tube::Message( "Assign Unique IDs" );
-      typedef itk::TubeSpatialObject< DimensionT >  TubeType;
+      using TubeType = itk::TubeSpatialObject< DimensionT >;
 
       typename TubeType::ChildrenListType::iterator tubeIterator;
 

--- a/include/tubeComputeBinaryImageSimilarityMetrics.h
+++ b/include/tubeComputeBinaryImageSimilarityMetrics.h
@@ -42,16 +42,15 @@ class ComputeBinaryImageSimilarityMetrics:
   public itk::ProcessObject
 {
 public:
-  /** Standard class typedefs. */
-  typedef ComputeBinaryImageSimilarityMetrics     Self;
-  typedef itk::ProcessObject                      Superclass;
-  typedef itk::SmartPointer< Self >               Pointer;
-  typedef itk::SmartPointer< const Self >         ConstPointer;
-  typedef TInputImage                             InputImageType;
-  typedef typename TInputImage::PixelType         LabelType;
+  /** Standard class type alias. */
+  using Self = ComputeBinaryImageSimilarityMetrics;
+  using Superclass = itk::ProcessObject;
+  using Pointer = itk::SmartPointer< Self >;
+  using ConstPointer = itk::SmartPointer< const Self >;
+  using InputImageType = TInputImage;
+  using LabelType = typename TInputImage::PixelType;
 
-  typedef itk::LabelOverlapMeasuresImageFilter< InputImageType >
-    FilterType;
+  using FilterType = itk::LabelOverlapMeasuresImageFilter< InputImageType >;
 
   /** Method for creation through the object factory. */
   itkNewMacro( Self );

--- a/include/tubeComputeImageSimilarityMetrics.h
+++ b/include/tubeComputeImageSimilarityMetrics.h
@@ -45,16 +45,16 @@ class ComputeImageSimilarityMetrics:
   public itk::ProcessObject
 {
 public:
-  /** Standard class typedefs. */
-  typedef ComputeImageSimilarityMetrics              Self;
-  typedef itk::ProcessObject                         Superclass;
-  typedef itk::SmartPointer< Self >                  Pointer;
-  typedef itk::SmartPointer< const Self >            ConstPointer;
+  /** Standard class type alias. */
+  using Self = ComputeImageSimilarityMetrics;
+  using Superclass = itk::ProcessObject;
+  using Pointer = itk::SmartPointer< Self >;
+  using ConstPointer = itk::SmartPointer< const Self >;
 
-  typedef itk::tube::ComputeImageSimilarityMetrics<
-    TInputImage >                                    FilterType;
+  using FilterType = itk::tube::ComputeImageSimilarityMetrics<
+    TInputImage >;
 
-  typedef typename FilterType::ImageType             ImageType;
+  using ImageType = typename FilterType::ImageType;
 
   /** Method for creation through the object factory. */
   itkNewMacro( Self );

--- a/include/tubeComputeImageStatistics.h
+++ b/include/tubeComputeImageStatistics.h
@@ -47,15 +47,15 @@ class ComputeImageStatistics
   : public itk::ProcessObject
 {
 public:
-  /** Standard class typedefs. */
-  typedef ComputeImageStatistics           Self;
-  typedef itk::ProcessObject               Superclass;
-  typedef itk::SmartPointer< Self >        Pointer;
-  typedef itk::SmartPointer< const Self >  ConstPointer;
+  /** Standard class type alias. */
+  using Self = ComputeImageStatistics;
+  using Superclass = itk::ProcessObject;
+  using Pointer = itk::SmartPointer< Self >;
+  using ConstPointer = itk::SmartPointer< const Self >;
 
-  typedef itk::tube::ComputeImageStatistics< TPixel, VDimension > FilterType;
-  typedef typename FilterType::MaskType                           MaskType;
-  typedef typename FilterType::VolumeType                         VolumeType;
+  using FilterType = itk::tube::ComputeImageStatistics< TPixel, VDimension >;
+  using MaskType = typename FilterType::MaskType;
+  using VolumeType = typename FilterType::VolumeType;
 
 
   /** Method for creation through the object factory. */

--- a/include/tubeComputeTrainingMask.h
+++ b/include/tubeComputeTrainingMask.h
@@ -43,11 +43,11 @@ template< class TImage, class TLabelMap=itk::Image< typename TImage::PixelType,
 class ComputeTrainingMask : public itk::ProcessObject
 {
 public:
-  /** Standard class typedefs. */
-  typedef ComputeTrainingMask                             Self;
-  typedef itk::ProcessObject                              Superclass;
-  typedef itk::SmartPointer< Self >                       Pointer;
-  typedef itk::SmartPointer< const Self >                 ConstPointer;
+  /** Standard class type alias. */
+  using Self = ComputeTrainingMask;
+  using Superclass = itk::ProcessObject;
+  using Pointer = itk::SmartPointer< Self >;
+  using ConstPointer = itk::SmartPointer< const Self >;
 
   /** Method for creation through the object factory. */
   itkNewMacro( Self );
@@ -57,14 +57,13 @@ public:
 
 
   /** Typedef to images */
-  typedef TImage                                          ImageType;
-  typedef TLabelMap                                       LabelMapType;
+  using ImageType = TImage;
+  using LabelMapType = TLabelMap;
 
   itkStaticConstMacro( ImageDimension, unsigned int,
     ImageType::ImageDimension );
 
-  typedef typename itk::tube::ComputeTrainingMaskFilter< ImageType, LabelMapType >
-                                                          FilterType;
+  using FilterType = typename itk::tube::ComputeTrainingMaskFilter< ImageType, LabelMapType >;
 
   tubeWrapSetMacro( Gap, double, Filter );
   tubeWrapGetMacro( Gap, double, Filter );

--- a/include/tubeComputeTubeFlyThroughImage.h
+++ b/include/tubeComputeTubeFlyThroughImage.h
@@ -44,20 +44,20 @@ class ComputeTubeFlyThroughImage:
   public itk::ProcessObject
 {
 public:
-  /** Standard class typedefs. */
-  typedef ComputeTubeFlyThroughImage                 Self;
-  typedef itk::ProcessObject                         Superclass;
-  typedef itk::SmartPointer< Self >                  Pointer;
-  typedef itk::SmartPointer< const Self >            ConstPointer;
+  /** Standard class type alias. */
+  using Self = ComputeTubeFlyThroughImage;
+  using Superclass = itk::ProcessObject;
+  using Pointer = itk::SmartPointer< Self >;
+  using ConstPointer = itk::SmartPointer< const Self >;
 
-  typedef itk::tube::ComputeTubeFlyThroughImageFilter< TPixel,
-    Dimension >                                     FilterType;
+  using FilterType = itk::tube::ComputeTubeFlyThroughImageFilter< TPixel,
+    Dimension >;
 
-  typedef typename FilterType::TubeGroupType        TubeGroupType;
-  typedef typename FilterType::TubeType             TubeType;
-  typedef typename FilterType::InputImageType       InputImageType;
-  typedef typename FilterType::OutputImageType      OutputImageType;
-  typedef typename FilterType::OutputMaskType       OutputMaskType;
+  using TubeGroupType = typename FilterType::TubeGroupType;
+  using TubeType = typename FilterType::TubeType;
+  using InputImageType = typename FilterType::InputImageType;
+  using OutputImageType = typename FilterType::OutputImageType;
+  using OutputMaskType = typename FilterType::OutputMaskType;
 
   /** Method for creation through the object factory. */
   itkNewMacro( Self );

--- a/include/tubeComputeTubeMeasures.h
+++ b/include/tubeComputeTubeMeasures.h
@@ -43,17 +43,16 @@ class ComputeTubeMeasures:
   public itk::ProcessObject
 {
 public:
-  /** Standard class typedefs. */
-  typedef ComputeTubeMeasures                        Self;
-  typedef itk::ProcessObject                         Superclass;
-  typedef itk::SmartPointer< Self >                  Pointer;
-  typedef itk::SmartPointer< const Self >            ConstPointer;
+  /** Standard class type alias. */
+  using Self = ComputeTubeMeasures;
+  using Superclass = itk::ProcessObject;
+  using Pointer = itk::SmartPointer< Self >;
+  using ConstPointer = itk::SmartPointer< const Self >;
 
-  typedef itk::tube::ComputeTubeMeasuresFilter< TPixel, Dimension >
-    FilterType;
+  using FilterType = itk::tube::ComputeTubeMeasuresFilter< TPixel, Dimension >;
 
-  typedef typename FilterType::InputImageType       InputImageType;
-  typedef typename FilterType::OutputImageType      OutputImageType;
+  using InputImageType = typename FilterType::InputImageType;
+  using OutputImageType = typename FilterType::OutputImageType;
 
   /** Method for creation through the object factory. */
   itkNewMacro( Self );

--- a/include/tubeConvertImagesToCSV.h
+++ b/include/tubeConvertImagesToCSV.h
@@ -42,11 +42,11 @@ class ConvertImagesToCSV:
   public itk::ProcessObject
 {
 public:
-  /** Standard class typedefs. */
-  typedef ConvertImagesToCSV                              Self;
-  typedef itk::ProcessObject                              Superclass;
-  typedef itk::SmartPointer< Self >                       Pointer;
-  typedef itk::SmartPointer< const Self >                 ConstPointer;
+  /** Standard class type alias. */
+  using Self = ConvertImagesToCSV;
+  using Superclass = itk::ProcessObject;
+  using Pointer = itk::SmartPointer< Self >;
+  using ConstPointer = itk::SmartPointer< const Self >;
 
   /** Method for creation through the object factory. */
   itkNewMacro( Self );
@@ -54,14 +54,13 @@ public:
   /** Run-time type information ( and related methods ). */
   itkTypeMacro( ConvertImagesToCSV, ProcessObject );
 
-  typedef TInputMask                                      InputMaskType;
-  typedef typename InputMaskType::PixelType               MaskPixelType;
+  using InputMaskType = TInputMask;
+  using MaskPixelType = typename InputMaskType::PixelType;
 
-  typedef TInputImage                                     InputImageType;
-  typedef typename InputImageType::PixelType              InputPixelType;
+  using InputImageType = TInputImage;
+  using InputPixelType = typename InputImageType::PixelType;
 
-  typedef itk::tube::ConvertImagesToCSVFilter< InputImageType, InputMaskType >
-    ConvertImagesToCSVFilterType;
+  using ConvertImagesToCSVFilterType = itk::tube::ConvertImagesToCSVFilter< InputImageType, InputMaskType >;
 
   tubeWrapSetObjectMacro( InputMask, InputMaskType, ConvertImagesToCSVFilter );
   tubeWrapGetObjectMacro( InputMask, InputMaskType, ConvertImagesToCSVFilter );

--- a/include/tubeConvertShrunkenSeedImageToList.h
+++ b/include/tubeConvertShrunkenSeedImageToList.h
@@ -42,11 +42,11 @@ class ConvertShrunkenSeedImageToList
   : public itk::ProcessObject
 {
 public:
-  /** Standard class typedefs. */
-  typedef ConvertShrunkenSeedImageToList                        Self;
-  typedef itk::ProcessObject                                    Superclass;
-  typedef itk::SmartPointer< Self >                             Pointer;
-  typedef itk::SmartPointer< const Self >                       ConstPointer;
+  /** Standard class type alias. */
+  using Self = ConvertShrunkenSeedImageToList;
+  using Superclass = itk::ProcessObject;
+  using Pointer = itk::SmartPointer< Self >;
+  using ConstPointer = itk::SmartPointer< const Self >;
 
   /** Method for creation through the object factory. */
   itkNewMacro( Self );
@@ -54,14 +54,14 @@ public:
   /** Run-time type information (and related methods). */
   itkTypeMacro( ConvertShrunkenSeedImageToList, ProcessObject );
 
-  typedef TImage                                           ImageType;
-  typedef typename ImageType::PixelType                    PixelType;
+  using ImageType = TImage;
+  using PixelType = typename ImageType::PixelType;
 
-  typedef TPointsImage                                     PointsImageType;
-  typedef typename PointsImageType::PixelType              PointsPixelType;
+  using PointsImageType = TPointsImage;
+  using PointsPixelType = typename PointsImageType::PixelType;
 
-  typedef itk::tube::ConvertShrunkenSeedImageToListFilter< ImageType,
-    PointsImageType > ConvertShrunkenSeedImageToListFilterType;
+  using ConvertShrunkenSeedImageToListFilterType = itk::tube::ConvertShrunkenSeedImageToListFilter< ImageType,
+    PointsImageType >;
 
   tubeWrapSetConstObjectMacro( Input, ImageType,
     ConvertShrunkenSeedImageToListFilter );

--- a/include/tubeConvertSpatialGraphToImage.h
+++ b/include/tubeConvertSpatialGraphToImage.h
@@ -43,19 +43,19 @@ class ConvertSpatialGraphToImage:
   public itk::ProcessObject
 {
 public:
-  /** Standard class typedefs. */
-  typedef ConvertSpatialGraphToImage      Self;
-  typedef ProcessObject                   Superclass;
-  typedef itk::SmartPointer< Self >       Pointer;
-  typedef itk::SmartPointer< const Self > ConstPointer;
+  /** Standard class type alias. */
+  using Self = ConvertSpatialGraphToImage;
+  using Superclass = ProcessObject;
+  using Pointer = itk::SmartPointer< Self >;
+  using ConstPointer = itk::SmartPointer< const Self >;
 
-  typedef itk::tube::ConvertSpatialGraphToImageFilter
-    < TInputImage, TOutputImage >         FilterType;
+  using FilterType = itk::tube::ConvertSpatialGraphToImageFilter
+    < TInputImage, TOutputImage >;
 
-  typedef typename FilterType::InputImageType      InputImageType;
-  typedef typename FilterType::InputImagePointer   InputImagePointer;
-  typedef typename FilterType::OutputImageType     OutputImageType;
-  typedef typename FilterType::OutputImagePointer  OutputImagePointer;
+  using InputImageType = typename FilterType::InputImageType;
+  using InputImagePointer = typename FilterType::InputImagePointer;
+  using OutputImageType = typename FilterType::OutputImageType;
+  using OutputImagePointer = typename FilterType::OutputImagePointer;
 
   /** Method for creation through the object factory. */
   itkNewMacro( Self );

--- a/include/tubeConvertTubesToDensityImage.h
+++ b/include/tubeConvertTubesToDensityImage.h
@@ -45,18 +45,18 @@ class ConvertTubesToDensityImage:
   public itk::ProcessObject
 {
 public:
-  /** Standard class typedefs. */
-  typedef ConvertTubesToDensityImage                 Self;
-  typedef itk::ProcessObject                         Superclass;
-  typedef itk::SmartPointer< Self >                  Pointer;
-  typedef itk::SmartPointer< const Self >            ConstPointer;
+  /** Standard class type alias. */
+  using Self = ConvertTubesToDensityImage;
+  using Superclass = itk::ProcessObject;
+  using Pointer = itk::SmartPointer< Self >;
+  using ConstPointer = itk::SmartPointer< const Self >;
 
   /** Typdefs */
-  typedef itk::Image< TOutputPixel, Dimension >          DensityImageType;
-  typedef typename DensityImageType::PixelType           DensityPixelType;
-  typedef typename DensityImageType::Pointer             DensityImagePointer;
-  typedef typename DensityImageType::SizeType            SizeType;
-  typedef typename DensityImageType::SpacingType         SpacingType;
+  using DensityImageType = itk::Image< TOutputPixel, Dimension >;
+  using DensityPixelType = typename DensityImageType::PixelType;
+  using DensityImagePointer = typename DensityImageType::Pointer;
+  using SizeType = typename DensityImageType::SizeType;
+  using SpacingType = typename DensityImageType::SpacingType;
 
   /** Method for creation through the object factory. */
   itkNewMacro( Self );
@@ -64,17 +64,17 @@ public:
   /** Run-time type information ( and related methods ). */
   itkTypeMacro( ConvertTubesToDensityImage, Object );
 
-  typedef itk::Image< TOutputPixel, Dimension >          RadiusImageType;
-  typedef typename RadiusImageType::Pointer              RadiusImagePointer;
-  typedef itk::Vector< TOutputPixel, Dimension >         TangentPixelType;
-  typedef itk::Image< TangentPixelType, Dimension >      TangentImageType;
-  typedef typename TangentImageType::Pointer             TangentImagePointer;
+  using RadiusImageType = itk::Image< TOutputPixel, Dimension >;
+  using RadiusImagePointer = typename RadiusImageType::Pointer;
+  using TangentPixelType = itk::Vector< TOutputPixel, Dimension >;
+  using TangentImageType = itk::Image< TangentPixelType, Dimension >;
+  using TangentImagePointer = typename TangentImageType::Pointer;
 
-  typedef itk::GroupSpatialObject< Dimension >           TubeGroupType;
-  typedef typename TubeGroupType::Pointer                TubeGroupPointer;
+  using TubeGroupType = itk::GroupSpatialObject< Dimension >;
+  using TubeGroupPointer = typename TubeGroupType::Pointer;
 
-  typedef itk::tube::TubeSpatialObjectToDensityImageFilter<
-  DensityImageType, RadiusImageType, TangentImageType >  FilterType;
+  using FilterType = itk::tube::TubeSpatialObjectToDensityImageFilter<
+  DensityImageType, RadiusImageType, TangentImageType >;
 
   /** Set maximum density intensity value. Its a constant */
   tubeWrapSetMacro( MaxDensityIntensity, DensityPixelType, Filter );

--- a/include/tubeConvertTubesToImage.h
+++ b/include/tubeConvertTubesToImage.h
@@ -46,18 +46,18 @@ class ConvertTubesToImage:
   public itk::ProcessObject
 {
 public:
-  /** Standard class typedefs. */
-  typedef ConvertTubesToImage                        Self;
-  typedef itk::ProcessObject                         Superclass;
-  typedef itk::SmartPointer< Self >                  Pointer;
-  typedef itk::SmartPointer< const Self >            ConstPointer;
+  /** Standard class type alias. */
+  using Self = ConvertTubesToImage;
+  using Superclass = itk::ProcessObject;
+  using Pointer = itk::SmartPointer< Self >;
+  using ConstPointer = itk::SmartPointer< const Self >;
 
-  typedef TImage                                     OutputImageType;
+  using OutputImageType = TImage;
 
-  typedef itk::tube::TubeSpatialObjectToImageFilter<
-    TImage::ImageDimension, OutputImageType >        FilterType;
+  using FilterType = itk::tube::TubeSpatialObjectToImageFilter<
+    TImage::ImageDimension, OutputImageType >;
 
-  typedef typename FilterType::SpatialObjectType     TubesType;
+  using TubesType = typename FilterType::SpatialObjectType;
 
   /** Method for creation through the object factory. */
   itkNewMacro( Self );

--- a/include/tubeConvertTubesToTubeGraph.h
+++ b/include/tubeConvertTubesToTubeGraph.h
@@ -45,17 +45,17 @@ class ConvertTubesToTubeGraph:
   public itk::ProcessObject
 {
 public:
-  /** Standard class typedefs. */
-  typedef ConvertTubesToTubeGraph                    Self;
-  typedef itk::ProcessObject                         Superclass;
-  typedef itk::SmartPointer< Self >                  Pointer;
-  typedef itk::SmartPointer< const Self >            ConstPointer;
+  /** Standard class type alias. */
+  using Self = ConvertTubesToTubeGraph;
+  using Superclass = itk::ProcessObject;
+  using Pointer = itk::SmartPointer< Self >;
+  using ConstPointer = itk::SmartPointer< const Self >;
 
-  typedef itk::tube::TubeSpatialObjectToTubeGraphFilter
-    < TPixel, Dimension > FilterType;
+  using FilterType = itk::tube::TubeSpatialObjectToTubeGraphFilter
+    < TPixel, Dimension >;
 
-  typedef typename FilterType::InputImageType     InputImageType;
-  typedef typename FilterType::TubeGroupType      TubeGroupType;
+  using InputImageType = typename FilterType::InputImageType;
+  using TubeGroupType = typename FilterType::TubeGroupType;
 
   /** Method for creation through the object factory. */
   itkNewMacro( Self );

--- a/include/tubeCropImage.h
+++ b/include/tubeCropImage.h
@@ -42,11 +42,11 @@ class CropImage:
   public itk::ProcessObject
 {
 public:
-  /** Standard class typedefs. */
-  typedef CropImage                       Self;
-  typedef itk::ProcessObject              Superclass;
-  typedef itk::SmartPointer< Self >       Pointer;
-  typedef itk::SmartPointer< const Self > ConstPointer;
+  /** Standard class type alias. */
+  using Self = CropImage;
+  using Superclass = itk::ProcessObject;
+  using Pointer = itk::SmartPointer< Self >;
+  using ConstPointer = itk::SmartPointer< const Self >;
 
   /** Method for creation through the object factory. */
   itkNewMacro( Self );
@@ -56,13 +56,13 @@ public:
 
 
   /** Typedef to images */
-  typedef TInputImage                          InputImageType;
-  typedef TOutputImage                         OutputImageType;
-  typedef typename InputImageType::IndexType   InputIndexType;
-  typedef typename InputImageType::SizeType    InputSizeType;
+  using InputImageType = TInputImage;
+  using OutputImageType = TOutputImage;
+  using InputIndexType = typename InputImageType::IndexType;
+  using InputSizeType = typename InputImageType::SizeType;
 
-  typedef itk::tube::CropImageFilter< InputImageType,
-    OutputImageType >                          FilterType;
+  using FilterType = itk::tube::CropImageFilter< InputImageType,
+    OutputImageType >;
 
   tubeWrapSetMacro( Min, InputIndexType, Filter );
   tubeWrapGetMacro( Min, InputIndexType, Filter );

--- a/include/tubeCropTubes.h
+++ b/include/tubeCropTubes.h
@@ -39,18 +39,18 @@ class CropTubes:
   public itk::ProcessObject
 {
 public:
-  /** Standard class typedefs. */
-  typedef CropTubes                                Self;
-  typedef itk::ProcessObject                       Superclass;
-  typedef itk::SmartPointer< Self >                Pointer;
-  typedef itk::SmartPointer< const Self >          ConstPointer;
-  typedef itk::tube::CropTubesFilter< VDimension > FilterType;
+  /** Standard class type alias. */
+  using Self = CropTubes;
+  using Superclass = itk::ProcessObject;
+  using Pointer = itk::SmartPointer< Self >;
+  using ConstPointer = itk::SmartPointer< const Self >;
+  using FilterType = itk::tube::CropTubesFilter< VDimension >;
 
-  typedef typename FilterType::TubeGroupType       TubeGroupType;
-  typedef typename TubeGroupType::Pointer          TubeGroupPointer;
-  typedef typename FilterType::ImageType           ImageType;
-  typedef typename FilterType::PointType           PointType;
-  typedef typename FilterType::VectorType          VectorType;
+  using TubeGroupType = typename FilterType::TubeGroupType;
+  using TubeGroupPointer = typename TubeGroupType::Pointer;
+  using ImageType = typename FilterType::ImageType;
+  using PointType = typename FilterType::PointType;
+  using VectorType = typename FilterType::VectorType;
 
   /** Method for creation through the object factory. */
   itkNewMacro( Self );

--- a/include/tubeEnhanceContrastUsingPrior.h
+++ b/include/tubeEnhanceContrastUsingPrior.h
@@ -44,18 +44,18 @@ class EnhanceContrastUsingPrior:
   public itk::ProcessObject
 {
 public:
-  /** Standard class typedefs. */
-  typedef EnhanceContrastUsingPrior       Self;
-  typedef itk::ProcessObject              Superclass;
-  typedef itk::SmartPointer< Self >       Pointer;
-  typedef itk::SmartPointer< const Self > ConstPointer;
+  /** Standard class type alias. */
+  using Self = EnhanceContrastUsingPrior;
+  using Superclass = itk::ProcessObject;
+  using Pointer = itk::SmartPointer< Self >;
+  using ConstPointer = itk::SmartPointer< const Self >;
 
-  typedef itk::tube::EnhanceContrastUsingPriorImageFilter
-    < TPixel, VDimension >                FilterType;
+  using FilterType = itk::tube::EnhanceContrastUsingPriorImageFilter
+    < TPixel, VDimension >;
 
-  typedef typename FilterType::ImageType           ImageType;
-  typedef typename ImageType::ConstPointer         ConstImagePointer;
-  typedef typename ImageType::Pointer              ImagePointer;
+  using ImageType = typename FilterType::ImageType;
+  using ConstImagePointer = typename ImageType::ConstPointer;
+  using ImagePointer = typename ImageType::Pointer;
 
   /** Method for creation through the object factory. */
   itkNewMacro( Self );

--- a/include/tubeEnhanceEdgesUsingDiffusion.h
+++ b/include/tubeEnhanceEdgesUsingDiffusion.h
@@ -43,17 +43,17 @@ class EnhanceEdgesUsingDiffusion:
   public itk::ProcessObject
 {
 public:
-  /** Standard class typedefs. */
-  typedef EnhanceEdgesUsingDiffusion                Self;
-  typedef itk::ProcessObject                        Superclass;
-  typedef itk::SmartPointer< Self >                 Pointer;
-  typedef itk::SmartPointer< const Self >           ConstPointer;
+  /** Standard class type alias. */
+  using Self = EnhanceEdgesUsingDiffusion;
+  using Superclass = itk::ProcessObject;
+  using Pointer = itk::SmartPointer< Self >;
+  using ConstPointer = itk::SmartPointer< const Self >;
 
-  typedef TInputImage                               InputImageType;
-  typedef TOutputImage                              OutputImageType;
+  using InputImageType = TInputImage;
+  using OutputImageType = TOutputImage;
 
-  typedef itk::tube::AnisotropicEdgeEnhancementDiffusionImageFilter<
-    InputImageType, OutputImageType>  FilterType;
+  using FilterType = itk::tube::AnisotropicEdgeEnhancementDiffusionImageFilter<
+    InputImageType, OutputImageType>;
 
   /** Method for creation through the object factory. */
   itkNewMacro( Self );

--- a/include/tubeEnhanceTubesUsingDiffusion.h
+++ b/include/tubeEnhanceTubesUsingDiffusion.h
@@ -45,16 +45,16 @@ class EnhanceTubesUsingDiffusion:
   public itk::ProcessObject
 {
 public:
-  /** Standard class typedefs. */
-  typedef EnhanceTubesUsingDiffusion                Self;
-  typedef itk::ProcessObject                        Superclass;
-  typedef itk::SmartPointer< Self >                 Pointer;
-  typedef itk::SmartPointer< const Self >           ConstPointer;
+  /** Standard class type alias. */
+  using Self = EnhanceTubesUsingDiffusion;
+  using Superclass = itk::ProcessObject;
+  using Pointer = itk::SmartPointer< Self >;
+  using ConstPointer = itk::SmartPointer< const Self >;
 
-  typedef itk::Image< TPixel, Dimension >           ImageType;
+  using ImageType = itk::Image< TPixel, Dimension >;
 
-  typedef itk::tube::TubeEnhancingDiffusion2DImageFilter< TPixel,
-    Dimension >                                     FilterType;
+  using FilterType = itk::tube::TubeEnhancingDiffusion2DImageFilter< TPixel,
+    Dimension >;
 
   /** Method for creation through the object factory. */
   itkNewMacro( Self );

--- a/include/tubeEnhanceTubesUsingDiscriminantAnalysis.h
+++ b/include/tubeEnhanceTubesUsingDiscriminantAnalysis.h
@@ -44,29 +44,29 @@ class EnhanceTubesUsingDiscriminantAnalysis:
   public itk::ProcessObject
 {
 public:
-  /** Standard class typedefs. */
-  typedef EnhanceTubesUsingDiscriminantAnalysis        Self;
-  typedef itk::ProcessObject                           Superclass;
-  typedef itk::SmartPointer< Self >                    Pointer;
-  typedef itk::SmartPointer< const Self >              ConstPointer;
+  /** Standard class type alias. */
+  using Self = EnhanceTubesUsingDiscriminantAnalysis;
+  using Superclass = itk::ProcessObject;
+  using Pointer = itk::SmartPointer< Self >;
+  using ConstPointer = itk::SmartPointer< const Self >;
 
-  typedef TImage                                       ImageType;
-  typedef typename ImageType::PixelType                PixelType;
-  typedef typename ImageType::IndexType                IndexType;
+  using ImageType = TImage;
+  using PixelType = typename ImageType::PixelType;
+  using IndexType = typename ImageType::IndexType;
 
-  typedef TLabelMap                                    LabelMapType;
+  using LabelMapType = TLabelMap;
 
-  typedef itk::tube::RidgeSeedFilter< ImageType, LabelMapType >   FilterType;
-  typedef itk::tube::RidgeSeedFilterIO< ImageType, LabelMapType > FilterIOType;
+  using FilterType = itk::tube::RidgeSeedFilter< ImageType, LabelMapType >;
+  using FilterIOType = itk::tube::RidgeSeedFilterIO< ImageType, LabelMapType >;
 
-  typedef typename FilterType::ProbabilityImageType    OutputImageType;
+  using OutputImageType = typename FilterType::ProbabilityImageType;
 
-  typedef typename FilterType::ObjectIdType            ObjectIdType;
-  typedef typename FilterType::RidgeScalesType         RidgeScalesType;
-  typedef typename FilterType::WhitenMeansType         WhitenMeansType;
-  typedef typename FilterType::WhitenStdDevsType       WhitenStdDevsType;
-  typedef typename FilterType::VectorType              VectorType;
-  typedef typename FilterType::MatrixType              MatrixType;
+  using ObjectIdType = typename FilterType::ObjectIdType;
+  using RidgeScalesType = typename FilterType::RidgeScalesType;
+  using WhitenMeansType = typename FilterType::WhitenMeansType;
+  using WhitenStdDevsType = typename FilterType::WhitenStdDevsType;
+  using VectorType = typename FilterType::VectorType;
+  using MatrixType = typename FilterType::MatrixType;
 
   /** Method for creation through the object factory. */
   itkNewMacro( Self );

--- a/include/tubeImageMath.h
+++ b/include/tubeImageMath.h
@@ -44,20 +44,20 @@ class ImageMath:
   public itk::ProcessObject
 {
 public:
-  /** Standard class typedefs. */
-  typedef ImageMath                                  Self;
-  typedef itk::ProcessObject                         Superclass;
-  typedef itk::SmartPointer< Self >                  Pointer;
-  typedef itk::SmartPointer< const Self >            ConstPointer;
+  /** Standard class type alias. */
+  using Self = ImageMath;
+  using Superclass = itk::ProcessObject;
+  using Pointer = itk::SmartPointer< Self >;
+  using ConstPointer = itk::SmartPointer< const Self >;
 
-  typedef tube::ImageMathFilters< TInputImage::ImageDimension >  FilterType;
+  using FilterType = tube::ImageMathFilters< TInputImage::ImageDimension >;
 
-  typedef TInputImage                                InputImageType;
-  typedef typename FilterType::ImageType             ImageType;
-  typedef TInputImage                                OutputImageType;
+  using InputImageType = TInputImage;
+  using ImageType = typename FilterType::ImageType;
+  using OutputImageType = TInputImage;
 
-  typedef itk::Image< unsigned char, TInputImage::ImageDimension> ImageTypeUChar;
-  typedef itk::Image< short, TInputImage::ImageDimension>         ImageTypeShort;
+  using ImageTypeUChar = itk::Image< unsigned char, TInputImage::ImageDimension>;
+  using ImageTypeShort = itk::Image< short, TInputImage::ImageDimension>;
 
   /** Method for creation through the object factory. */
   itkNewMacro( Self );
@@ -66,7 +66,7 @@ public:
   itkTypeMacro( ImageMath, ProcessObject );
 
   void SetInput( InputImageType * input )
-  { typedef itk::CastImageFilter< InputImageType, ImageType > CastFilterType;
+  { using CastFilterType = itk::CastImageFilter< InputImageType, ImageType >;
     typename CastFilterType::Pointer castFilter = CastFilterType::New();
     castFilter->SetInput( input );
     castFilter->Update();
@@ -82,7 +82,7 @@ public:
 
   /** Get current result */
   OutputImageType * GetOutput( void )
-  { typedef itk::CastImageFilter< ImageType,InputImageType > CastFilterType;
+  { using CastFilterType = itk::CastImageFilter< ImageType,InputImageType >;
     typename CastFilterType::Pointer castFilter = CastFilterType::New();
     castFilter->SetInput( m_Filter.GetOutput() );
     castFilter->Update();
@@ -96,7 +96,7 @@ public:
 
   /** Get current result */
   ImageTypeUChar * GetOutputUChar( void )
-  { typedef itk::CastImageFilter< ImageType, ImageTypeUChar > CastFilterType;
+  { using CastFilterType = itk::CastImageFilter< ImageType, ImageTypeUChar >;
     typename CastFilterType::Pointer castFilter = CastFilterType::New();
     castFilter->SetInput( m_Filter.GetOutput() );
     castFilter->Update();
@@ -106,7 +106,7 @@ public:
 
   /** Get current result */
   ImageTypeShort * GetOutputShort( void )
-  { typedef itk::CastImageFilter< ImageType, ImageTypeShort > CastFilterType;
+  { using CastFilterType = itk::CastImageFilter< ImageType, ImageTypeShort >;
     typename CastFilterType::Pointer castFilter = CastFilterType::New();
     castFilter->SetInput( m_Filter.GetOutput() );
     castFilter->Update();
@@ -138,7 +138,7 @@ public:
     this->Modified(); };
 
   void AddImages( InputImageType * input2, float weight1, float weight2 )
-  { typedef itk::CastImageFilter< InputImageType, ImageType > CastFilterType;
+  { using CastFilterType = itk::CastImageFilter< InputImageType, ImageType >;
     typename CastFilterType::Pointer castFilter = CastFilterType::New();
     castFilter->SetInput( input2 );
     castFilter->Update();
@@ -146,7 +146,7 @@ public:
     this->Modified(); };
 
   void MultiplyImages( InputImageType * input2 )
-  { typedef itk::CastImageFilter< InputImageType, ImageType > CastFilterType;
+  { using CastFilterType = itk::CastImageFilter< InputImageType, ImageType >;
     typename CastFilterType::Pointer castFilter = CastFilterType::New();
     castFilter->SetInput( input2 );
     castFilter->Update();
@@ -166,7 +166,7 @@ public:
   { m_Filter.NormalizeImage( 2 ); this->Modified(); };
 
   void FuseUsingMax( InputImageType * input2, float offset2 )
-  { typedef itk::CastImageFilter< InputImageType, ImageType > CastFilterType;
+  { using CastFilterType = itk::CastImageFilter< InputImageType, ImageType >;
     typename CastFilterType::Pointer castFilter = CastFilterType::New();
     castFilter->SetInput( input2 );
     castFilter->Update();
@@ -183,7 +183,7 @@ public:
 
   double MeanWithinMaskRange( InputImageType * mask, float maskThreshLow,
     float maskThreshHigh )
-  { typedef itk::CastImageFilter< InputImageType, ImageType > CastFilterType;
+  { using CastFilterType = itk::CastImageFilter< InputImageType, ImageType >;
     typename CastFilterType::Pointer castFilter = CastFilterType::New();
     castFilter->SetInput( mask );
     castFilter->Update();
@@ -192,7 +192,7 @@ public:
 
   double StdDevWithinMaskRange( InputImageType * mask, float maskThreshLow,
     float maskThreshHigh )
-  { typedef itk::CastImageFilter< InputImageType, ImageType > CastFilterType;
+  { using CastFilterType = itk::CastImageFilter< InputImageType, ImageType >;
     typename CastFilterType::Pointer castFilter = CastFilterType::New();
     castFilter->SetInput( mask );
     castFilter->Update();
@@ -204,7 +204,7 @@ public:
 
   void ReplaceValuesOutsideMaskRange( InputImageType * mask, float maskThreshLow,
     float maskThreshHigh, float valFalse )
-  { typedef itk::CastImageFilter< InputImageType, ImageType > CastFilterType;
+  { using CastFilterType = itk::CastImageFilter< InputImageType, ImageType >;
     typename CastFilterType::Pointer castFilter = CastFilterType::New();
     castFilter->SetInput( mask );
     castFilter->Update();
@@ -219,7 +219,7 @@ public:
 
   void ReplaceValueWithinMaskRange( InputImageType * mask, float maskThreshLow,
     float maskThreshHigh, float imageVal, float newImageVal )
-  { typedef itk::CastImageFilter< InputImageType, ImageType > CastFilterType;
+  { using CastFilterType = itk::CastImageFilter< InputImageType, ImageType >;
     typename CastFilterType::Pointer castFilter = CastFilterType::New();
     castFilter->SetInput( mask );
     castFilter->Update();
@@ -264,7 +264,7 @@ public:
 
   void IntensityCorrection( unsigned int nBins, unsigned int nMatchPoints,
     InputImageType * referenceImage )
-  { typedef itk::CastImageFilter< InputImageType, ImageType > CastFilterType;
+  { using CastFilterType = itk::CastImageFilter< InputImageType, ImageType >;
     typename CastFilterType::Pointer castFilter = CastFilterType::New();
     castFilter->SetInput( referenceImage );
     castFilter->Update();
@@ -275,7 +275,7 @@ public:
   { m_Filter.Resize( factor ); this->Modified(); };
 
   void Resize( InputImageType * referenceImage )
-  { typedef itk::CastImageFilter< InputImageType, ImageType > CastFilterType;
+  { using CastFilterType = itk::CastImageFilter< InputImageType, ImageType >;
     typename CastFilterType::Pointer castFilter = CastFilterType::New();
     castFilter->SetInput( referenceImage );
     castFilter->Update();

--- a/include/tubeMergeAdjacentImages.h
+++ b/include/tubeMergeAdjacentImages.h
@@ -48,18 +48,18 @@ class MergeAdjacentImages:
   public itk::ProcessObject
 {
 public:
-  /** Standard class typedefs. */
-  typedef MergeAdjacentImages                                  Self;
-  typedef itk::ProcessObject                                   Superclass;
-  typedef itk::SmartPointer< Self >                            Pointer;
-  typedef itk::SmartPointer< const Self >                      ConstPointer;
+  /** Standard class type alias. */
+  using Self = MergeAdjacentImages;
+  using Superclass = itk::ProcessObject;
+  using Pointer = itk::SmartPointer< Self >;
+  using ConstPointer = itk::SmartPointer< const Self >;
 
-  typedef TImage                                               ImageType;
-  typedef typename TImage::PixelType                           PixelType;
+  using ImageType = TImage;
+  using PixelType = typename TImage::PixelType;
 
-  typedef itk::tube::MergeAdjacentImagesFilter< ImageType >    FilterType;
-  typedef typename FilterType::PaddingType                     PaddingType;
-  typedef typename FilterType::TransformType                   TransformType;
+  using FilterType = itk::tube::MergeAdjacentImagesFilter< ImageType >;
+  using PaddingType = typename FilterType::PaddingType;
+  using TransformType = typename FilterType::TransformType;
 
   /** Method for creation through the object factory. */
   itkNewMacro( Self );

--- a/include/tubeRegisterImages.h
+++ b/include/tubeRegisterImages.h
@@ -42,27 +42,27 @@ class RegisterImages:
   public itk::ProcessObject
 {
 public:
-  /** Standard class typedefs. */
-  typedef RegisterImages                  Self;
-  typedef itk::ProcessObject              Superclass;
-  typedef itk::SmartPointer< Self >       Pointer;
-  typedef itk::SmartPointer< const Self > ConstPointer;
+  /** Standard class type alias. */
+  using Self = RegisterImages;
+  using Superclass = itk::ProcessObject;
+  using Pointer = itk::SmartPointer< Self >;
+  using ConstPointer = itk::SmartPointer< const Self >;
 
-  typedef TImage                                             ImageType;
+  using ImageType = TImage;
 
-  typedef itk::ImageToImageRegistrationHelper< ImageType >   FilterType;
+  using FilterType = itk::ImageToImageRegistrationHelper< ImageType >;
 
-  typedef typename FilterType::MaskObjectType       MaskObjectType;
-  typedef typename FilterType::PointType            PointType;
-  typedef typename FilterType::PixelType            PixelType;
+  using MaskObjectType = typename FilterType::MaskObjectType;
+  using PointType = typename FilterType::PointType;
+  using PixelType = typename FilterType::PixelType;
 
-  typedef typename FilterType::LandmarkVectorType   LandmarkVectorType;
+  using LandmarkVectorType = typename FilterType::LandmarkVectorType;
 
-  typedef typename FilterType::RigidTransformType   RigidTransformType;
-  typedef typename FilterType::AffineTransformType  AffineTransformType;
+  using RigidTransformType = typename FilterType::RigidTransformType;
+  using AffineTransformType = typename FilterType::AffineTransformType;
 
-  typedef typename FilterType::MatrixTransformType  MatrixTransformType;
-  typedef typename FilterType::BSplineTransformType BSplineTransformType;
+  using MatrixTransformType = typename FilterType::MatrixTransformType;
+  using BSplineTransformType = typename FilterType::BSplineTransformType;
 
   /** Method for creation through the object factory. */
   itkNewMacro( Self );

--- a/include/tubeResampleImage.h
+++ b/include/tubeResampleImage.h
@@ -42,19 +42,19 @@ class ResampleImage:
   public itk::ProcessObject
 {
 public:
-  /** Standard class typedefs. */
-  typedef ResampleImage                   Self;
-  typedef itk::ProcessObject              Superclass;
-  typedef itk::SmartPointer< Self >       Pointer;
-  typedef itk::SmartPointer< const Self > ConstPointer;
+  /** Standard class type alias. */
+  using Self = ResampleImage;
+  using Superclass = itk::ProcessObject;
+  using Pointer = itk::SmartPointer< Self >;
+  using ConstPointer = itk::SmartPointer< const Self >;
 
-  typedef itk::tube::ReResampleImageFilter< typename TImage::PixelType,
-          TImage::ImageDimension >            FilterType;
+  using FilterType = itk::tube::ReResampleImageFilter< typename TImage::PixelType,
+          TImage::ImageDimension >;
 
-  typedef typename FilterType::ImageType      ImageType;
-  typedef typename ImageType::ConstPointer    ConstImagePointer;
-  typedef typename ImageType::Pointer         ImagePointer;
-  typedef typename FilterType::TransformType  TransformType;
+  using ImageType = typename FilterType::ImageType;
+  using ConstImagePointer = typename ImageType::ConstPointer;
+  using ImagePointer = typename ImageType::Pointer;
+  using TransformType = typename FilterType::TransformType;
 
   /** Method for creation through the object factory. */
   itkNewMacro( Self );

--- a/include/tubeSegmentBinaryImageSkeleton3D.h
+++ b/include/tubeSegmentBinaryImageSkeleton3D.h
@@ -45,18 +45,18 @@ class SegmentBinaryImageSkeleton3D:
   public itk::ProcessObject
 {
 public:
-  /** Standard class typedefs. */
-  typedef SegmentBinaryImageSkeleton3D               Self;
-  typedef itk::ProcessObject                         Superclass;
-  typedef itk::SmartPointer< Self >                  Pointer;
-  typedef itk::SmartPointer< const Self >            ConstPointer;
+  /** Standard class type alias. */
+  using Self = SegmentBinaryImageSkeleton3D;
+  using Superclass = itk::ProcessObject;
+  using Pointer = itk::SmartPointer< Self >;
+  using ConstPointer = itk::SmartPointer< const Self >;
 
-  typedef TImageType                                 ImageType;
+  using ImageType = TImageType;
 
-  typedef itk::tube::BinaryThinningImageFilter3D<
-    TImageType, TImageType >                         FilterType;
+  using FilterType = itk::tube::BinaryThinningImageFilter3D<
+    TImageType, TImageType >;
 
-  typedef typename FilterType::EndPointListType      EndPointListType;
+  using EndPointListType = typename FilterType::EndPointListType;
 
   /** Method for creation through the object factory. */
   itkNewMacro( Self );

--- a/include/tubeSegmentConnectedComponents.h
+++ b/include/tubeSegmentConnectedComponents.h
@@ -41,19 +41,19 @@ class SegmentConnectedComponents:
   public itk::ProcessObject
 {
 public:
-  typedef TImage                                ImageType;
+  using ImageType = TImage;
 
-  typedef TSeedMask                             SeedMaskType;
+  using SeedMaskType = TSeedMask;
 
-  /** Standard class typedefs. */
-  typedef SegmentConnectedComponents            Self;
-  typedef itk::ProcessObject                    Superclass;
-  typedef itk::SmartPointer< Self >             Pointer;
-  typedef itk::SmartPointer< const Self >       ConstPointer;
+  /** Standard class type alias. */
+  using Self = SegmentConnectedComponents;
+  using Superclass = itk::ProcessObject;
+  using Pointer = itk::SmartPointer< Self >;
+  using ConstPointer = itk::SmartPointer< const Self >;
 
 
-  typedef itk::ConnectedComponentImageFilter< ImageType,
-    ImageType, ImageType >                      FilterType;
+  using FilterType = itk::ConnectedComponentImageFilter< ImageType,
+    ImageType, ImageType >;
 
   /** Method for creation through the object factory. */
   itkNewMacro( Self );

--- a/include/tubeSegmentConnectedComponentsUsingParzenPDFs.h
+++ b/include/tubeSegmentConnectedComponentsUsingParzenPDFs.h
@@ -44,31 +44,31 @@ class SegmentConnectedComponentsUsingParzenPDFs:
   public itk::ProcessObject
 {
 public:
-  typedef TImage                                InputImageType;
-  typedef typename TImage::PixelType            InputImagePixelType;
+  using InputImageType = TImage;
+  using InputImagePixelType = typename TImage::PixelType;
 
-  typedef TLabelMap                             LabelMapType;
-  typedef typename TLabelMap::PixelType         LabelMapPixelType;
+  using LabelMapType = TLabelMap;
+  using LabelMapPixelType = typename TLabelMap::PixelType;
 
-  /** Standard class typedefs. */
-  typedef SegmentConnectedComponentsUsingParzenPDFs  Self;
-  typedef itk::ProcessObject                         Superclass;
-  typedef itk::SmartPointer< Self >                  Pointer;
-  typedef itk::SmartPointer< const Self >            ConstPointer;
+  /** Standard class type alias. */
+  using Self = SegmentConnectedComponentsUsingParzenPDFs;
+  using Superclass = itk::ProcessObject;
+  using Pointer = itk::SmartPointer< Self >;
+  using ConstPointer = itk::SmartPointer< const Self >;
 
 
-  typedef itk::tube::PDFSegmenterParzen< InputImageType,
-    LabelMapType >                                  FilterType;
+  using FilterType = itk::tube::PDFSegmenterParzen< InputImageType,
+    LabelMapType >;
 
-  typedef typename FilterType::PDFImageType            PDFImageType;
-  //typedef typename FilterType::LabeledFeatureSpaceType LabeledFeatureSpaceType;
+  using PDFImageType = typename FilterType::PDFImageType;
+  //using LabeledFeatureSpaceType = typename FilterType::LabeledFeatureSpaceType;
 
-  typedef typename FilterType::ProbabilityImageType  ProbabilityImageType;
-  typedef typename FilterType::ProbabilityVectorType ProbabilityVectorType;
-  typedef typename FilterType::FeatureVectorType     FeatureVectorType;
-  typedef typename FilterType::VectorDoubleType      VectorDoubleType;
-  typedef typename FilterType::VectorUIntType        VectorUIntType;
-  typedef typename FilterType::ObjectIdListType      ObjectIdListType;
+  using ProbabilityImageType = typename FilterType::ProbabilityImageType;
+  using ProbabilityVectorType = typename FilterType::ProbabilityVectorType;
+  using FeatureVectorType = typename FilterType::FeatureVectorType;
+  using VectorDoubleType = typename FilterType::VectorDoubleType;
+  using VectorUIntType = typename FilterType::VectorUIntType;
+  using ObjectIdListType = typename FilterType::ObjectIdListType;
 
   /** Method for creation through the object factory. */
   itkNewMacro( Self );
@@ -174,8 +174,7 @@ private:
   void SetInput( const DataObjectIdentifierType &, itk::DataObject * ) override
     {};
 
-  typedef itk::tube::FeatureVectorGenerator< InputImageType >
-                                                  FeatureVectorGeneratorType;
+  using FeatureVectorGeneratorType = itk::tube::FeatureVectorGenerator< InputImageType >;
 
   typename FilterType::Pointer                    m_Filter;
   typename FeatureVectorGeneratorType::Pointer    m_FVGenerator;

--- a/include/tubeSegmentTubeUsingMinimalPath.h
+++ b/include/tubeSegmentTubeUsingMinimalPath.h
@@ -45,20 +45,20 @@ class SegmentTubeUsingMinimalPath:
   public itk::ProcessObject
 {
 public:
-  /** Standard class typedefs. */
-  typedef SegmentTubeUsingMinimalPath               Self;
-  typedef itk::ProcessObject                         Superclass;
-  typedef itk::SmartPointer< Self >                  Pointer;
-  typedef itk::SmartPointer< const Self >            ConstPointer;
+  /** Standard class type alias. */
+  using Self = SegmentTubeUsingMinimalPath;
+  using Superclass = itk::ProcessObject;
+  using Pointer = itk::SmartPointer< Self >;
+  using ConstPointer = itk::SmartPointer< const Self >;
 
-  typedef itk::tube::SegmentTubeUsingMinimalPathFilter
-    < Dimension, TInputPixel >                       FilterType;
+  using FilterType = itk::tube::SegmentTubeUsingMinimalPathFilter
+    < Dimension, TInputPixel >;
 
-  typedef typename FilterType::InputImageType         InputImageType;
-  typedef typename InputImageType::Pointer            InputImagePointer;
-  typedef typename FilterType::InputSpatialObjectType TubeGroupType;
-  typedef typename TubeGroupType::Pointer             TubeGroupPointer;
-  typedef typename FilterType::PointType              PointType;
+  using InputImageType = typename FilterType::InputImageType;
+  using InputImagePointer = typename InputImageType::Pointer;
+  using TubeGroupType = typename FilterType::InputSpatialObjectType;
+  using TubeGroupPointer = typename TubeGroupType::Pointer;
+  using PointType = typename FilterType::PointType;
 
 
   /** Method for creation through the object factory. */

--- a/include/tubeSegmentTubes.h
+++ b/include/tubeSegmentTubes.h
@@ -43,29 +43,29 @@ class SegmentTubes:
   public itk::ProcessObject
 {
 public:
-  /** Standard class typedefs. */
-  typedef SegmentTubes                                 Self;
-  typedef itk::ProcessObject                           Superclass;
-  typedef itk::SmartPointer< Self >                    Pointer;
-  typedef itk::SmartPointer< const Self >              ConstPointer;
+  /** Standard class type alias. */
+  using Self = SegmentTubes;
+  using Superclass = itk::ProcessObject;
+  using Pointer = itk::SmartPointer< Self >;
+  using ConstPointer = itk::SmartPointer< const Self >;
 
-  typedef TInputImage                                  ImageType;
-  typedef typename ImageType::PixelType                PixelType;
-  typedef typename ImageType::IndexType                IndexType;
+  using ImageType = TInputImage;
+  using PixelType = typename ImageType::PixelType;
+  using IndexType = typename ImageType::IndexType;
 
-  typedef itk::tube::TubeExtractor< ImageType >        FilterType;
-  typedef itk::tube::RidgeExtractor< ImageType >       RidgeFilterType;
-  typedef itk::tube::RadiusExtractor3< ImageType >     RadiusFilterType;
+  using FilterType = itk::tube::TubeExtractor< ImageType >;
+  using RidgeFilterType = itk::tube::RidgeExtractor< ImageType >;
+  using RadiusFilterType = itk::tube::RadiusExtractor3< ImageType >;
 
-  typedef typename FilterType::TubeMaskImageType       TubeMaskImageType;
-  typedef typename FilterType::TubeType                TubeType;
-  typedef typename FilterType::TubeGroupType           TubeGroupType;
+  using TubeMaskImageType = typename FilterType::TubeMaskImageType;
+  using TubeType = typename FilterType::TubeType;
+  using TubeGroupType = typename FilterType::TubeGroupType;
 
-  typedef typename FilterType::ContinuousIndexType     ContinuousIndexType;
-  typedef std::vector< ContinuousIndexType >           ContinuousIndexListType;
-  typedef typename FilterType::RadiusListType          RadiusListType;
-  typedef typename FilterType::PointType               PointType;
-  typedef std::vector< PointType >                     PointListType;
+  using ContinuousIndexType = typename FilterType::ContinuousIndexType;
+  using ContinuousIndexListType = std::vector< ContinuousIndexType >;
+  using RadiusListType = typename FilterType::RadiusListType;
+  using PointType = typename FilterType::PointType;
+  using PointListType = std::vector< PointType >;
 
   /** Method for creation through the object factory. */
   itkNewMacro( Self );

--- a/include/tubeSegmentUsingOtsuThreshold.h
+++ b/include/tubeSegmentUsingOtsuThreshold.h
@@ -44,21 +44,21 @@ class SegmentUsingOtsuThreshold:
   public itk::ProcessObject
 {
 public:
-  /** Standard class typedefs. */
-  typedef SegmentUsingOtsuThreshold                 Self;
-  typedef itk::ProcessObject                        Superclass;
-  typedef itk::SmartPointer< Self >                 Pointer;
-  typedef itk::SmartPointer< const Self >           ConstPointer;
+  /** Standard class type alias. */
+  using Self = SegmentUsingOtsuThreshold;
+  using Superclass = itk::ProcessObject;
+  using Pointer = itk::SmartPointer< Self >;
+  using ConstPointer = itk::SmartPointer< const Self >;
 
-  typedef TImageType                                InputImageType;
-  typedef TMaskType                                 MaskImageType;
-  typedef MaskImageType                             OutputImageType;
+  using InputImageType = TImageType;
+  using MaskImageType = TMaskType;
+  using OutputImageType = MaskImageType;
 
-  typedef typename InputImageType::PixelType        InputPixelType;
-  typedef typename MaskImageType::PixelType         MaskPixelType;
+  using InputPixelType = typename InputImageType::PixelType;
+  using MaskPixelType = typename MaskImageType::PixelType;
 
-  typedef itk::OtsuThresholdImageFilter< InputImageType,
-    OutputImageType >                               FilterType;
+  using FilterType = itk::OtsuThresholdImageFilter< InputImageType,
+    OutputImageType >;
 
   /** Method for creation through the object factory. */
   itkNewMacro( Self );

--- a/include/tubeShrinkImageWithBlending.h
+++ b/include/tubeShrinkImageWithBlending.h
@@ -41,11 +41,11 @@ class ShrinkImageWithBlending:
   public itk::ProcessObject
 {
 public:
-  /** Standard class typedefs. */
-  typedef ShrinkImageWithBlending                         Self;
-  typedef itk::ProcessObject                              Superclass;
-  typedef itk::SmartPointer< Self >                       Pointer;
-  typedef itk::SmartPointer< const Self >                 ConstPointer;
+  /** Standard class type alias. */
+  using Self = ShrinkImageWithBlending;
+  using Superclass = itk::ProcessObject;
+  using Pointer = itk::SmartPointer< Self >;
+  using ConstPointer = itk::SmartPointer< const Self >;
 
   /** Method for creation through the object factory. */
   itkNewMacro( Self );
@@ -55,17 +55,17 @@ public:
 
 
   /** Typedef to images */
-  typedef TInputImage                                InputImageType;
-  typedef TOutputImage                               OutputImageType;
-  typedef typename TInputImage::IndexType            InputIndexType;
-  typedef typename TInputImage::SizeType             InputSizeType;
+  using InputImageType = TInputImage;
+  using OutputImageType = TOutputImage;
+  using InputIndexType = typename TInputImage::IndexType;
+  using InputSizeType = typename TInputImage::SizeType;
 
-  typedef itk::tube::ShrinkWithBlendingImageFilter< InputImageType,
-    OutputImageType >                                FilterType;
+  using FilterType = itk::tube::ShrinkWithBlendingImageFilter< InputImageType,
+    OutputImageType >;
 
-  typedef typename FilterType::PointImagePixelType   PointImagePixelType;
-  typedef typename FilterType::PointImageType        PointImageType;
-  typedef typename FilterType::ShrinkFactorsType     ShrinkFactorsType;
+  using PointImagePixelType = typename FilterType::PointImagePixelType;
+  using PointImageType = typename FilterType::PointImageType;
+  using ShrinkFactorsType = typename FilterType::ShrinkFactorsType;
 
   /** Set the shrink factors. Values are clamped to
    * a minimum value of 1. Default is 1 for all dimensions. */

--- a/include/tubeTubeMath.h
+++ b/include/tubeTubeMath.h
@@ -44,18 +44,18 @@ class TubeMath:
   public itk::ProcessObject
 {
 public:
-  /** Standard class typedefs. */
-  typedef TubeMath                                   Self;
-  typedef itk::ProcessObject                         Superclass;
-  typedef itk::SmartPointer< Self >                  Pointer;
-  typedef itk::SmartPointer< const Self >            ConstPointer;
+  /** Standard class type alias. */
+  using Self = TubeMath;
+  using Superclass = itk::ProcessObject;
+  using Pointer = itk::SmartPointer< Self >;
+  using ConstPointer = itk::SmartPointer< const Self >;
 
-  typedef tube::TubeMathFilters< DimensionT, ImagePixelT >  FilterType;
+  using FilterType = tube::TubeMathFilters< DimensionT, ImagePixelT >;
 
-  typedef typename FilterType::TubeGroupType         TubeGroupType;
-  typedef typename FilterType::TubeType              TubeType;
-  typedef typename FilterType::ImageType             ImageType;
-  typedef typename FilterType::FloatImageType        FloatImageType;
+  using TubeGroupType = typename FilterType::TubeGroupType;
+  using TubeType = typename FilterType::TubeType;
+  using ImageType = typename FilterType::ImageType;
+  using FloatImageType = typename FilterType::FloatImageType;
 
   /** Method for creation through the object factory. */
   itkNewMacro( Self );

--- a/include/tubeWrite4DImageFrom3DImages.h
+++ b/include/tubeWrite4DImageFrom3DImages.h
@@ -43,13 +43,13 @@ class Write4DImageFrom3DImages:
   public itk::ProcessObject
 {
 public:
-  /** Standard class typedefs. */
-  typedef Write4DImageFrom3DImages                     Self;
-  typedef itk::ProcessObject                           Superclass;
-  typedef itk::SmartPointer< Self >                    Pointer;
-  typedef itk::SmartPointer< const Self >              ConstPointer;
+  /** Standard class type alias. */
+  using Self = Write4DImageFrom3DImages;
+  using Superclass = itk::ProcessObject;
+  using Pointer = itk::SmartPointer< Self >;
+  using ConstPointer = itk::SmartPointer< const Self >;
 
-  typedef InputImageT                                  InputImageType;
+  using InputImageType = InputImageT;
 
   /** Method for creation through the object factory. */
   itkNewMacro( Self );
@@ -90,7 +90,7 @@ private:
   void SetInput( const DataObjectIdentifierType &, itk::DataObject * ) 
     override {};
 
-  typedef itk::Image< typename InputImageType::PixelType, 4 >  OutputImageType;
+  using OutputImageType = itk::Image< typename InputImageType::PixelType, 4 >;
 
   unsigned int                       m_NumberOfInputImages;
   typename OutputImageType::Pointer  m_OutputImage;

--- a/include/tubeWrite4DImageFrom3DImages.hxx
+++ b/include/tubeWrite4DImageFrom3DImages.hxx
@@ -133,7 +133,7 @@ void
 Write4DImageFrom3DImages< InputImageT >::
 Update()
 {
-  typedef itk::ImageFileWriter< OutputImageType >  WriterType;
+  using WriterType = itk::ImageFileWriter< OutputImageType >;
   typename WriterType::Pointer writer = WriterType::New();
   writer->SetInput( m_OutputImage );
   writer->SetFileName( m_FileName );

--- a/include/tubeWriteTubesAsPolyData.h
+++ b/include/tubeWriteTubesAsPolyData.h
@@ -41,11 +41,11 @@ class WriteTubesAsPolyData:
   public itk::ProcessObject
 {
 public:
-  /** Standard class typedefs. */
-  typedef WriteTubesAsPolyData                         Self;
-  typedef itk::ProcessObject                           Superclass;
-  typedef itk::SmartPointer< Self >                    Pointer;
-  typedef itk::SmartPointer< const Self >              ConstPointer;
+  /** Standard class type alias. */
+  using Self = WriteTubesAsPolyData;
+  using Superclass = itk::ProcessObject;
+  using Pointer = itk::SmartPointer< Self >;
+  using ConstPointer = itk::SmartPointer< const Self >;
 
   /** Method for creation through the object factory. */
   itkNewMacro( Self );
@@ -56,8 +56,8 @@ public:
   /***/
   /***/
   /***/
-  typedef itk::GroupSpatialObject<3>       GroupSpatialObjectType;
-  typedef itk::TubeSpatialObject<3>        TubeSpatialObjectType;
+  using GroupSpatialObjectType = itk::GroupSpatialObject<3>;
+  using TubeSpatialObjectType = itk::TubeSpatialObject<3>;
 
   /** Set the source image. */
   void SetInput( GroupSpatialObjectType * grp )

--- a/prefer-type-alias-over-typedef.sh
+++ b/prefer-type-alias-over-typedef.sh
@@ -1,0 +1,37 @@
+cat > ./typdef_vim_script.vim << EOF
+:%s/typedef  *\(.*<\_s*.*[>,]\_s*.*[><,]\_s*.*[><,]\_s*.*[><,]\_s*.*[><,]\_s*.*[^>]>\)\_s *\([A-Za-z0-9][A-Za-z0-9]*\);\{-};/using \2 = \1;/ge
+:%s/typedef  *\(.*<\_s*.*[><,]\_s*.*[><,]\_s*.*[><,]\_s*.*[><,]\_s*.*[^>]>\)\_s *\([A-Za-z0-9][A-Za-z0-9]*\);\{-};/using \2 = \1;/ge
+:%s/typedef  *\(.*<\_s*.*[><,]\_s*.*[><,]\_s*.*[><,]\_s*.*[^>]>\)\_s *\([A-Za-z0-9][A-Za-z0-9]*\);\{-};/using \2 = \1;/ge
+:%s/typedef  *\(.*<\_s*.*[><,]\_s*.*[><,]\_s*.*[^>]>\)\_s *\([A-Za-z0-9][A-Za-z0-9]*\);\{-};/using \2 = \1;/ge
+:%s/typedef  *\(.*<\_s*.*[><,]\_s*.*[^>]>\)\_s *\([A-Za-z0-9][A-Za-z0-9]*\);\{-};/using \2 = \1;/ge
+:%s/typedef  *\(.*<\_s*.*[^>]>\)\_s *\([A-Za-z0-9][A-Za-z0-9]*\);\{-};/using \2 = \1;/ge
+
+:%s/\*\(.*\) typedef\(s*\)\(.*\)\*/*\1 type alias\3*/ge
+:%s/\*\*\(.*\) typedef\(s*\)\(.*\)/**\1 type alias\3/ge
+:%s/\/\/\(.*\)typedefs/\/\/\1type alias/ge
+
+:%s/typedef  *\(.*<\_s*.*,\_s*.*,\_s*[^>]*>\)  *\([A-Za-z0-9][A-Za-z0-9]*\);\{-};/using \2 = \1;/ge
+:%s/\/\/\(.*\)typedefs/\/\/\1type alias/ge
+:%s/typedef  *\(.*<\_s*.*[>,]\_s.*[^>]>\)\_s *\([A-Za-z0-9][A-Za-z0-9]*\);\{-};/using \2 = \1;/ge
+:%s/\*\(.*\) typedef\(s*\)\(.*\)\*/*\1 type alias\3*/ge
+:%s/\*\*\(.*\) typedef\(s*\)\(.*\)/**\1 type alias\3/ge
+:%s/typedef  *\(.*[><,]*\_s*.*[><,]\_s.*[^>]>\)\_s *\([A-Za-z0-9][A-Za-z0-9]*\);\{-};/using \2 = \1;/ge
+:%s/typedef  *\(.*<\_s*.*[>,]\_s*.*[><,]\_s*.*[><,]\_s*.*[^>]>\)\_s *\([A-Za-z0-9][A-Za-z0-9]*\);\{-};/using \2 = \1;/ge
+:%s/typedef  *\(.*<\_s*.*[>,]\_s*.*[><,]\_s*.*[><,]\_s*.*[><,]\_s*.*[><,]\_s*.*[^>]>\)\_s *\([A-Za-z0-9][A-Za-z0-9]*\);\{-};/using \2 = \1;/ge
+
+:%s/typedef  *\(.*\) * \([a-zA-Z0-9]*\);/using \2 = \1;/g
+:%s/typedef  *\(.*<\_s*.*,\n[^>]*>\)  *\([A-Za-z0-9][A-Za-z0-9]*\);\{-};/using \2 = \1;/ge
+:%s/typedef  *\(.*<\_s*.*,.*>\{-}>\)  *\([A-Za-z0-9][A-Za-z0-9]*\);\{-};/using \2 = \1;/ge
+:%s/\(  *\)typedef  *\(.*<.*>\)\_s\(  *\)\([A-Za-z0-9][A-Za-z0-9]*\);\{-};/\1using \4 =\r\1    \2;/ge
+:%s/typedef support\(\.*\)/type alias support/ge
+
+:%s/  *;/;/ge
+:w
+:q
+EOF
+
+for ff in $(git grep -l "typedef" |fgrep -v ThirdParty |head -n 1500); do
+   vim -S ./typdef_vim_script.vim $ff;
+done
+
+rm ./typdef_vim_script.vim

--- a/src/Common/tubeIndent.h
+++ b/src/Common/tubeIndent.h
@@ -38,9 +38,9 @@ class Indent
 {
 public:
 
-  typedef Indent        Self;
-  typedef Self *        Pointer;
-  typedef const Self *  ConstPointer;
+  using Self = Indent;
+  using Pointer = Self *;
+  using ConstPointer = const Self *;
 
   /** Constructor with initial level of indentation. */
   Indent( unsigned int indent = 0 )

--- a/src/Common/tubeObject.h
+++ b/src/Common/tubeObject.h
@@ -39,9 +39,9 @@ class Object
 {
 public:
 
-  typedef Object        Self;
-  typedef Self *        Pointer;
-  typedef const Self *  ConstPointer;
+  using Self = Object;
+  using Pointer = Self *;
+  using ConstPointer = const Self *;
 
   tubeTypeMacroNoOverride( Object );
 

--- a/src/Common/tubeTestMain.h
+++ b/src/Common/tubeTestMain.h
@@ -43,8 +43,8 @@ limitations under the License.
 
 #define ITK_TEST_DIMENSION_MAX 6
 
-typedef int ( *MainFuncPointer )( int argc, char * argv[] );
-std::map< std::string, MainFuncPointer > StringToTestFunctionMap;
+using StringToTestFunctionMap = int ( *MainFuncPointer )( int argc, char * argv[] );
+std::map< std::string, MainFuncPointer >;
 
 #define REGISTER_TEST( test ) \
 extern int test( int argc, char * argv[] ); \
@@ -81,7 +81,7 @@ int main( int argc, char * argv[] )
   unsigned int numberOfPixelsTolerance = 0;
   unsigned int radiusTolerance = 0;
 
-  typedef std::pair< char *, char * > ComparePairType;
+  using ComparePairType = std::pair< char *, char * >;
   std::vector< ComparePairType > compareList;
 
   itk::OutputWindow::SetInstance( itk::TextOutput::New() );
@@ -246,10 +246,10 @@ int RegressionTestImage( const char * testImageFilename,
 {
   // Use the factory mechanism to read the test
   // and baseline files and convert them to double
-  typedef itk::Image< double, ITK_TEST_DIMENSION_MAX >        ImageType;
-  typedef itk::Image< unsigned char, ITK_TEST_DIMENSION_MAX > OutputType;
-  typedef itk::Image< unsigned char, 2 >                      DiffOutputType;
-  typedef itk::ImageFileReader< ImageType >                   ReaderType;
+  using ImageType = itk::Image< double, ITK_TEST_DIMENSION_MAX >;
+  using OutputType = itk::Image< unsigned char, ITK_TEST_DIMENSION_MAX >;
+  using DiffOutputType = itk::Image< unsigned char, 2 >;
+  using ReaderType = itk::ImageFileReader< ImageType >;
 
   // Read the baseline file
   ReaderType::Pointer baselineReader = ReaderType::New();
@@ -298,7 +298,7 @@ int RegressionTestImage( const char * testImageFilename,
     }
 
   // Now compare the two images
-  typedef itk::tube::DifferenceImageFilter<ImageType, ImageType> DiffType;
+  using DiffType = itk::tube::DifferenceImageFilter<ImageType, ImageType>;
   DiffType::Pointer diff = DiffType::New();
   diff->SetValidInput( baselineReader->GetOutput() );
   diff->SetTestInput( testReader->GetOutput() );
@@ -312,14 +312,10 @@ int RegressionTestImage( const char * testImageFilename,
   // if there are discrepancies, create an difference image
   if( ( status > numberOfPixelsTolerance ) && reportErrors )
     {
-    typedef itk::RescaleIntensityImageFilter<ImageType, OutputType>
-      RescaleType;
-    typedef itk::ExtractImageFilter<OutputType, DiffOutputType>
-      ExtractType;
-    typedef itk::ImageFileWriter<DiffOutputType>
-      WriterType;
-    typedef itk::ImageRegion<ITK_TEST_DIMENSION_MAX>
-      RegionType;
+    using RescaleType = itk::RescaleIntensityImageFilter<ImageType, OutputType>;
+    using ExtractType = itk::ExtractImageFilter<OutputType, DiffOutputType>;
+    using WriterType = itk::ImageFileWriter<DiffOutputType>;
+    using RegionType = itk::ImageRegion<ITK_TEST_DIMENSION_MAX>;
 
     OutputType::SizeType size;
     size.Fill( 0 );

--- a/src/Filtering/itkGeneralizedDistanceTransformImageFilter.h
+++ b/src/Filtering/itkGeneralizedDistanceTransformImageFilter.h
@@ -129,11 +129,11 @@ class GeneralizedDistanceTransformImageFilter
 : public ImageToImageFilter<TFunctionImage, TDistanceImage>
 {
 public:
-  /** Standard class typedefs. */
-  typedef GeneralizedDistanceTransformImageFilter            Self;
-  typedef ImageToImageFilter<TFunctionImage, TDistanceImage> Superclass;
-  typedef SmartPointer<Self>                                 Pointer;
-  typedef SmartPointer<const Self>                           ConstPointer;
+  /** Standard class type alias. */
+  using Self = GeneralizedDistanceTransformImageFilter;
+  using Superclass = ImageToImageFilter<TFunctionImage, TDistanceImage>;
+  using Pointer = SmartPointer<Self>;
+  using ConstPointer = SmartPointer<const Self>;
 
   /** Method for creation through the object factory */
   itkNewMacro( Self );
@@ -143,17 +143,17 @@ public:
     ImageToImageFilter );
 
   /** Types and pointer types for the images and their content. */
-  typedef TFunctionImage                                  FunctionImageType;
-  typedef TDistanceImage                                  DistanceImageType;
-  typedef TLabelImage                                     LabelImageType;
-  typedef typename TFunctionImage::SpacingType::ValueType SpacingType;
+  using FunctionImageType = TFunctionImage;
+  using DistanceImageType = TDistanceImage;
+  using LabelImageType = TLabelImage;
+  using SpacingType = typename TFunctionImage::SpacingType::ValueType;
 
-  typedef typename FunctionImageType::ConstPointer   FunctionImageConstPointer;
-  typedef typename DistanceImageType::Pointer        DistanceImagePointer;
-  typedef typename LabelImageType::Pointer           LabelImagePointer;
-  typedef typename FunctionImageType::IndexValueType IndexValueType;
-  typedef typename LabelImageType::PixelType         LabelPixelType;
-  typedef typename DistanceImageType::PixelType      DistancePixelType;
+  using FunctionImageConstPointer = typename FunctionImageType::ConstPointer;
+  using DistanceImagePointer = typename DistanceImageType::Pointer;
+  using LabelImagePointer = typename LabelImageType::Pointer;
+  using IndexValueType = typename FunctionImageType::IndexValueType;
+  using LabelPixelType = typename LabelImageType::PixelType;
+  using DistancePixelType = typename DistanceImageType::PixelType;
 
   /** Set if a voronoi map should be created. */
   void SetCreateVoronoiMap( bool );
@@ -236,7 +236,7 @@ private:
   // functions and types help with this.
 
   /** The index positions on which a parabola apex can be. */
-  typedef typename DistanceImageType::IndexValueType AbscissaIndexType;
+  using AbscissaIndexType = typename DistanceImageType::IndexValueType;
 
   /** A parabola p( x ) = ( x-is )^2+y is defined by the apex abscissa
    * index i and the apex height y. The label is additional information
@@ -252,7 +252,7 @@ private:
 
   /** The envelope is a vector of parabolas, ordered from left to right by
    * their abscissa ordinate. */
-  typedef std::vector<Parabola> Parabolas;
+  using Parabolas = std::vector<Parabola>;
 
   /** Compute the intersection abscissa of two parabolas p and q. Their apex
    * ordinates have to be different.

--- a/src/Filtering/itkGeneralizedDistanceTransformImageFilter.txx
+++ b/src/Filtering/itkGeneralizedDistanceTransformImageFilter.txx
@@ -308,10 +308,10 @@ GeneralizedDistanceTransformImageFilter<
   //
   // To make better use of L1 cache, a few scanlines are read and written in
   // parallel for dimensions 1 and upward. See below for details.
-  typedef itk::ImageLinearIteratorWithIndex<DistanceImageType> DIt;
+  using DIt = itk::ImageLinearIteratorWithIndex<DistanceImageType>;
   DIt distanceIt(distance, distance->GetRequestedRegion());
 
-  typedef itk::ImageLinearIteratorWithIndex<LabelImageType> LIt;
+  using LIt = itk::ImageLinearIteratorWithIndex<LabelImageType>;
   LIt voronoiMapIt;
   if (this->m_CreateVoronoiMap)
     {
@@ -323,7 +323,7 @@ GeneralizedDistanceTransformImageFilter<
   // Compute the maximal extent in number of pixels, rounded up to fill full
   // cache lines.
   // This is used to set up various vectors, buffers, and a division table
-  typedef typename DistanceImageType::SizeValueType DistSizeValueType;
+  using DistSizeValueType = typename DistanceImageType::SizeValueType;
   DistSizeValueType maxSize = 0;
 
   for (unsigned int d = 0; d < FunctionImageType::ImageDimension; ++d)
@@ -605,7 +605,7 @@ GeneralizedDistanceTransformImageFilter<
             }
           else
             {
-            // No wait, this one! ;-)
+            // No wait, this one!;-)
             for (size_t line = 0; line < parallelLines; ++line, ++offset)
               {
               addParabola(

--- a/src/Filtering/itkImageRegionSplitter.h
+++ b/src/Filtering/itkImageRegionSplitter.h
@@ -68,11 +68,11 @@ template< unsigned int VImageDimension >
 class ImageRegionSplitter:public ImageRegionSplitterBase
 {
 public:
-  /** Standard class typedefs. */
-  typedef ImageRegionSplitter        Self;
-  typedef ImageRegionSplitterBase    Superclass;
-  typedef SmartPointer< Self >       Pointer;
-  typedef SmartPointer< const Self > ConstPointer;
+  /** Standard class type alias. */
+  using Self = ImageRegionSplitter;
+  using Superclass = ImageRegionSplitterBase;
+  using Pointer = SmartPointer< Self >;
+  using ConstPointer = SmartPointer< const Self >;
 
   /** Method for creation through the object factory. */
   itkNewMacro( Self );
@@ -87,15 +87,15 @@ public:
   static unsigned int GetImageDimension()
     { return VImageDimension; }
 
-  /** Index typedef support. An index is used to access pixel values. */
-  typedef Index< VImageDimension >           IndexType;
+  /** Index type alias support. An index is used to access pixel values. */
+  using IndexType = Index< VImageDimension >;
 
-  /** Size typedef support. A size is used to define region bounds. */
-  typedef Size< VImageDimension >          SizeType;
-  typedef typename SizeType::SizeValueType SizeValueType;
+  /** Size type alias support. A size is used to define region bounds. */
+  using SizeType = Size< VImageDimension >;
+  using SizeValueType = typename SizeType::SizeValueType;
 
-  /** Region typedef support.   */
-  typedef ImageRegion< VImageDimension > RegionType;
+  /** Region type alias support.   */
+  using RegionType = ImageRegion< VImageDimension >;
 
   /** How many pieces can the specifed region be split? A given region
    * cannot always be divided into the requested number of pieces.  For

--- a/src/Filtering/itktubeAnisotropicCoherenceEnhancingDiffusionImageFilter.h
+++ b/src/Filtering/itktubeAnisotropicCoherenceEnhancingDiffusionImageFilter.h
@@ -60,14 +60,13 @@ class AnisotropicCoherenceEnhancingDiffusionImageFilter
   : public AnisotropicDiffusionTensorImageFilter< TInputImage, TOutputImage >
 {
 public:
-  /** Standard class typedefs */
-  typedef AnisotropicCoherenceEnhancingDiffusionImageFilter Self;
+  /** Standard class type alias */
+  using Self = AnisotropicCoherenceEnhancingDiffusionImageFilter;
 
-  typedef AnisotropicDiffusionTensorImageFilter<TInputImage, TOutputImage>
-                                                           Superclass;
+  using Superclass = AnisotropicDiffusionTensorImageFilter<TInputImage, TOutputImage>;
 
-  typedef SmartPointer< Self >                             Pointer;
-  typedef SmartPointer< const Self >                       ConstPointer;
+  using Pointer = SmartPointer< Self >;
+  using ConstPointer = SmartPointer< const Self >;
 
 
   /** Method for creation through the object factory */
@@ -77,43 +76,39 @@ public:
   itkTypeMacro( AnisotropicCoherenceEnhancingDiffusionImageFilter,
                 ImageToImageFilter );
 
-  /** Convenient typedefs */
-  typedef typename Superclass::InputImageType  InputImageType;
-  typedef typename Superclass::OutputImageType OutputImageType;
-  typedef typename Superclass::PixelType       PixelType;
+  /** Convenient type alias */
+  using InputImageType = typename Superclass::InputImageType;
+  using OutputImageType = typename Superclass::OutputImageType;
+  using PixelType = typename Superclass::PixelType;
 
   typedef typename Superclass::DiffusionTensorImageType
                                                 DiffusionTensorImageType;
 
   // Structure tensor type
-  typedef StructureTensorRecursiveGaussianImageFilter < InputImageType >
-                                                StructureTensorFilterType;
+  using StructureTensorFilterType = StructureTensorRecursiveGaussianImageFilter < InputImageType >;
 
   /** Dimensionality of input and output data is assumed to be the same.
    * It is inherited from the superclass. */
   itkStaticConstMacro( ImageDimension, unsigned int,
                        Superclass::ImageDimension );
 
-  typedef itk::Matrix<double, ImageDimension, ImageDimension> MatrixType;
+  using MatrixType = itk::Matrix<double, ImageDimension, ImageDimension>;
 
   // Define image of matrix pixel type
-  typedef itk::Image< MatrixType, ImageDimension>  OutputMatrixImageType;
+  using OutputMatrixImageType = itk::Image< MatrixType, ImageDimension>;
 
   // Define the symmetric tensor pixel type
-  typedef itk::SymmetricSecondRankTensor< double, ImageDimension>
-                                                         TensorPixelType;
-  typedef itk::Image< TensorPixelType, ImageDimension>
-                                                         TensorImageType;
+  using TensorPixelType = itk::SymmetricSecondRankTensor< double, ImageDimension>;
+  using TensorImageType = itk::Image< TensorPixelType, ImageDimension>;
 
    // Define the type for storing the eigenvalue
-  typedef itk::FixedArray< double, ImageDimension >      EigenValueArrayType;
+  using EigenValueArrayType = itk::FixedArray< double, ImageDimension >;
 
   // Declare the types of the output images
-  typedef itk::Image< EigenValueArrayType, ImageDimension >
-                                                  EigenAnalysisOutputImageType;
+  using EigenAnalysisOutputImageType = itk::Image< EigenValueArrayType, ImageDimension >;
 
   /** The container type for the update buffer. */
-  typedef OutputImageType UpdateBufferType;
+  using UpdateBufferType = OutputImageType;
 
   /** Define diffusion image nbd type */
   typedef typename Superclass::DiffusionTensorNeighborhoodType

--- a/src/Filtering/itktubeAnisotropicCoherenceEnhancingDiffusionImageFilter.hxx
+++ b/src/Filtering/itktubeAnisotropicCoherenceEnhancingDiffusionImageFilter.hxx
@@ -80,19 +80,15 @@ AnisotropicCoherenceEnhancingDiffusionImageFilter<TInputImage, TOutputImage>
   StructureTensorFilter->Update();
 
   // Step 1.2: Identify the eigenvectors of the structure tensor
-  typedef  Matrix< double, 3, 3>
-    EigenVectorMatrixType;
-  typedef  Image< EigenVectorMatrixType, 3>
-    EigenVectorImageType;
-  typedef  typename itk::Image< EigenValueArrayType, 3>
-    EigenValueImageType;
+  using EigenVectorMatrixType = Matrix< double, 3, 3>;
+  using EigenVectorImageType = Image< EigenVectorMatrixType, 3>;
+  using EigenValueImageType = typename itk::Image< EigenValueArrayType, 3>;
 
   typedef  typename StructureTensorFilterType::OutputImageType
     SymmetricSecondRankTensorImageType;
-  typedef  SymmetricEigenVectorAnalysisImageFilter<
+  using EigenVectorAnalysisFilterType = SymmetricEigenVectorAnalysisImageFilter<
     SymmetricSecondRankTensorImageType, EigenValueImageType,
-    EigenVectorImageType>
-    EigenVectorAnalysisFilterType;
+    EigenVectorImageType>;
 
   typename EigenVectorAnalysisFilterType::Pointer eigenVectorAnalysisFilter
     = EigenVectorAnalysisFilterType::New();
@@ -105,9 +101,8 @@ AnisotropicCoherenceEnhancingDiffusionImageFilter<TInputImage, TOutputImage>
   eigenVectorAnalysisFilter->Update();
 
   //Step 1.3: Compute the eigenvalues
-  typedef itk::SymmetricEigenAnalysisImageFilter<
-    SymmetricSecondRankTensorImageType, EigenValueImageType>
-    EigenAnalysisFilterType;
+  using EigenAnalysisFilterType = itk::SymmetricEigenAnalysisImageFilter<
+    SymmetricSecondRankTensorImageType, EigenValueImageType>;
 
   typename EigenAnalysisFilterType::Pointer eigenAnalysisFilter
     = EigenAnalysisFilterType::New();
@@ -135,8 +130,7 @@ AnisotropicCoherenceEnhancingDiffusionImageFilter<TInputImage, TOutputImage>
   eigenVectorImageIterator.GoToBegin();
 
   //Iterator for the diffusion tensor image
-  typedef itk::ImageRegionIterator< DiffusionTensorImageType >
-    DiffusionTensorIteratorType;
+  using DiffusionTensorIteratorType = itk::ImageRegionIterator< DiffusionTensorImageType >;
   DiffusionTensorIteratorType it( this->GetDiffusionTensorImage(),
     this->GetDiffusionTensorImage()->GetLargestPossibleRegion() );
 

--- a/src/Filtering/itktubeAnisotropicDiffusionTensorFunction.h
+++ b/src/Filtering/itktubeAnisotropicDiffusionTensorFunction.h
@@ -53,11 +53,11 @@ class AnisotropicDiffusionTensorFunction
   : public FiniteDifferenceFunction< TImageType >
 {
 public:
-  /** Standard class typedefs. */
-  typedef AnisotropicDiffusionTensorFunction          Self;
-  typedef FiniteDifferenceFunction<TImageType>        Superclass;
-  typedef SmartPointer< Self >                        Pointer;
-  typedef SmartPointer< const Self >                  ConstPointer;
+  /** Standard class type alias. */
+  using Self = AnisotropicDiffusionTensorFunction;
+  using Superclass = FiniteDifferenceFunction<TImageType>;
+  using Pointer = SmartPointer< Self >;
+  using ConstPointer = SmartPointer< const Self >;
 
   /** Method for creation through the object factory. */
   itkNewMacro( Self );
@@ -70,40 +70,37 @@ public:
   itkStaticConstMacro( ImageDimension, unsigned int,
     Superclass::ImageDimension );
 
-  /** Convenient typedefs. */
-  typedef typename Superclass::TimeStepType             TimeStepType;
-  typedef typename Superclass::PixelType                PixelType;
-  typedef double                                        ScalarValueType;
-  typedef typename Superclass::NeighborhoodType         NeighborhoodType;
-  typedef typename Superclass::FloatOffsetType          FloatOffsetType;
-  typedef typename Superclass::ImageType::SpacingType   SpacingType;
+  /** Convenient type alias. */
+  using TimeStepType = typename Superclass::TimeStepType;
+  using PixelType = typename Superclass::PixelType;
+  using ScalarValueType = double;
+  using NeighborhoodType = typename Superclass::NeighborhoodType;
+  using FloatOffsetType = typename Superclass::FloatOffsetType;
+  using SpacingType = typename Superclass::ImageType::SpacingType;
 
-  /** Diffusion tensor typedefs. */
-  typedef DiffusionTensor3D< double >              DiffusionTensorType;
-  typedef itk::Image< DiffusionTensorType, 3 >     DiffusionTensorImageType;
+  /** Diffusion tensor type alias. */
+  using DiffusionTensorType = DiffusionTensor3D< double >;
+  using DiffusionTensorImageType = itk::Image< DiffusionTensorType, 3 >;
 
   /** The default boundary condition for finite difference
    * functions that is used unless overridden in the Evaluate() method. */
-  typedef ZeroFluxNeumannBoundaryCondition< DiffusionTensorImageType >
-                                           DefaultBoundaryConditionType;
-  typedef ConstNeighborhoodIterator< DiffusionTensorImageType,
-    DefaultBoundaryConditionType>          DiffusionTensorNeighborhoodType;
+  using DefaultBoundaryConditionType = ZeroFluxNeumannBoundaryCondition< DiffusionTensorImageType >;
+  using DiffusionTensorNeighborhoodType = ConstNeighborhoodIterator< DiffusionTensorImageType,
+    DefaultBoundaryConditionType>;
 
-  /** Scalar derivative typedefs. */
-  typedef itk::Vector< ScalarValueType,
-    itkGetStaticConstMacro( ImageDimension )>    ScalarDerivativeType;
-  typedef itk::Image< ScalarDerivativeType, 3 >  ScalarDerivativeImageType;
+  /** Scalar derivative type alias. */
+  using ScalarDerivativeType = itk::Vector< ScalarValueType,
+    itkGetStaticConstMacro( ImageDimension )>;
+  using ScalarDerivativeImageType = itk::Image< ScalarDerivativeType, 3 >;
 
-  typedef ImageRegionIterator< ScalarDerivativeImageType >
-    ScalarDerivativeImageRegionType;
+  using ScalarDerivativeImageRegionType = ImageRegionIterator< ScalarDerivativeImageType >;
 
-  /** Tensor derivative typedefs. */
-  typedef itk::Matrix< ScalarValueType,
+  /** Tensor derivative type alias. */
+  using TensorDerivativeType = itk::Matrix< ScalarValueType,
     itkGetStaticConstMacro( ImageDimension ),
-    itkGetStaticConstMacro( ImageDimension ) >  TensorDerivativeType;
-  typedef itk::Image< TensorDerivativeType, 3 > TensorDerivativeImageType;
-  typedef ImageRegionIterator< TensorDerivativeImageType >
-    TensorDerivativeImageRegionType;
+    itkGetStaticConstMacro( ImageDimension ) >;
+  using TensorDerivativeImageType = itk::Image< TensorDerivativeType, 3 >;
+  using TensorDerivativeImageRegionType = ImageRegionIterator< TensorDerivativeImageType >;
 
   /** A global data type for this class of equations.  Used to store
    * values that are needed in calculating the time step and other

--- a/src/Filtering/itktubeAnisotropicDiffusionTensorImageFilter.h
+++ b/src/Filtering/itktubeAnisotropicDiffusionTensorImageFilter.h
@@ -52,11 +52,11 @@ class AnisotropicDiffusionTensorImageFilter
   : public FiniteDifferenceImageFilter< TInputImage, TOutputImage >
 {
 public:
-  /** Standard class typedefs */
-  typedef AnisotropicDiffusionTensorImageFilter                   Self;
-  typedef FiniteDifferenceImageFilter<TInputImage, TOutputImage>  Superclass;
-  typedef SmartPointer< Self >                                    Pointer;
-  typedef SmartPointer< const Self >                              ConstPointer;
+  /** Standard class type alias */
+  using Self = AnisotropicDiffusionTensorImageFilter;
+  using Superclass = FiniteDifferenceImageFilter<TInputImage, TOutputImage>;
+  using Pointer = SmartPointer< Self >;
+  using ConstPointer = SmartPointer< const Self >;
 
   // itkNewMacro( Self );  // Not included since pure virtual
 
@@ -64,36 +64,34 @@ public:
   itkTypeMacro( AnisotropicDiffusionTensorImageFilter,
     FiniteDifferenceImageFiler );
 
-  /** Convenient typedefs */
-  typedef typename Superclass::InputImageType  InputImageType;
-  typedef typename Superclass::OutputImageType OutputImageType;
-  typedef typename Superclass::PixelType       PixelType;
+  /** Convenient type alias */
+  using InputImageType = typename Superclass::InputImageType;
+  using OutputImageType = typename Superclass::OutputImageType;
+  using PixelType = typename Superclass::PixelType;
 
   /** Dimensionality of input and output data is assumed to be the same.
    * It is inherited from the superclass. */
   itkStaticConstMacro( ImageDimension, unsigned int,
     Superclass::ImageDimension );
 
-  /** Type of associated function, with associated typedefs */
-  typedef AnisotropicDiffusionTensorFunction< InputImageType >
-      FiniteDifferenceFunctionType;
+  /** Type of associated function, with associated type alias */
+  using FiniteDifferenceFunctionType = AnisotropicDiffusionTensorFunction< InputImageType >;
   typedef typename FiniteDifferenceFunctionType::DiffusionTensorType
       TensorPixelType;
   typedef typename FiniteDifferenceFunctionType::DiffusionTensorImageType
       DiffusionTensorImageType;
 
   // Define the type for storing the eigenvalues
-  typedef FixedArray< double, ImageDimension >   EigenValueArrayType;
+  using EigenValueArrayType = FixedArray< double, ImageDimension >;
 
   // Declare the types of the output images
-  typedef Image< EigenValueArrayType, ImageDimension >
-      EigenAnalysisOutputImageType;
+  using EigenAnalysisOutputImageType = Image< EigenValueArrayType, ImageDimension >;
 
   /** The value type of a time step.  Inherited from the superclass. */
-  typedef typename Superclass::TimeStepType TimeStepType;
+  using TimeStepType = typename Superclass::TimeStepType;
 
   /** The container type for the update buffer. */
-  typedef OutputImageType UpdateBufferType;
+  using UpdateBufferType = OutputImageType;
 
   /** Define diffusion image neighborhood type */
   typedef typename
@@ -155,7 +153,7 @@ protected:
   void virtual UpdateDiffusionTensorImage( void ) = 0;
 
   /** The type of region used for multithreading */
-  typedef typename UpdateBufferType::RegionType ThreadRegionType;
+  using ThreadRegionType = typename UpdateBufferType::RegionType;
 
   /** The type of region used for multithreading */
   typedef typename DiffusionTensorImageType::RegionType

--- a/src/Filtering/itktubeAnisotropicDiffusionTensorImageFilter.hxx
+++ b/src/Filtering/itktubeAnisotropicDiffusionTensorImageFilter.hxx
@@ -206,7 +206,7 @@ AnisotropicDiffusionTensorImageFilter<TInputImage, TOutputImage>
   this->GetMultiThreader()->SingleMethodExecute();
 
 #ifdef INTERMEDIATE_OUTPUTS
-  typedef ImageFileWriter< OutputImageType > WriterType;
+  using WriterType = ImageFileWriter< OutputImageType >;
   typename WriterType::Pointer   writer = WriterType::New();
   writer->SetFileName( "UpdatedOutputImage.mha" );
   writer->SetInput( m_UpdateBuffer );
@@ -362,8 +362,7 @@ AnisotropicDiffusionTensorImageFilter<TInputImage, TOutputImage>
     SizeType;
   typedef typename FiniteDifferenceFunctionType::NeighborhoodType
     NeighborhoodIteratorType;
-  typedef ImageRegionIterator<UpdateBufferType>
-    UpdateIteratorType;
+  using UpdateIteratorType = ImageRegionIterator<UpdateBufferType>;
 
   typename OutputImageType::Pointer output = this->GetOutput();
   typename FiniteDifferenceFunctionType::SpacingType spacing =
@@ -382,19 +381,18 @@ AnisotropicDiffusionTensorImageFilter<TInputImage, TOutputImage>
   // Break the input into a series of regions.  The first region is free
   // of boundary conditions, the rest with boundary conditions.  We operate
   // on the output region because input has been copied to output.
-  typedef NeighborhoodAlgorithm::ImageBoundaryFacesCalculator<
-    OutputImageType >   FaceCalculatorType;
+  using FaceCalculatorType = NeighborhoodAlgorithm::ImageBoundaryFacesCalculator<
+    OutputImageType >;
 
-  typedef typename FaceCalculatorType::FaceListType FaceListType;
+  using FaceListType = typename FaceCalculatorType::FaceListType;
 
   FaceCalculatorType faceCalculator;
 
   FaceListType faceList = faceCalculator( output, regionToProcess, radius );
   typename FaceListType::iterator fIt = faceList.begin();
 
-  typedef NeighborhoodAlgorithm::ImageBoundaryFacesCalculator<
-    DiffusionTensorImageType>
-    DiffusionTensorFaceCalculatorType;
+  using DiffusionTensorFaceCalculatorType = NeighborhoodAlgorithm::ImageBoundaryFacesCalculator<
+    DiffusionTensorImageType>;
 
   typedef typename DiffusionTensorFaceCalculatorType::FaceListType
     DiffusionTensorFaceListType;

--- a/src/Filtering/itktubeAnisotropicEdgeEnhancementDiffusionImageFilter.h
+++ b/src/Filtering/itktubeAnisotropicEdgeEnhancementDiffusionImageFilter.h
@@ -60,14 +60,13 @@ class AnisotropicEdgeEnhancementDiffusionImageFilter
   : public AnisotropicDiffusionTensorImageFilter< TInputImage, TOutputImage >
 {
 public:
-  /** Standard class typedefs */
-  typedef AnisotropicEdgeEnhancementDiffusionImageFilter Self;
+  /** Standard class type alias */
+  using Self = AnisotropicEdgeEnhancementDiffusionImageFilter;
 
-  typedef AnisotropicDiffusionTensorImageFilter<TInputImage, TOutputImage>
-                                                           Superclass;
+  using Superclass = AnisotropicDiffusionTensorImageFilter<TInputImage, TOutputImage>;
 
-  typedef SmartPointer< Self >                             Pointer;
-  typedef SmartPointer< const Self >                       ConstPointer;
+  using Pointer = SmartPointer< Self >;
+  using ConstPointer = SmartPointer< const Self >;
 
 
   /** Method for creation through the object factory */
@@ -77,43 +76,39 @@ public:
   itkTypeMacro( AnisotropicEdgeEnhancementDiffusionImageFilter,
                 ImageToImageFilter );
 
-  /** Convenient typedefs */
-  typedef typename Superclass::InputImageType  InputImageType;
-  typedef typename Superclass::OutputImageType OutputImageType;
-  typedef typename Superclass::PixelType       PixelType;
+  /** Convenient type alias */
+  using InputImageType = typename Superclass::InputImageType;
+  using OutputImageType = typename Superclass::OutputImageType;
+  using PixelType = typename Superclass::PixelType;
 
   typedef typename Superclass::DiffusionTensorImageType
                                                 DiffusionTensorImageType;
 
   // Structure tensor type
-  typedef StructureTensorRecursiveGaussianImageFilter < InputImageType >
-                                                StructureTensorFilterType;
+  using StructureTensorFilterType = StructureTensorRecursiveGaussianImageFilter < InputImageType >;
 
   /** Dimensionality of input and output data is assumed to be the same.
    * It is inherited from the superclass. */
   itkStaticConstMacro( ImageDimension, unsigned int,
                        Superclass::ImageDimension );
 
-  typedef itk::Matrix<double, ImageDimension, ImageDimension> MatrixType;
+  using MatrixType = itk::Matrix<double, ImageDimension, ImageDimension>;
 
   // Define image of matrix pixel type
-  typedef itk::Image< MatrixType, ImageDimension>  OutputMatrixImageType;
+  using OutputMatrixImageType = itk::Image< MatrixType, ImageDimension>;
 
   // Define the symmetric tensor pixel type
-  typedef itk::SymmetricSecondRankTensor< double, ImageDimension>
-                                                         TensorPixelType;
-  typedef itk::Image< TensorPixelType, ImageDimension>
-                                                         TensorImageType;
+  using TensorPixelType = itk::SymmetricSecondRankTensor< double, ImageDimension>;
+  using TensorImageType = itk::Image< TensorPixelType, ImageDimension>;
 
    // Define the type for storing the eigenvalue
-  typedef itk::FixedArray< double, ImageDimension >      EigenValueArrayType;
+  using EigenValueArrayType = itk::FixedArray< double, ImageDimension >;
 
   // Declare the types of the output images
-  typedef itk::Image< EigenValueArrayType, ImageDimension >
-    EigenAnalysisOutputImageType;
+  using EigenAnalysisOutputImageType = itk::Image< EigenValueArrayType, ImageDimension >;
 
   /** The container type for the update buffer. */
-  typedef OutputImageType UpdateBufferType;
+  using UpdateBufferType = OutputImageType;
 
   /** Define diffusion image nbd type */
   typedef typename Superclass::DiffusionTensorNeighborhoodType

--- a/src/Filtering/itktubeAnisotropicEdgeEnhancementDiffusionImageFilter.hxx
+++ b/src/Filtering/itktubeAnisotropicEdgeEnhancementDiffusionImageFilter.hxx
@@ -81,19 +81,15 @@ AnisotropicEdgeEnhancementDiffusionImageFilter<TInputImage, TOutputImage>
   StructureTensorFilter->Update();
 
   // Step 1.2: Identify the eigenvectors of the structure tensor
-  typedef  Matrix< double, 3, 3>
-    EigenVectorMatrixType;
-  typedef  Image< EigenVectorMatrixType, 3>
-    EigenVectorImageType;
-  typedef  typename itk::Image< EigenValueArrayType, 3>
-    EigenValueImageType;
+  using EigenVectorMatrixType = Matrix< double, 3, 3>;
+  using EigenVectorImageType = Image< EigenVectorMatrixType, 3>;
+  using EigenValueImageType = typename itk::Image< EigenValueArrayType, 3>;
 
   typedef  typename StructureTensorFilterType::OutputImageType
     SymmetricSecondRankTensorImageType;
-  typedef  SymmetricEigenVectorAnalysisImageFilter<
+  using EigenVectorAnalysisFilterType = SymmetricEigenVectorAnalysisImageFilter<
     SymmetricSecondRankTensorImageType, EigenValueImageType,
-    EigenVectorImageType>
-    EigenVectorAnalysisFilterType;
+    EigenVectorImageType>;
 
   typename EigenVectorAnalysisFilterType::Pointer eigenVectorAnalysisFilter
     = EigenVectorAnalysisFilterType::New();
@@ -106,9 +102,8 @@ AnisotropicEdgeEnhancementDiffusionImageFilter<TInputImage, TOutputImage>
   eigenVectorAnalysisFilter->Update();
 
   //Step 1.3: Compute the eigenvalues
-  typedef SymmetricEigenAnalysisImageFilter<SymmetricSecondRankTensorImageType,
-    EigenValueImageType>
-    EigenAnalysisFilterType;
+  using EigenAnalysisFilterType = SymmetricEigenAnalysisImageFilter<SymmetricSecondRankTensorImageType,
+    EigenValueImageType>;
 
   typename EigenAnalysisFilterType::Pointer eigenAnalysisFilter =
     EigenAnalysisFilterType::New();
@@ -121,8 +116,7 @@ AnisotropicEdgeEnhancementDiffusionImageFilter<TInputImage, TOutputImage>
 
   /* Compute the gradient magnitude. This is required to set Lambda1 */
 
-  typedef itk::GradientMagnitudeRecursiveGaussianImageFilter<InputImageType>
-    GradientMagnitudeFilterType;
+  using GradientMagnitudeFilterType = itk::GradientMagnitudeRecursiveGaussianImageFilter<InputImageType>;
 
   typename GradientMagnitudeFilterType::Pointer gradientMagnitudeFilter =
     GradientMagnitudeFilterType::New();
@@ -147,8 +141,7 @@ AnisotropicEdgeEnhancementDiffusionImageFilter<TInputImage, TOutputImage>
   eigenVectorImageIterator.GoToBegin();
 
   //Iterator for the diffusion tensor image
-  typedef itk::ImageRegionIterator< DiffusionTensorImageType >
-    DiffusionTensorIteratorType;
+  using DiffusionTensorIteratorType = itk::ImageRegionIterator< DiffusionTensorImageType >;
   DiffusionTensorIteratorType it( this->GetDiffusionTensorImage(),
     this->GetDiffusionTensorImage()->GetLargestPossibleRegion() );
 

--- a/src/Filtering/itktubeAnisotropicHybridDiffusionImageFilter.h
+++ b/src/Filtering/itktubeAnisotropicHybridDiffusionImageFilter.h
@@ -59,14 +59,13 @@ class AnisotropicHybridDiffusionImageFilter
   : public AnisotropicDiffusionTensorImageFilter< TInputImage, TOutputImage >
 {
 public:
-  /** Standard class typedefs */
-  typedef AnisotropicHybridDiffusionImageFilter Self;
+  /** Standard class type alias */
+  using Self = AnisotropicHybridDiffusionImageFilter;
 
-  typedef AnisotropicDiffusionTensorImageFilter<TInputImage, TOutputImage>
-                                                           Superclass;
+  using Superclass = AnisotropicDiffusionTensorImageFilter<TInputImage, TOutputImage>;
 
-  typedef SmartPointer< Self >                             Pointer;
-  typedef SmartPointer< const Self >                       ConstPointer;
+  using Pointer = SmartPointer< Self >;
+  using ConstPointer = SmartPointer< const Self >;
 
 
   /** Method for creation through the object factory */
@@ -75,43 +74,39 @@ public:
   /** Run-time type information ( and related methods ) */
   itkTypeMacro( AnisotropicHybridDiffusionImageFilter, ImageToImageFilter );
 
-  /** Convenient typedefs */
-  typedef typename Superclass::InputImageType  InputImageType;
-  typedef typename Superclass::OutputImageType OutputImageType;
-  typedef typename Superclass::PixelType       PixelType;
+  /** Convenient type alias */
+  using InputImageType = typename Superclass::InputImageType;
+  using OutputImageType = typename Superclass::OutputImageType;
+  using PixelType = typename Superclass::PixelType;
 
   typedef typename Superclass::DiffusionTensorImageType
                                                 DiffusionTensorImageType;
 
   // Structure tensor type
-  typedef StructureTensorRecursiveGaussianImageFilter < InputImageType >
-                                                StructureTensorFilterType;
+  using StructureTensorFilterType = StructureTensorRecursiveGaussianImageFilter < InputImageType >;
 
   /** Dimensionality of input and output data is assumed to be the same.
    * It is inherited from the superclass. */
   itkStaticConstMacro( ImageDimension, unsigned int,
                        Superclass::ImageDimension );
 
-  typedef Matrix<double, ImageDimension, ImageDimension> MatrixType;
+  using MatrixType = Matrix<double, ImageDimension, ImageDimension>;
 
   // Define image of matrix pixel type
-  typedef Image< MatrixType, ImageDimension>  OutputMatrixImageType;
+  using OutputMatrixImageType = Image< MatrixType, ImageDimension>;
 
   // Define the symmetric tensor pixel type
-  typedef SymmetricSecondRankTensor< double, ImageDimension>
-                                                         TensorPixelType;
-  typedef Image< TensorPixelType, ImageDimension>
-                                                         TensorImageType;
+  using TensorPixelType = SymmetricSecondRankTensor< double, ImageDimension>;
+  using TensorImageType = Image< TensorPixelType, ImageDimension>;
 
    // Define the type for storing the eigenvalue
-  typedef FixedArray< double, ImageDimension >      EigenValueArrayType;
+  using EigenValueArrayType = FixedArray< double, ImageDimension >;
 
   // Declare the types of the output images
-  typedef Image< EigenValueArrayType, ImageDimension >
-                                                  EigenAnalysisOutputImageType;
+  using EigenAnalysisOutputImageType = Image< EigenValueArrayType, ImageDimension >;
 
   /** The container type for the update buffer. */
-  typedef OutputImageType UpdateBufferType;
+  using UpdateBufferType = OutputImageType;
 
   /** Define diffusion image nbd type */
   typedef typename Superclass::DiffusionTensorNeighborhoodType

--- a/src/Filtering/itktubeAnisotropicHybridDiffusionImageFilter.hxx
+++ b/src/Filtering/itktubeAnisotropicHybridDiffusionImageFilter.hxx
@@ -83,19 +83,15 @@ AnisotropicHybridDiffusionImageFilter<TInputImage, TOutputImage>
   structureTensorFilter->Update();
 
   // Step 1.2: Identify the eigenvectors of the structure tensor
-  typedef  Matrix< double, 3, 3>
-    EigenVectorMatrixType;
-  typedef  Image< EigenVectorMatrixType, 3>
-    EigenVectorImageType;
-  typedef  typename itk::Image< EigenValueArrayType, 3>
-    EigenValueImageType;
+  using EigenVectorMatrixType = Matrix< double, 3, 3>;
+  using EigenVectorImageType = Image< EigenVectorMatrixType, 3>;
+  using EigenValueImageType = typename itk::Image< EigenValueArrayType, 3>;
 
   typedef  typename StructureTensorFilterType::OutputImageType
     SymmetricSecondRankTensorImageType;
-  typedef  SymmetricEigenVectorAnalysisImageFilter<
+  using EigenVectorAnalysisFilterType = SymmetricEigenVectorAnalysisImageFilter<
     SymmetricSecondRankTensorImageType, EigenValueImageType,
-    EigenVectorImageType>
-    EigenVectorAnalysisFilterType;
+    EigenVectorImageType>;
 
   typename EigenVectorAnalysisFilterType::Pointer eigenVectorAnalysisFilter
     = EigenVectorAnalysisFilterType::New();
@@ -108,9 +104,8 @@ AnisotropicHybridDiffusionImageFilter<TInputImage, TOutputImage>
   eigenVectorAnalysisFilter->Update();
 
   //Step 1.3: Compute the eigenvalues
-  typedef itk::SymmetricEigenAnalysisImageFilter<
-    SymmetricSecondRankTensorImageType, EigenValueImageType>
-    EigenAnalysisFilterType;
+  using EigenAnalysisFilterType = itk::SymmetricEigenAnalysisImageFilter<
+    SymmetricSecondRankTensorImageType, EigenValueImageType>;
 
   typename EigenAnalysisFilterType::Pointer eigenAnalysisFilter
     = EigenAnalysisFilterType::New();
@@ -123,8 +118,7 @@ AnisotropicHybridDiffusionImageFilter<TInputImage, TOutputImage>
 
   /* Compute the gradient magnitude. This is required to set Lambda1 */
 
-  typedef itk::GradientMagnitudeRecursiveGaussianImageFilter<InputImageType>
-    GradientMagnitudeFilterType;
+  using GradientMagnitudeFilterType = itk::GradientMagnitudeRecursiveGaussianImageFilter<InputImageType>;
 
   typename GradientMagnitudeFilterType::Pointer gradientMagnitudeFilter
     = GradientMagnitudeFilterType::New();
@@ -149,8 +143,7 @@ AnisotropicHybridDiffusionImageFilter<TInputImage, TOutputImage>
   eigenVectorImageIterator.GoToBegin();
 
   //Iterator for the diffusion tensor image
-  typedef itk::ImageRegionIterator< DiffusionTensorImageType >
-    DiffusionTensorIteratorType;
+  using DiffusionTensorIteratorType = itk::ImageRegionIterator< DiffusionTensorImageType >;
   DiffusionTensorIteratorType it( this->GetDiffusionTensorImage(),
     this->GetDiffusionTensorImage()->GetLargestPossibleRegion() );
 

--- a/src/Filtering/itktubeBinaryThinningImageFilter3D.h
+++ b/src/Filtering/itktubeBinaryThinningImageFilter3D.h
@@ -73,15 +73,15 @@ class ITK_EXPORT BinaryThinningImageFilter3D :
     public ImageToImageFilter<TInputImage,TOutputImage>
 {
 public:
-  /** Standard class typedefs. */
-  typedef BinaryThinningImageFilter3D                  Self;
-  typedef ImageToImageFilter<TInputImage,TOutputImage> Superclass;
-  typedef SmartPointer<Self>                           Pointer;
-  typedef SmartPointer<const Self>                     ConstPointer;
+  /** Standard class type alias. */
+  using Self = BinaryThinningImageFilter3D;
+  using Superclass = ImageToImageFilter<TInputImage,TOutputImage>;
+  using Pointer = SmartPointer<Self>;
+  using ConstPointer = SmartPointer<const Self>;
 
-  typedef typename TInputImage::PointType              PointType;
+  using PointType = typename TInputImage::PointType;
 
-  typedef std::vector< PointType >                     EndPointListType;
+  using EndPointListType = std::vector< PointType >;
 
   /** Method for creation through the object factory */
   itkNewMacro(Self);
@@ -90,37 +90,37 @@ public:
   itkTypeMacro( BinaryThinningImageFilter3D, ImageToImageFilter );
 
   /** Type for input image. */
-  typedef   TInputImage       InputImageType;
+  using InputImageType = TInputImage;
 
   /** Type for output image: Skelenton of the object.  */
-  typedef   TOutputImage      OutputImageType;
+  using OutputImageType = TOutputImage;
 
   /** Type for the region of the input image. */
-  typedef typename InputImageType::RegionType RegionType;
+  using RegionType = typename InputImageType::RegionType;
 
   /** Type for the pixel type of the input image. */
-  typedef typename InputImageType::PixelType InputImagePixelType ;
+  using InputImagePixelType = typename InputImageType::PixelType;
 
   /** Type for the pixel type of the input image. */
-  typedef typename OutputImageType::PixelType OutputImagePixelType ;
+  using OutputImagePixelType = typename OutputImageType::PixelType;
 
   /** Type for the size of the input image. */
-  typedef typename RegionType::SizeType SizeType;
+  using SizeType = typename RegionType::SizeType;
 
   /** Pointer Type for input image. */
-  typedef typename InputImageType::ConstPointer InputImagePointer;
+  using InputImagePointer = typename InputImageType::ConstPointer;
 
   /** Pointer Type for the output image. */
-  typedef typename OutputImageType::Pointer OutputImagePointer;
+  using OutputImagePointer = typename OutputImageType::Pointer;
   
   /** Boundary condition type for the neighborhood iterator */
-  typedef ConstantBoundaryCondition< TInputImage > ConstBoundaryConditionType;
+  using ConstBoundaryConditionType = ConstantBoundaryCondition< TInputImage >;
   
   /** Neighborhood iterator type */
-  typedef NeighborhoodIterator<TInputImage, ConstBoundaryConditionType> NeighborhoodIteratorType;
+  using NeighborhoodIteratorType = NeighborhoodIterator<TInputImage, ConstBoundaryConditionType>;
   
   /** Neighborhood type */
-  typedef typename NeighborhoodIteratorType::NeighborhoodType NeighborhoodType;
+  using NeighborhoodType = typename NeighborhoodIteratorType::NeighborhoodType;
 
   /** Get Skelenton by thinning image. */
   OutputImageType * GetThinning(void);

--- a/src/Filtering/itktubeBinaryThinningImageFilter3D.hxx
+++ b/src/Filtering/itktubeBinaryThinningImageFilter3D.hxx
@@ -134,13 +134,13 @@ BinaryThinningImageFilter3D<TInputImage,TOutputImage>
   NeighborhoodIteratorType ot( radius, thinImage, region );
   ot.SetBoundaryCondition( boundaryCondition );
 
-  typedef typename OutputImageType::IndexType  IndexType;
+  using IndexType = typename OutputImageType::IndexType;
 
   std::vector < IndexType > simpleBorderPoints;
   typename std::vector < IndexType >::iterator simpleBorderPointsIt;
 
   // Define offsets
-  typedef typename NeighborhoodIteratorType::OffsetType OffsetType;
+  using OffsetType = typename NeighborhoodIteratorType::OffsetType;
   OffsetType N   = {{ 0,-1, 0}};  // north
   OffsetType S   = {{ 0, 1, 0}};  // south
   OffsetType E   = {{ 1, 0, 0}};  // east

--- a/src/Filtering/itktubeCVTImageFilter.h
+++ b/src/Filtering/itktubeCVTImageFilter.h
@@ -47,11 +47,11 @@ class CVTImageFilter
 {
 public:
 
-  /** Standard class typedefs. */
-  typedef CVTImageFilter                                  Self;
-  typedef ImageToImageFilter< TInputImage, TOutputImage>  Superclass;
-  typedef SmartPointer< Self >                            Pointer;
-  typedef SmartPointer< const Self >                      ConstPointer;
+  /** Standard class type alias. */
+  using Self = CVTImageFilter;
+  using Superclass = ImageToImageFilter< TInputImage, TOutputImage>;
+  using Pointer = SmartPointer< Self >;
+  using ConstPointer = SmartPointer< const Self >;
 
   /** Method for creation through the object factory. */
   itkNewMacro( Self );
@@ -61,22 +61,21 @@ public:
   itkStaticConstMacro( ImageDimension, unsigned int,
                        TInputImage::ImageDimension );
 
-  typedef TInputImage                                   InputImageType;
-  typedef typename InputImageType::PixelType            InputPixelType;
+  using InputImageType = TInputImage;
+  using InputPixelType = typename InputImageType::PixelType;
 
-  typedef typename InputImageType::IndexType            IndexType;
-  typedef ContinuousIndex<double, itkGetStaticConstMacro( ImageDimension )>
-                                                        ContinuousIndexType;
+  using IndexType = typename InputImageType::IndexType;
+  using ContinuousIndexType = ContinuousIndex<double, itkGetStaticConstMacro( ImageDimension )>;
 
-  typedef TOutputImage                                  OutputImageType;
-  typedef typename OutputImageType::PixelType           OutputPixelType;
+  using OutputImageType = TOutputImage;
+  using OutputPixelType = typename OutputImageType::PixelType;
 
-  typedef typename InputImageType::RegionType           RegionType;
-  typedef typename RegionType::SizeType                 SizeType;
+  using RegionType = typename InputImageType::RegionType;
+  using SizeType = typename RegionType::SizeType;
 
-  typedef std::vector<ContinuousIndexType>              PointArrayType;
+  using PointArrayType = std::vector<ContinuousIndexType>;
 
-  typedef enum {CVT_GRID, CVT_RANDOM, CVT_USER}         SamplingMethodEnum;
+  using SamplingMethodEnum = enum {CVT_GRID, CVT_RANDOM, CVT_USER};
 
   /** */
   itkGetMacro( NumberOfCentroids, unsigned int );

--- a/src/Filtering/itktubeCVTImageFilter.hxx
+++ b/src/Filtering/itktubeCVTImageFilter.hxx
@@ -230,8 +230,7 @@ GenerateData( void )
       }
     }
 
-  typedef DanielssonDistanceMapImageFilter<OutputImageType, OutputImageType>
-    DDFilterType;
+  using DDFilterType = DanielssonDistanceMapImageFilter<OutputImageType, OutputImageType>;
   typename DDFilterType::Pointer ddFilter = DDFilterType::New();
   ddFilter->SetInput( m_OutputImage );
   ddFilter->SetInputIsBinary( false );

--- a/src/Filtering/itktubeComputeTubeFlyThroughImageFilter.h
+++ b/src/Filtering/itktubeComputeTubeFlyThroughImageFilter.h
@@ -45,19 +45,19 @@ class ComputeTubeFlyThroughImageFilter
 {
 public:
 
-  /** Tube class typedef */
-  typedef GroupSpatialObject< Dimension >                TubeGroupType;
-  typedef TubeSpatialObject< Dimension >                 TubeType;
-  typedef Image< TPixel, Dimension >                     InputImageType;
-  typedef InputImageType                                 OutputImageType;
-  typedef Image< unsigned char, Dimension >              OutputMaskType;
+  /** Tube class type alias */
+  using TubeGroupType = GroupSpatialObject< Dimension >;
+  using TubeType = TubeSpatialObject< Dimension >;
+  using InputImageType = Image< TPixel, Dimension >;
+  using OutputImageType = InputImageType;
+  using OutputMaskType = Image< unsigned char, Dimension >;
 
-  /** Standard class typedefs. */
-  typedef ComputeTubeFlyThroughImageFilter               Self;
-  typedef SpatialObjectToImageFilter< TubeGroupType,
-    InputImageType >                                     SuperClass;
-  typedef SmartPointer< Self >                           Pointer;
-  typedef SmartPointer< const Self >                     ConstPointer;
+  /** Standard class type alias. */
+  using Self = ComputeTubeFlyThroughImageFilter;
+  using SuperClass = SpatialObjectToImageFilter< TubeGroupType,
+    InputImageType >;
+  using Pointer = SmartPointer< Self >;
+  using ConstPointer = SmartPointer< const Self >;
 
   /** Method for creation through the object factory. */
   itkNewMacro( Self );

--- a/src/Filtering/itktubeComputeTubeFlyThroughImageFilter.hxx
+++ b/src/Filtering/itktubeComputeTubeFlyThroughImageFilter.hxx
@@ -68,7 +68,7 @@ ComputeTubeFlyThroughImageFilter< TPixel, Dimension >
   // Find the user specified tybe
   itkDebugMacro( << "Finding user specified tube" );
 
-  typedef typename TubeGroupType::ChildrenListType      TubeListType;
+  using TubeListType = typename TubeGroupType::ChildrenListType;
 
   TubeType * inputTube = NULL;
   bool blnTubeFound = false;
@@ -110,7 +110,7 @@ ComputeTubeFlyThroughImageFilter< TPixel, Dimension >
   inputTube->ComputeTangentsAndNormals();
 
   // Get list of tube points
-  typedef typename TubeType::TubePointListType    TubePointListType;
+  using TubePointListType = typename TubeType::TubePointListType;
 
   TubePointListType tubePointList = inputTube->GetPoints();
 
@@ -226,17 +226,15 @@ ComputeTubeFlyThroughImageFilter< TPixel, Dimension >
   // and fill into corresponding slice in the output image
   itkDebugMacro( "Generating fly through image" );
 
-  typedef typename TubeType::TubePointType             TubePointType;
-  typedef typename TubePointType::CovariantVectorType  TubeNormalType;
-  typedef ImageRegionIteratorWithIndex<
-    OutputImageType >                                  OutputImageIteratorType;
-  typedef ImageRegionIterator< OutputMaskType >        OutputMaskIteratorType;
+  using TubePointType = typename TubeType::TubePointType;
+  using TubeNormalType = typename TubePointType::CovariantVectorType;
+  using OutputImageIteratorType = ImageRegionIteratorWithIndex<
+    OutputImageType >;
+  using OutputMaskIteratorType = ImageRegionIterator< OutputMaskType >;
 
-  typedef LinearInterpolateImageFunction< InputImageType, double >
-    InterpolatorType;
+  using InterpolatorType = LinearInterpolateImageFunction< InputImageType, double >;
 
-  typedef MinimumMaximumImageFilter< InputImageType >
-    MinMaxImageFilterType;
+  using MinMaxImageFilterType = MinimumMaximumImageFilter< InputImageType >;
 
   typename MinMaxImageFilterType::Pointer minmaxFilter =
   MinMaxImageFilterType::New();

--- a/src/Filtering/itktubeComputeTubeMeasuresFilter.h
+++ b/src/Filtering/itktubeComputeTubeMeasuresFilter.h
@@ -43,20 +43,20 @@ class ComputeTubeMeasuresFilter
 {
 public:
 
-  /** Tube class typedef */
-  typedef Image< TPixel, Dimension >                     InputImageType;
-  typedef Image< float, Dimension >                      OutputImageType;
+  /** Tube class type alias */
+  using InputImageType = Image< TPixel, Dimension >;
+  using OutputImageType = Image< float, Dimension >;
 
-  /** Standard class typedefs. */
-  typedef ComputeTubeMeasuresFilter                      Self;
-  typedef ImageToImageFilter
-    < InputImageType, OutputImageType >                  SuperClass;
-  typedef SmartPointer< Self >                           Pointer;
-  typedef SmartPointer< const Self >                     ConstPointer;
+  /** Standard class type alias. */
+  using Self = ComputeTubeMeasuresFilter;
+  using SuperClass = ImageToImageFilter
+    < InputImageType, OutputImageType >;
+  using Pointer = SmartPointer< Self >;
+  using ConstPointer = SmartPointer< const Self >;
 
-  typedef itk::RescaleIntensityImageFilter
-    < InputImageType, OutputImageType >                  RescaleFilterType;
-  typedef itk::tube::RidgeFFTFilter< OutputImageType >   RidgeFilterType;
+  using RescaleFilterType = itk::RescaleIntensityImageFilter
+    < InputImageType, OutputImageType >;
+  using RidgeFilterType = itk::tube::RidgeFFTFilter< OutputImageType >;
 
   /** Method for creation through the object factory. */
   itkNewMacro( Self );

--- a/src/Filtering/itktubeContrastCostFunction.h
+++ b/src/Filtering/itktubeContrastCostFunction.h
@@ -39,11 +39,11 @@ class ContrastCostFunction : public itk::SingleValuedCostFunction
 {
 public:
 
-  /** Tube class typedef */
-  typedef ContrastCostFunction                    Self;
-  typedef SingleValuedCostFunction                Superclass;
-  typedef SmartPointer< Self >                    Pointer;
-  typedef SmartPointer< const Self >              ConstPointer;
+  /** Tube class type alias */
+  using Self = ContrastCostFunction;
+  using Superclass = SingleValuedCostFunction;
+  using Pointer = SmartPointer< Self >;
+  using ConstPointer = SmartPointer< const Self >;
 
   /** Method for creation through the object factory. */
   itkNewMacro( Self );
@@ -51,13 +51,12 @@ public:
   /** Run-time type information ( and related methods ). */
   itkTypeMacro( ContrastCostFunction, SingleValuedCostFunction );
 
-  typedef Superclass::MeasureType          MeasureType;
-  typedef Superclass::ParametersType       ParametersType;
-  typedef Superclass::DerivativeType       DerivativeType;
-  typedef itk::Image< TPixel, VDimension > ImageType;
+  using MeasureType = Superclass::MeasureType;
+  using ParametersType = Superclass::ParametersType;
+  using DerivativeType = Superclass::DerivativeType;
+  using ImageType = itk::Image< TPixel, VDimension >;
 
-  typedef itk::SmoothingRecursiveGaussianImageFilter< ImageType, ImageType >
-                                                  BlurFilterType;
+  using BlurFilterType = itk::SmoothingRecursiveGaussianImageFilter< ImageType, ImageType >;
   /** Set/Get input image */
   itkSetConstObjectMacro( InputImage, ImageType );
   itkGetConstObjectMacro( InputImage, ImageType );

--- a/src/Filtering/itktubeContrastCostFunction.hxx
+++ b/src/Filtering/itktubeContrastCostFunction.hxx
@@ -107,8 +107,8 @@ ContrastCostFunction< TPixel, Dimension >
   double sumBkg = 0;
   double sumsBkg = 0;
 
-  typedef ImageRegionIterator< ImageType >       ImageIteratorType;
-  typedef ImageRegionConstIterator< ImageType >  ConstImageIteratorType;
+  using ImageIteratorType = ImageRegionIterator< ImageType >;
+  using ConstImageIteratorType = ImageRegionConstIterator< ImageType >;
 
   ConstImageIteratorType iterObj( imgObj,
     imgObj->GetLargestPossibleRegion() );

--- a/src/Filtering/itktubeConvertImagesToCSVFilter.h
+++ b/src/Filtering/itktubeConvertImagesToCSVFilter.h
@@ -37,28 +37,28 @@ namespace tube
  class ConvertImagesToCSVFilter : public ProcessObject
 {
 public:
-  /** Standard class typedefs. */
-  typedef ConvertImagesToCSVFilter              Self;
-  typedef ProcessObject                         Superclass;
-  typedef SmartPointer< Self >                  Pointer;
-  typedef SmartPointer< const Self >            ConstPointer;
+  /** Standard class type alias. */
+  using Self = ConvertImagesToCSVFilter;
+  using Superclass = ProcessObject;
+  using Pointer = SmartPointer< Self >;
+  using ConstPointer = SmartPointer< const Self >;
 
-  typedef TInputImage                                InputImageType;
-  typedef typename InputImageType::Pointer           ImagePointer;
-  typedef typename InputImageType::PixelType         InputPixelType;
-  typedef typename InputImageType::IndexType         IndexType;
-  typedef ImageFileReader< InputImageType >          ReaderType;
-  typedef ImageRegionConstIterator< InputImageType > InputImageIteratorType;
+  using InputImageType = TInputImage;
+  using ImagePointer = typename InputImageType::Pointer;
+  using InputPixelType = typename InputImageType::PixelType;
+  using IndexType = typename InputImageType::IndexType;
+  using ReaderType = ImageFileReader< InputImageType >;
+  using InputImageIteratorType = ImageRegionConstIterator< InputImageType >;
 
-  typedef TInputMask                                 InputMaskType;
-  typedef typename InputMaskType::Pointer            MaskPointer;
-  typedef typename InputMaskType::PixelType          MaskPixelType;
-  typedef typename InputMaskType::IndexType          MaskIndexType;
-  typedef ImageFileReader< InputMaskType >           MaskReaderType;
-  typedef ImageRegionConstIterator< InputMaskType >  MaskIteratorType;
+  using InputMaskType = TInputMask;
+  using MaskPointer = typename InputMaskType::Pointer;
+  using MaskPixelType = typename InputMaskType::PixelType;
+  using MaskIndexType = typename InputMaskType::IndexType;
+  using MaskReaderType = ImageFileReader< InputMaskType >;
+  using MaskIteratorType = ImageRegionConstIterator< InputMaskType >;
 
-  typedef vnl_matrix< InputPixelType >                VnlMatrixType;
-  typedef SimpleDataObjectDecorator< VnlMatrixType >  OutputType;
+  using VnlMatrixType = vnl_matrix< InputPixelType >;
+  using OutputType = SimpleDataObjectDecorator< VnlMatrixType >;
 
   /** Method for creation through the object factory. */
   itkNewMacro( Self );

--- a/src/Filtering/itktubeConvertShrunkenSeedImageToListFilter.h
+++ b/src/Filtering/itktubeConvertShrunkenSeedImageToListFilter.h
@@ -40,28 +40,28 @@ class ConvertShrunkenSeedImageToListFilter
   : public ProcessObject
 {
 public:
-  /** Standard class typedefs. */
-  typedef ConvertShrunkenSeedImageToListFilter             Self;
-  typedef ProcessObject                                    Superclass;
-  typedef SmartPointer< Self >                             Pointer;
-  typedef SmartPointer< const Self >                       ConstPointer;
+  /** Standard class type alias. */
+  using Self = ConvertShrunkenSeedImageToListFilter;
+  using Superclass = ProcessObject;
+  using Pointer = SmartPointer< Self >;
+  using ConstPointer = SmartPointer< const Self >;
 
-  typedef TImage                                           ImageType;
-  typedef typename ImageType::Pointer                      ImagePointer;
-  typedef typename ImageType::PixelType                    PixelType;
-  typedef typename ImageType::IndexType                    IndexType;
-  typedef ImageFileReader< ImageType >                     ReaderType;
-  typedef ImageRegionIterator< ImageType >                 IteratorType;
+  using ImageType = TImage;
+  using ImagePointer = typename ImageType::Pointer;
+  using PixelType = typename ImageType::PixelType;
+  using IndexType = typename ImageType::IndexType;
+  using ReaderType = ImageFileReader< ImageType >;
+  using IteratorType = ImageRegionIterator< ImageType >;
 
-  typedef TPointsImage                                     PointsImageType;
-  typedef typename PointsImageType::Pointer                PointsImagePointer;
-  typedef typename PointsImageType::PixelType              PointsPixelType;
-  typedef typename PointsImageType::IndexType              PointsIndexType;
-  typedef ImageFileReader< PointsImageType >               PointsReaderType;
-  typedef ImageRegionIterator< PointsImageType >           PointsIteratorType;
+  using PointsImageType = TPointsImage;
+  using PointsImagePointer = typename PointsImageType::Pointer;
+  using PointsPixelType = typename PointsImageType::PixelType;
+  using PointsIndexType = typename PointsImageType::IndexType;
+  using PointsReaderType = ImageFileReader< PointsImageType >;
+  using PointsIteratorType = ImageRegionIterator< PointsImageType >;
 
-  typedef vnl_matrix< PixelType >                          VnlMatrixType;
-  typedef SimpleDataObjectDecorator< VnlMatrixType >       OutputType;
+  using VnlMatrixType = vnl_matrix< PixelType >;
+  using OutputType = SimpleDataObjectDecorator< VnlMatrixType >;
 
   /** Method for creation through the object factory. */
   itkNewMacro( Self );

--- a/src/Filtering/itktubeConvertSpatialGraphToImageFilter.h
+++ b/src/Filtering/itktubeConvertSpatialGraphToImageFilter.h
@@ -41,11 +41,11 @@ class ConvertSpatialGraphToImageFilter
 {
 public:
 
-  /** Standard class typedefs. */
-  typedef ConvertSpatialGraphToImageFilter                Self;
-  typedef ImageToImageFilter< TInputImage, TOutputImage>  Superclass;
-  typedef SmartPointer< Self >                            Pointer;
-  typedef SmartPointer< const Self >                      ConstPointer;
+  /** Standard class type alias. */
+  using Self = ConvertSpatialGraphToImageFilter;
+  using Superclass = ImageToImageFilter< TInputImage, TOutputImage>;
+  using Pointer = SmartPointer< Self >;
+  using ConstPointer = SmartPointer< const Self >;
 
   /** Method for creation through the object factory. */
   itkNewMacro( Self );
@@ -55,11 +55,11 @@ public:
   itkStaticConstMacro( ImageDimension, unsigned int,
                        TInputImage::ImageDimension );
 
-  typedef TInputImage                                   InputImageType;
-  typedef typename InputImageType::PixelType            InputPixelType;
-  typedef TOutputImage                                  OutputImageType;
-  typedef typename InputImageType::Pointer              InputImagePointer;
-  typedef typename OutputImageType::Pointer             OutputImagePointer;
+  using InputImageType = TInputImage;
+  using InputPixelType = typename InputImageType::PixelType;
+  using OutputImageType = TOutputImage;
+  using InputImagePointer = typename InputImageType::Pointer;
+  using OutputImagePointer = typename OutputImageType::Pointer;
 
   itkGetMacro( AdjacencyMatrixImage, OutputImagePointer );
   itkGetMacro( BranchnessImage, OutputImagePointer );

--- a/src/Filtering/itktubeCropImageFilter.h
+++ b/src/Filtering/itktubeCropImageFilter.h
@@ -48,11 +48,11 @@ class CropImageFilter:
   public ExtractImageFilter< TInputImage, TOutputImage >
 {
 public:
-  /** Standard class typedefs. */
-  typedef CropImageFilter                                 Self;
-  typedef ExtractImageFilter< TInputImage, TOutputImage > Superclass;
-  typedef SmartPointer< Self >                            Pointer;
-  typedef SmartPointer< const Self >                      ConstPointer;
+  /** Standard class type alias. */
+  using Self = CropImageFilter;
+  using Superclass = ExtractImageFilter< TInputImage, TOutputImage >;
+  using Pointer = SmartPointer< Self >;
+  using ConstPointer = SmartPointer< const Self >;
 
   /** Method for creation through the object factory. */
   itkNewMacro( Self );
@@ -61,20 +61,20 @@ public:
   itkTypeMacro( CropImageFilter, ExtractImageFilter );
 
   /** Typedef to describe the output and input image region types. */
-  typedef typename Superclass::OutputImageRegionType OutputImageRegionType;
-  typedef typename Superclass::InputImageRegionType  InputImageRegionType;
+  using OutputImageRegionType = typename Superclass::OutputImageRegionType;
+  using InputImageRegionType = typename Superclass::InputImageRegionType;
 
   /** Typedef to describe the type of pixel. */
-  typedef typename Superclass::OutputImagePixelType OutputImagePixelType;
-  typedef typename Superclass::InputImagePixelType  InputImagePixelType;
+  using OutputImagePixelType = typename Superclass::OutputImagePixelType;
+  using InputImagePixelType = typename Superclass::InputImagePixelType;
 
   /** Typedef to describe the output and input image index and size types. */
-  typedef typename Superclass::OutputImageIndexType OutputImageIndexType;
-  typedef typename Superclass::InputImageIndexType  InputImageIndexType;
-  typedef typename Superclass::OutputImageSizeType  OutputImageSizeType;
-  typedef typename Superclass::InputImageSizeType   InputImageSizeType;
-  typedef InputImageSizeType                        SizeType;
-  typedef TInputImage                               ImageType;
+  using OutputImageIndexType = typename Superclass::OutputImageIndexType;
+  using InputImageIndexType = typename Superclass::InputImageIndexType;
+  using OutputImageSizeType = typename Superclass::OutputImageSizeType;
+  using InputImageSizeType = typename Superclass::InputImageSizeType;
+  using SizeType = InputImageSizeType;
+  using ImageType = TInputImage;
 
   /** ImageDimension constants */
   itkStaticConstMacro( InputImageDimension, unsigned int,

--- a/src/Filtering/itktubeCropTubesFilter.h
+++ b/src/Filtering/itktubeCropTubesFilter.h
@@ -44,21 +44,20 @@ class CropTubesFilter
     GroupSpatialObject< VDimension >, GroupSpatialObject< VDimension > >
 {
 public:
-  /** Standard class typedefs. */
-  typedef GroupSpatialObject< VDimension >      TubeGroupType;
+  /** Standard class type alias. */
+  using TubeGroupType = GroupSpatialObject< VDimension >;
 
-  typedef CropTubesFilter                            Self;
-  typedef SpatialObjectToSpatialObjectFilter< TubeGroupType, TubeGroupType >
-                                                     Superclass;
-  typedef SmartPointer< Self >                       Pointer;
-  typedef SmartPointer< const Self >                 ConstPointer;
-  typedef TubeSpatialObject< VDimension >      TubeType;
-  typedef TubeSpatialObjectPoint< VDimension > TubePointType;
+  using Self = CropTubesFilter;
+  using Superclass = SpatialObjectToSpatialObjectFilter< TubeGroupType, TubeGroupType >;
+  using Pointer = SmartPointer< Self >;
+  using ConstPointer = SmartPointer< const Self >;
+  using TubeType = TubeSpatialObject< VDimension >;
+  using TubePointType = TubeSpatialObjectPoint< VDimension >;
 
-  typedef double                                     PixelType;
-  typedef itk::Image< PixelType, VDimension >        ImageType;
-  typedef itk::Vector< PixelType, VDimension >       VectorType;
-  typedef itk::Point< double, VDimension >           PointType;
+  using PixelType = double;
+  using ImageType = itk::Image< PixelType, VDimension >;
+  using VectorType = itk::Vector< PixelType, VDimension >;
+  using PointType = itk::Point< double, VDimension >;
 
   /** Run-time type information ( and related methods ).   */
   itkTypeMacro( CropTubesFilter,

--- a/src/Filtering/itktubeDifferenceImageFilter.h
+++ b/src/Filtering/itktubeDifferenceImageFilter.h
@@ -49,11 +49,11 @@ class DifferenceImageFilter
   : public ImageToImageFilter< TInputImage, TOutputImage >
 {
 public:
-  /** Standard class typedefs. */
-  typedef DifferenceImageFilter                           Self;
-  typedef ImageToImageFilter< TInputImage, TOutputImage > Superclass;
-  typedef SmartPointer< Self >                            Pointer;
-  typedef SmartPointer< const Self >                      ConstPointer;
+  /** Standard class type alias. */
+  using Self = DifferenceImageFilter;
+  using Superclass = ImageToImageFilter< TInputImage, TOutputImage >;
+  using Pointer = SmartPointer< Self >;
+  using ConstPointer = SmartPointer< const Self >;
 
   /** Method for creation through the object factory. */
   itkNewMacro( Self );
@@ -61,14 +61,14 @@ public:
   /** Run-time type information ( and related methods ). */
   itkTypeMacro( DifferenceImageFilter, ImageToImageFilter );
 
-  /** Some convenient typedefs. */
-  typedef TInputImage                               InputImageType;
-  typedef TOutputImage                              OutputImageType;
-  typedef typename OutputImageType::PixelType       OutputPixelType;
-  typedef typename OutputImageType::RegionType      OutputImageRegionType;
+  /** Some convenient type alias. */
+  using InputImageType = TInputImage;
+  using OutputImageType = TOutputImage;
+  using OutputPixelType = typename OutputImageType::PixelType;
+  using OutputImageRegionType = typename OutputImageType::RegionType;
 
-  typedef typename NumericTraits<OutputPixelType>::RealType RealType;
-  typedef typename NumericTraits<RealType>::AccumulateType  AccumulateType;
+  using RealType = typename NumericTraits<OutputPixelType>::RealType;
+  using AccumulateType = typename NumericTraits<RealType>::AccumulateType;
 
   /** Set the valid image input.  This will be input 0.  */
   virtual void SetValidInput( const InputImageType* validImage );

--- a/src/Filtering/itktubeDifferenceImageFilter.hxx
+++ b/src/Filtering/itktubeDifferenceImageFilter.hxx
@@ -128,15 +128,14 @@ DifferenceImageFilter<TInputImage, TOutputImage>
 ::ThreadedGenerateData( const OutputImageRegionType &threadRegion,
   ThreadIdType threadId )
 {
-  typedef ConstNeighborhoodIterator<InputImageType>   SmartIterator;
-  typedef ImageRegionConstIterator<InputImageType>    InputIterator;
-  typedef ImageRegionIterator<OutputImageType>        OutputIterator;
-  typedef NeighborhoodAlgorithm::ImageBoundaryFacesCalculator<InputImageType>
-                                                      FacesCalculator;
-  typedef typename FacesCalculator::RadiusType        RadiusType;
-  typedef typename FacesCalculator::FaceListType      FaceListType;
-  typedef typename FaceListType::iterator             FaceListIterator;
-  typedef typename InputImageType::PixelType          InputPixelType;
+  using SmartIterator = ConstNeighborhoodIterator<InputImageType>;
+  using InputIterator = ImageRegionConstIterator<InputImageType>;
+  using OutputIterator = ImageRegionIterator<OutputImageType>;
+  using FacesCalculator = NeighborhoodAlgorithm::ImageBoundaryFacesCalculator<InputImageType>;
+  using RadiusType = typename FacesCalculator::RadiusType;
+  using FaceListType = typename FacesCalculator::FaceListType;
+  using FaceListIterator = typename FaceListType::iterator;
+  using InputPixelType = typename InputImageType::PixelType;
 
   // Prepare standard boundary condition.
   ZeroFluxNeumannBoundaryCondition<InputImageType> nbc;

--- a/src/Filtering/itktubeEnhanceContrastUsingPriorImageFilter.h
+++ b/src/Filtering/itktubeEnhanceContrastUsingPriorImageFilter.h
@@ -47,12 +47,12 @@ class EnhanceContrastUsingPriorImageFilter
   Image< TPixel, VDimension > >
 {
 public:
-  /** Standard class typedefs. */
-  typedef Image< TPixel, VDimension >                     ImageType;
-  typedef EnhanceContrastUsingPriorImageFilter            Self;
-  typedef ImageToImageFilter< ImageType, ImageType >      Superclass;
-  typedef SmartPointer< Self >                            Pointer;
-  typedef SmartPointer< const Self >                      ConstPointer;
+  /** Standard class type alias. */
+  using ImageType = Image< TPixel, VDimension >;
+  using Self = EnhanceContrastUsingPriorImageFilter;
+  using Superclass = ImageToImageFilter< ImageType, ImageType >;
+  using Pointer = SmartPointer< Self >;
+  using ConstPointer = SmartPointer< const Self >;
 
   /** Method for creation through the object factory. */
   itkNewMacro( Self );
@@ -60,12 +60,11 @@ public:
   /** Run-time type information ( and related methods ). */
   itkTypeMacro( EnhanceContrastUsingPriorImageFilter, ImageToImageFilter );
 
-  /** Some convenient typedefs. */
-  typedef itk::tube::ContrastCostFunction< TPixel, VDimension >
-                                                ContrastCostFunctionType;
-  typedef itk::OnePlusOneEvolutionaryOptimizer  InitialOptimizerType;
-  typedef itk::FRPROptimizer                    OptimizerType;
-  typedef itk::ImageRegionIterator< ImageType > ImageIteratorType;
+  /** Some convenient type alias. */
+  using ContrastCostFunctionType = itk::tube::ContrastCostFunction< TPixel, VDimension >;
+  using InitialOptimizerType = itk::OnePlusOneEvolutionaryOptimizer;
+  using OptimizerType = itk::FRPROptimizer;
+  using ImageIteratorType = itk::ImageRegionIterator< ImageType >;
 
   /** Set/Get input Mask Image */
   itkSetObjectMacro( InputMaskImage, ImageType );

--- a/src/Filtering/itktubeExtractTubePointsSpatialObjectFilter.h
+++ b/src/Filtering/itktubeExtractTubePointsSpatialObjectFilter.h
@@ -56,23 +56,21 @@ template< class TTubeSpatialObject >
 class ExtractTubePointsSpatialObjectFilter : public ProcessObject
 {
 public:
-  /** Standard class typedefs. */
-  typedef ExtractTubePointsSpatialObjectFilter Self;
-  typedef ProcessObject                        Superclass;
-  typedef SmartPointer< Self >                 Pointer;
-  typedef SmartPointer< const Self >           ConstPointer;
+  /** Standard class type alias. */
+  using Self = ExtractTubePointsSpatialObjectFilter;
+  using Superclass = ProcessObject;
+  using Pointer = SmartPointer< Self >;
+  using ConstPointer = SmartPointer< const Self >;
 
-  typedef TTubeSpatialObject                   TubeSpatialObjectType;
+  using TubeSpatialObjectType = TTubeSpatialObject;
 
-  typedef typename TTubeSpatialObject::TubePointType   TubePointType;
+  using TubePointType = typename TTubeSpatialObject::TubePointType;
 
-  typedef VectorContainer< IdentifierType, TubePointType > PointsContainerType;
+  using PointsContainerType = VectorContainer< IdentifierType, TubePointType >;
 
-  typedef DataObjectDecorator< PointsContainerType >
-                                               PointsContainerDecoratorType;
+  using PointsContainerDecoratorType = DataObjectDecorator< PointsContainerType >;
 
-  typedef GroupSpatialObject< TubeSpatialObjectType::ObjectDimension >
-                                               GroupSpatialObjectType;
+  using GroupSpatialObjectType = GroupSpatialObject< TubeSpatialObjectType::ObjectDimension >;
 
   /** Run-time type information ( and related methods ). */
   itkTypeMacro( ExtractTubePointsSpatialObjectFilter, ProcessObject );

--- a/src/Filtering/itktubeExtractTubePointsSpatialObjectFilter.hxx
+++ b/src/Filtering/itktubeExtractTubePointsSpatialObjectFilter.hxx
@@ -126,7 +126,7 @@ ExtractTubePointsSpatialObjectFilter< TTubeSpatialObject >
   const GroupSpatialObjectType * inputGroup = this->GetInput();
 
   char childName[] = "Tube";
-  typedef typename TubeSpatialObjectType::ChildrenListType ChildrenListType;
+  using ChildrenListType = typename TubeSpatialObjectType::ChildrenListType;
   ChildrenListType * childrenList =
     inputGroup->GetChildren( inputGroup->GetMaximumDepth(), childName );
 

--- a/src/Filtering/itktubeFFTGaussianDerivativeIFFTFilter.h
+++ b/src/Filtering/itktubeFFTGaussianDerivativeIFFTFilter.h
@@ -46,11 +46,11 @@ class FFTGaussianDerivativeIFFTFilter :
 {
 public:
 
-  typedef FFTGaussianDerivativeIFFTFilter               Self;
-  typedef GaussianDerivativeFilter< TInputImage,
-    TOutputImage >                                      Superclass;
-  typedef SmartPointer< Self >                          Pointer;
-  typedef SmartPointer< const Self >                    ConstPointer;
+  using Self = FFTGaussianDerivativeIFFTFilter;
+  using Superclass = GaussianDerivativeFilter< TInputImage,
+    TOutputImage >;
+  using Pointer = SmartPointer< Self >;
+  using ConstPointer = SmartPointer< const Self >;
 
   itkNewMacro( Self );
 
@@ -59,14 +59,14 @@ public:
   itkStaticConstMacro( ImageDimension, unsigned int,
     TInputImage::ImageDimension );
 
-  typedef TInputImage                         InputImageType;
-  typedef TOutputImage                        OutputImageType;
-  typedef Image< double, ImageDimension >     RealImageType;
-  typedef typename RealImageType::Pointer     RealImagePointerType;
+  using InputImageType = TInputImage;
+  using OutputImageType = TOutputImage;
+  using RealImageType = Image< double, ImageDimension >;
+  using RealImagePointerType = typename RealImageType::Pointer;
   typedef typename Superclass::GaussianDerivativeImageSourceType
                                               GaussianDerivativeImageSourceType;
-  typedef typename Superclass::OrdersType     OrdersType;
-  typedef typename Superclass::SigmasType     SigmasType;
+  using OrdersType = typename Superclass::OrdersType;
+  using SigmasType = typename Superclass::SigmasType;
 
   void GenerateNJet( typename OutputImageType::Pointer & D,
     std::vector< typename TOutputImage::Pointer > & Dx,
@@ -75,18 +75,16 @@ public:
   void GenerateData() override;
 
 protected:
-  typedef ForwardFFTImageFilter< RealImageType >          FFTFilterType;
+  using FFTFilterType = ForwardFFTImageFilter< RealImageType >;
 
-  typedef typename FFTFilterType::OutputImageType         ComplexImageType;
+  using ComplexImageType = typename FFTFilterType::OutputImageType;
 
-  typedef FFTShiftImageFilter< RealImageType, RealImageType >
-                                                          FFTShiftFilterType;
+  using FFTShiftFilterType = FFTShiftImageFilter< RealImageType, RealImageType >;
 
-  typedef InverseFFTImageFilter< ComplexImageType, RealImageType >
-                                                          InverseFFTFilterType;
+  using InverseFFTFilterType = InverseFFTImageFilter< ComplexImageType, RealImageType >;
 
-  typedef MultiplyImageFilter< ComplexImageType, ComplexImageType,
-    ComplexImageType >                                    MultiplyFilterType;
+  using MultiplyFilterType = MultiplyImageFilter< ComplexImageType, ComplexImageType,
+    ComplexImageType >;
 
   FFTGaussianDerivativeIFFTFilter( void );
   virtual ~FFTGaussianDerivativeIFFTFilter( void ) {}

--- a/src/Filtering/itktubeFFTGaussianDerivativeIFFTFilter.hxx
+++ b/src/Filtering/itktubeFFTGaussianDerivativeIFFTFilter.hxx
@@ -48,7 +48,7 @@ void
 FFTGaussianDerivativeIFFTFilter<TInputImage, TOutputImage>
 ::ComputeInputImageFFT()
 {
-  typedef PadImageFilter< InputImageType, RealImageType >   PadFilterType;
+  using PadFilterType = PadImageFilter< InputImageType, RealImageType >;
   typename PadFilterType::Pointer padFilter = PadFilterType::New();
   padFilter->SetInput( this->GetInput() );
   padFilter->SetGreatestPrimeFactor( 5 );
@@ -142,8 +142,7 @@ FFTGaussianDerivativeIFFTFilter<TInputImage, TOutputImage>
   iFFTFilter->SetInput( m_ConvolvedImageFFT );
   iFFTFilter->Update();
 
-  typedef RegionFromReferenceImageFilter< RealImageType, TOutputImage >
-    RegionFromFilterType;
+  using RegionFromFilterType = RegionFromReferenceImageFilter< RealImageType, TOutputImage >;
   typename RegionFromFilterType::Pointer regionFrom =
     RegionFromFilterType::New();
 

--- a/src/Filtering/itktubeGaussianDerivativeFilter.h
+++ b/src/Filtering/itktubeGaussianDerivativeFilter.h
@@ -34,11 +34,11 @@ class GaussianDerivativeFilter :
 {
 public:
 
-  /** Standard class typedefs. */
-  typedef GaussianDerivativeFilter                        Self;
-  typedef ImageToImageFilter< TInputImage, TOutputImage > Superclass;
-  typedef SmartPointer< Self >                            Pointer;
-  typedef SmartPointer< const Self >                      ConstPointer;
+  /** Standard class type alias. */
+  using Self = GaussianDerivativeFilter;
+  using Superclass = ImageToImageFilter< TInputImage, TOutputImage >;
+  using Pointer = SmartPointer< Self >;
+  using ConstPointer = SmartPointer< const Self >;
 
   /** Run-time type information ( and related methods ). */
   itkTypeMacro( GaussianDerivativeFilter, ImageToImageFilter );
@@ -46,12 +46,11 @@ public:
   itkStaticConstMacro( ImageDimension, unsigned int,
                        TInputImage::ImageDimension );
 
-  typedef TInputImage                         InputImageType;
-  typedef TOutputImage                        OutputImageType;
-  typedef Image< double, ImageDimension >     RealImageType;
-  typedef typename RealImageType::Pointer     RealImagePointerType;
-  typedef GaussianDerivativeImageSource< RealImageType >
-                                              GaussianDerivativeImageSourceType;
+  using InputImageType = TInputImage;
+  using OutputImageType = TOutputImage;
+  using RealImageType = Image< double, ImageDimension >;
+  using RealImagePointerType = typename RealImageType::Pointer;
+  using GaussianDerivativeImageSourceType = GaussianDerivativeImageSource< RealImageType >;
   typedef typename GaussianDerivativeImageSourceType::OrdersType
                                               OrdersType;
   typedef typename GaussianDerivativeImageSourceType::SigmasType

--- a/src/Filtering/itktubeGaussianDerivativeImageSource.h
+++ b/src/Filtering/itktubeGaussianDerivativeImageSource.h
@@ -49,48 +49,48 @@ class GaussianDerivativeImageSource :
     public ParametricImageSource< TOutputImage >
 {
 public:
-  /** Standard class typedefs. */
-  typedef GaussianDerivativeImageSource              Self;
-  typedef ParametricImageSource< TOutputImage >      Superclass;
-  typedef SmartPointer< Self >                       Pointer;
-  typedef SmartPointer< const Self >                 ConstPointer;
+  /** Standard class type alias. */
+  using Self = GaussianDerivativeImageSource;
+  using Superclass = ParametricImageSource< TOutputImage >;
+  using Pointer = SmartPointer< Self >;
+  using ConstPointer = SmartPointer< const Self >;
 
   /** Typedef for the output image type. */
-  typedef TOutputImage                     OutputImageType;
+  using OutputImageType = TOutputImage;
 
   /** Typedef for the output image PixelType. */
-  typedef typename TOutputImage::PixelType OutputImagePixelType;
+  using OutputImagePixelType = typename TOutputImage::PixelType;
 
   /** Typedef to describe the output image region type. */
-  typedef typename TOutputImage::RegionType OutputImageRegionType;
+  using OutputImageRegionType = typename TOutputImage::RegionType;
 
-  /** Spacing typedef support.  Spacing holds the size of a pixel.  The
+  /** Spacing type alias support.  Spacing holds the size of a pixel.  The
    * spacing is the geometric distance between image samples. */
-  typedef typename TOutputImage::SpacingType SpacingType;
+  using SpacingType = typename TOutputImage::SpacingType;
 
-  /** Origin typedef support.  The origin is the geometric coordinates
+  /** Origin type alias support.  The origin is the geometric coordinates
    * of the index ( 0,0 ). */
-  typedef typename TOutputImage::PointType PointType;
+  using PointType = typename TOutputImage::PointType;
 
-  /** Direction typedef support.  The direction is the direction
+  /** Direction type alias support.  The direction is the direction
    * cosines of the image. */
-  typedef typename TOutputImage::DirectionType DirectionType;
+  using DirectionType = typename TOutputImage::DirectionType;
 
   /** Dimensionality of the output image */
   itkStaticConstMacro( NDimensions, unsigned int,
     TOutputImage::ImageDimension );
 
-  typedef Vector< double, TOutputImage::ImageDimension > SigmasType;
-  typedef Vector< int, TOutputImage::ImageDimension >    OrdersType;
+  using SigmasType = Vector< double, TOutputImage::ImageDimension >;
+  using OrdersType = Vector< int, TOutputImage::ImageDimension >;
 
   /** Size type matches that used for images */
-  typedef typename TOutputImage::IndexType     IndexType;
-  typedef typename TOutputImage::SizeType      SizeType;
-  typedef typename TOutputImage::SizeValueType SizeValueType;
+  using IndexType = typename TOutputImage::IndexType;
+  using SizeType = typename TOutputImage::SizeType;
+  using SizeValueType = typename TOutputImage::SizeValueType;
 
   /** Types for parameters. */
-  typedef typename Superclass::ParametersValueType ParametersValueType;
-  typedef typename Superclass::ParametersType      ParametersType;
+  using ParametersValueType = typename Superclass::ParametersValueType;
+  using ParametersType = typename Superclass::ParametersType;
 
   /** Run-time type information ( and related methods ). */
   itkTypeMacro( GaussianDerivativeImageSource, ParametricImageSource );

--- a/src/Filtering/itktubeGaussianDerivativeImageSource.hxx
+++ b/src/Filtering/itktubeGaussianDerivativeImageSource.hxx
@@ -136,7 +136,7 @@ GaussianDerivativeImageSource< TOutputImage >
   outputPtr->Allocate();
 
   // Create an iterator that will walk the output region
-  typedef itk::ImageRegionIterator< TOutputImage > OutputIterator;
+  using OutputIterator = itk::ImageRegionIterator< TOutputImage >;
   OutputIterator outIt = OutputIterator( outputPtr,
                                          outputPtr->GetRequestedRegion() );
 

--- a/src/Filtering/itktubeInverseIntensityImageFilter.h
+++ b/src/Filtering/itktubeInverseIntensityImageFilter.h
@@ -42,23 +42,23 @@ class InverseIntensityImageFilter
 {
 public:
 
-  /** Standard class typedefs. */
-  typedef InverseIntensityImageFilter                     Self;
-  typedef ImageToImageFilter< TInputImage, TInputImage>   SuperClass;
+  /** Standard class type alias. */
+  using Self = InverseIntensityImageFilter;
+  using SuperClass = ImageToImageFilter< TInputImage, TInputImage>;
 
-  typedef SmartPointer< Self >                            Pointer;
-  typedef SmartPointer< const Self >                      ConstPointer;
+  using Pointer = SmartPointer< Self >;
+  using ConstPointer = SmartPointer< const Self >;
 
-  typedef TInputImage                             InputImageType;
-  typedef typename InputImageType::PixelType      InputPixelType;
-  typedef typename InputImageType::Pointer        InputImagePointer;
-  typedef typename InputImageType::ConstPointer   InputImageConstPointer;
+  using InputImageType = TInputImage;
+  using InputPixelType = typename InputImageType::PixelType;
+  using InputImagePointer = typename InputImageType::Pointer;
+  using InputImageConstPointer = typename InputImageType::ConstPointer;
 
-  typedef TInputImage                             OutputImageType;
-  typedef typename OutputImageType::PixelType     OutputPixelType;
-  typedef typename OutputImageType::Pointer       OutputImagePointer;
+  using OutputImageType = TInputImage;
+  using OutputPixelType = typename OutputImageType::PixelType;
+  using OutputImagePointer = typename OutputImageType::Pointer;
 
-  typedef typename InputImageType::RegionType     RegionType;
+  using RegionType = typename InputImageType::RegionType;
 
   /** Method for creation through the object factory. */
   itkNewMacro( Self );

--- a/src/Filtering/itktubeInverseIntensityImageFilter.hxx
+++ b/src/Filtering/itktubeInverseIntensityImageFilter.hxx
@@ -83,8 +83,8 @@ InverseIntensityImageFilter<TInputImage>
   if( m_InverseMaximumIntensity ) { myMax = m_InverseMaximumIntensity;  }
 
   // ** Build Input and output iterators for inversion ** //
-  typedef  ImageRegionConstIterator<InputImageType>      InputIteratorType;
-  typedef  ImageRegionIterator<OutputImageType>          OutputIteratorType;
+  using InputIteratorType = ImageRegionConstIterator<InputImageType>;
+  using OutputIteratorType = ImageRegionIterator<OutputImageType>;
   InputIteratorType it_input( InputImage, region );
   OutputIteratorType it_output( OutputImage, region );
 

--- a/src/Filtering/itktubeMinimumSpanningTreeVesselConnectivityFilter.h
+++ b/src/Filtering/itktubeMinimumSpanningTreeVesselConnectivityFilter.h
@@ -51,21 +51,20 @@ class MinimumSpanningTreeVesselConnectivityFilter
     GroupSpatialObject< ObjectDimension >, GroupSpatialObject< ObjectDimension > >
 {
 public:
-  /** Standard class typedefs. */
-  typedef GroupSpatialObject< ObjectDimension >      TubeGroupType;
+  /** Standard class type alias. */
+  using TubeGroupType = GroupSpatialObject< ObjectDimension >;
 
   typedef MinimumSpanningTreeVesselConnectivityFilter
                                                 Self;
-  typedef SpatialObjectToSpatialObjectFilter< TubeGroupType, TubeGroupType >
-                                                Superclass;
-  typedef SmartPointer< Self >                  Pointer;
-  typedef SmartPointer< const Self >            ConstPointer;
+  using Superclass = SpatialObjectToSpatialObjectFilter< TubeGroupType, TubeGroupType >;
+  using Pointer = SmartPointer< Self >;
+  using ConstPointer = SmartPointer< const Self >;
 
-  typedef TubeSpatialObject< ObjectDimension > TubeType;
-  typedef typename TubeType::Pointer            TubePointerType;
-  typedef typename TubeType::ConstPointer       TubeConstPointerType;
-  typedef itk::IndexValueType                   TubeIdType;
-  typedef std::vector< TubeIdType >             TubeIdListType;
+  using TubeType = TubeSpatialObject< ObjectDimension >;
+  using TubePointerType = typename TubeType::Pointer;
+  using TubeConstPointerType = typename TubeType::ConstPointer;
+  using TubeIdType = itk::IndexValueType;
+  using TubeIdListType = std::vector< TubeIdType >;
 
   /** Run-time type information ( and related methods ).   */
   itkTypeMacro( MinimumSpanningTreeVesselConnectivityFilter,
@@ -138,12 +137,9 @@ private:
     bool operator>( const ConnectionPointType & rhs ) const;
     };
 
-  typedef std::unordered_map< TubeIdType, GraphEdgeType >
-  GraphEdgeListType;
-  typedef std::unordered_map< TubeIdType, GraphEdgeListType >
-  TubeAdjacencyListGraphType;
-  typedef std::unordered_map< TubeIdType, TubePointerType >
-  TubeIdToPointerMapType;
+  using GraphEdgeListType = std::unordered_map< TubeIdType, GraphEdgeType >;
+  using TubeAdjacencyListGraphType = std::unordered_map< TubeIdType, GraphEdgeListType >;
+  using TubeIdToPointerMapType = std::unordered_map< TubeIdType, TubePointerType >;
 
   struct TubePQElementType
     {

--- a/src/Filtering/itktubeMinimumSpanningTreeVesselConnectivityFilter.hxx
+++ b/src/Filtering/itktubeMinimumSpanningTreeVesselConnectivityFilter.hxx
@@ -126,7 +126,7 @@ MinimumSpanningTreeVesselConnectivityFilter< ObjectDimension >
   // build a map between tube id and tube object
   tubeDebugMacro( << "Computing Tube ID to Object Map" );
 
-  typedef typename TubeGroupType::ChildrenListPointer TubeListPointerType;
+  using TubeListPointerType = typename TubeGroupType::ChildrenListPointer;
 
   char tubeName[] = "Tube";
   TubeListPointerType pTubeList
@@ -146,10 +146,10 @@ MinimumSpanningTreeVesselConnectivityFilter< ObjectDimension >
   // build graph
   tubeDebugMacro( << "Building tube graph" );
 
-  typedef typename TubeType::TubePointListType TubePointListType;
-  typedef typename TubeType::TubePointType     TubePointType;
-  typedef typename TubeType::PointType         PositionType;
-  typedef typename PositionType::VectorType    PositionVectorType;
+  using TubePointListType = typename TubeType::TubePointListType;
+  using TubePointType = typename TubeType::TubePointType;
+  using PositionType = typename TubeType::PointType;
+  using PositionVectorType = typename PositionType::VectorType;
 
   m_TubeGraph.clear();
 
@@ -577,7 +577,7 @@ MinimumSpanningTreeVesselConnectivityFilter< ObjectDimension >
 
   tubeDebugMacro( << "Adding remaining tubes to the output spatial group" );
 
-  typedef typename TubeGroupType::ChildrenListPointer TubeListPointerType;
+  using TubeListPointerType = typename TubeGroupType::ChildrenListPointer;
 
   char tubeName[] = "Tube";
   TubeListPointerType pTubeList

--- a/src/Filtering/itktubePadImageFilter.h
+++ b/src/Filtering/itktubePadImageFilter.h
@@ -53,26 +53,26 @@ class ITK_EXPORT PadImageFilter :
     public ImageToImageFilter<TInputImage, TOutputImage>
 {
 public:
-  /** Standard class typedefs. */
-  typedef PadImageFilter Self;
+  /** Standard class type alias. */
+  using Self = PadImageFilter;
 
-  typedef ImageToImageFilter<TInputImage, TOutputImage> Superclass;
+  using Superclass = ImageToImageFilter<TInputImage, TOutputImage>;
 
-  typedef SmartPointer<Self>        Pointer;
-  typedef SmartPointer<const Self>  ConstPointer;
+  using Pointer = SmartPointer<Self>;
+  using ConstPointer = SmartPointer<const Self>;
 
-  /** Some convenient typedefs. */
-  typedef TInputImage                              InputImageType;
-  typedef TOutputImage                             OutputImageType;
-  typedef typename InputImageType::Pointer         InputImagePointer;
-  typedef typename InputImageType::ConstPointer    InputImageConstPointer;
-  typedef typename InputImageType::PixelType       InputImagePixelType;
-  typedef typename OutputImageType::Pointer        OutputImagePointer;
-  typedef typename OutputImageType::ConstPointer   OutputImageConstPointer;
-  typedef typename OutputImageType::PixelType      OutputImagePixelType;
-  typedef typename InputImageType::RegionType      RegionType;
-  typedef typename InputImageType::IndexType       IndexType;
-  typedef typename InputImageType::SizeType        SizeType;
+  /** Some convenient type alias. */
+  using InputImageType = TInputImage;
+  using OutputImageType = TOutputImage;
+  using InputImagePointer = typename InputImageType::Pointer;
+  using InputImageConstPointer = typename InputImageType::ConstPointer;
+  using InputImagePixelType = typename InputImageType::PixelType;
+  using OutputImagePointer = typename OutputImageType::Pointer;
+  using OutputImageConstPointer = typename OutputImageType::ConstPointer;
+  using OutputImagePixelType = typename OutputImageType::PixelType;
+  using RegionType = typename InputImageType::RegionType;
+  using IndexType = typename InputImageType::IndexType;
+  using SizeType = typename InputImageType::SizeType;
 
   /** ImageDimension constants */
   itkStaticConstMacro( InputImageDimension, unsigned int,

--- a/src/Filtering/itktubePadImageFilter.hxx
+++ b/src/Filtering/itktubePadImageFilter.hxx
@@ -129,16 +129,16 @@ PadImageFilter<TInputImage, TOutputImage>
   ProgressAccumulator::Pointer progress = ProgressAccumulator::New();
   progress->SetMiniPipelineFilter( this );
 
-  typedef typename itk::PadImageFilter
-    < InputImageType, OutputImageType > PadType;
-  typedef typename itk::ConstantPadImageFilter
-    < InputImageType, OutputImageType > ConstantPadType;
-  typedef typename itk::ZeroFluxNeumannPadImageFilter
-    < InputImageType, OutputImageType > ZeroFluxPadType;
-  typedef typename itk::MirrorPadImageFilter
-    < InputImageType, OutputImageType > MirrorPadType;
-  typedef typename itk::WrapPadImageFilter
-    < InputImageType, OutputImageType > WrapPadType;
+  using PadType = typename itk::PadImageFilter
+    < InputImageType, OutputImageType >;
+  using ConstantPadType = typename itk::ConstantPadImageFilter
+    < InputImageType, OutputImageType >;
+  using ZeroFluxPadType = typename itk::ZeroFluxNeumannPadImageFilter
+    < InputImageType, OutputImageType >;
+  using MirrorPadType = typename itk::MirrorPadImageFilter
+    < InputImageType, OutputImageType >;
+  using WrapPadType = typename itk::WrapPadImageFilter
+    < InputImageType, OutputImageType >;
   SizeType s;
  
   typename PadType::Pointer pad0;

--- a/src/Filtering/itktubeReResampleImageFilter.h
+++ b/src/Filtering/itktubeReResampleImageFilter.h
@@ -48,20 +48,20 @@ class ReResampleImageFilter
 {
 public:
 
-  /** Standard class typedefs. */
-  typedef Image< TPixel, VDimension >                     ImageType;
-  typedef ReResampleImageFilter                           Self;
-  typedef itk::ProcessObject                              Superclass;
-  typedef SmartPointer< Self >                            Pointer;
-  typedef SmartPointer< const Self >                      ConstPointer;
+  /** Standard class type alias. */
+  using ImageType = Image< TPixel, VDimension >;
+  using Self = ReResampleImageFilter;
+  using Superclass = itk::ProcessObject;
+  using Pointer = SmartPointer< Self >;
+  using ConstPointer = SmartPointer< const Self >;
 
   /** Method for creation through the object factory. */
   itkNewMacro( Self );
 
   itkTypeMacro( ReResampleImageFilter, ProcessObject );
 
-  typedef typename ImageType::Pointer                     ImagePointer;
-  typedef itk::Transform< double, VDimension, VDimension> TransformType;
+  using ImagePointer = typename ImageType::Pointer;
+  using TransformType = itk::Transform< double, VDimension, VDimension>;
 
 
   /** Set/Get input Match Image */
@@ -122,8 +122,7 @@ private:
   ReResampleImageFilter( const Self& );
   void operator=( const Self& );
 
-  typedef typename itk::ResampleImageFilter< ImageType, ImageType >
-    ResampleFilterType;
+  using ResampleFilterType = typename itk::ResampleImageFilter< ImageType, ImageType >;
   typename ResampleFilterType::Pointer   m_Filter;
 
   typename ImageType::Pointer            m_MatchImage;

--- a/src/Filtering/itktubeReResampleImageFilter.hxx
+++ b/src/Filtering/itktubeReResampleImageFilter.hxx
@@ -186,31 +186,30 @@ Update( void )
       }
     }
 
-  typedef typename itk::InterpolateImageFunction< ImageType, double >
-    InterpType;
+  using InterpType = typename itk::InterpolateImageFunction< ImageType, double >;
   typename InterpType::Pointer interp;
   if( m_Interpolator == "Sinc" )
     {
-    typedef typename itk::WindowedSincInterpolateImageFunction<
-      ImageType, VDimension >     SincInterpType;
+    using SincInterpType = typename itk::WindowedSincInterpolateImageFunction<
+      ImageType, VDimension >;
     interp = SincInterpType::New();
     }
   else if( m_Interpolator == "BSpline" )
     {
-    typedef typename itk::BSplineInterpolateImageFunction<
-      ImageType, double >         BSplineInterpType;
+    using BSplineInterpType = typename itk::BSplineInterpolateImageFunction<
+      ImageType, double >;
     interp = BSplineInterpType::New();
     }
   else if( m_Interpolator == "NearestNeighbor" )
     {
-    typedef typename itk::NearestNeighborInterpolateImageFunction<
-      ImageType, double >    NearestNeighborInterpType;
+    using NearestNeighborInterpType = typename itk::NearestNeighborInterpolateImageFunction<
+      ImageType, double >;
     interp = NearestNeighborInterpType::New();
     }
   else // default = if( interpolator == "Linear" )
     {
-    typedef typename itk::LinearInterpolateImageFunction<
-      ImageType, double >    LinearInterpType;
+    using LinearInterpType = typename itk::LinearInterpolateImageFunction<
+      ImageType, double >;
     interp = LinearInterpType::New();
     }
   m_Filter->SetInterpolator( interp );

--- a/src/Filtering/itktubeRegionFromReferenceImageFilter.h
+++ b/src/Filtering/itktubeRegionFromReferenceImageFilter.h
@@ -41,11 +41,11 @@ class ITK_EXPORT RegionFromReferenceImageFilter
   : public ExtractImageFilter<TInputImage, TOutputImage>
 {
 public:
-  /** Standard class typedefs. */
-  typedef RegionFromReferenceImageFilter                 Self;
-  typedef ExtractImageFilter<TInputImage, TOutputImage>  Superclass;
-  typedef SmartPointer<Self>                             Pointer;
-  typedef SmartPointer<const Self>                       ConstPointer;
+  /** Standard class type alias. */
+  using Self = RegionFromReferenceImageFilter;
+  using Superclass = ExtractImageFilter<TInputImage, TOutputImage>;
+  using Pointer = SmartPointer<Self>;
+  using ConstPointer = SmartPointer<const Self>;
 
   /** Method for creation through the object factory. */
   itkNewMacro( Self );
@@ -54,19 +54,19 @@ public:
   itkTypeMacro( RegionFromReferenceImageFilter, ExtractImageFilter );
 
   /** Typedef to describe the output and input image region types. */
-  typedef typename Superclass::OutputImageRegionType OutputImageRegionType;
-  typedef typename Superclass::InputImageRegionType  InputImageRegionType;
+  using OutputImageRegionType = typename Superclass::OutputImageRegionType;
+  using InputImageRegionType = typename Superclass::InputImageRegionType;
 
   /** Typedef to describe the type of pixel. */
-  typedef typename Superclass::OutputImagePixelType OutputImagePixelType;
-  typedef typename Superclass::InputImagePixelType  InputImagePixelType;
+  using OutputImagePixelType = typename Superclass::OutputImagePixelType;
+  using InputImagePixelType = typename Superclass::InputImagePixelType;
 
   /** Typedef to describe the output and input image index and size types. */
-  typedef typename Superclass::OutputImageIndexType OutputImageIndexType;
-  typedef typename Superclass::InputImageIndexType  InputImageIndexType;
-  typedef typename Superclass::OutputImageSizeType  OutputImageSizeType;
-  typedef typename Superclass::InputImageSizeType   InputImageSizeType;
-  typedef InputImageSizeType                        SizeType;
+  using OutputImageIndexType = typename Superclass::OutputImageIndexType;
+  using InputImageIndexType = typename Superclass::InputImageIndexType;
+  using OutputImageSizeType = typename Superclass::OutputImageSizeType;
+  using InputImageSizeType = typename Superclass::InputImageSizeType;
+  using SizeType = InputImageSizeType;
 
   /** ImageDimension constants */
   itkStaticConstMacro( InputImageDimension, unsigned int,
@@ -76,8 +76,7 @@ public:
   itkStaticConstMacro( ImageDimension, unsigned int,
     Superclass::OutputImageDimension );
 
-  typedef ImageBase< itkGetStaticConstMacro( ImageDimension ) >
-    ReferenceImageType;
+  using ReferenceImageType = ImageBase< itkGetStaticConstMacro( ImageDimension ) >;
 
   /** Copy the output information from another Image. */
   void SetReferenceImage ( const ReferenceImageType *image );

--- a/src/Filtering/itktubeResampleTubesFilter.h
+++ b/src/Filtering/itktubeResampleTubesFilter.h
@@ -43,26 +43,25 @@ class ResampleTubesFilter
   : public SpatialObjectFilter< ObjectDimension >
 {
 public:
-  /** Standard class typedefs. */
-  typedef itk::SpatialObject< ObjectDimension >      SpatialObjectType;
+  /** Standard class type alias. */
+  using SpatialObjectType = itk::SpatialObject< ObjectDimension >;
 
-  typedef ResampleTubesFilter< ObjectDimension >     Self;
-  typedef SpatialObjectFilter< ObjectDimension >     Superclass;
-  typedef SmartPointer< Self >                  Pointer;
-  typedef SmartPointer< const Self >            ConstPointer;
+  using Self = ResampleTubesFilter< ObjectDimension >;
+  using Superclass = SpatialObjectFilter< ObjectDimension >;
+  using Pointer = SmartPointer< Self >;
+  using ConstPointer = SmartPointer< const Self >;
 
-  typedef char                                  PixelType;
-  typedef itk::Image< PixelType, ObjectDimension >   ImageType;
+  using PixelType = char;
+  using ImageType = itk::Image< PixelType, ObjectDimension >;
 
   /** Typedefs for Displacement field tranform.    */
-  typedef itk::DisplacementFieldTransform< double, ObjectDimension >
-    DisplacementFieldTransformType;
+  using DisplacementFieldTransformType = itk::DisplacementFieldTransform< double, ObjectDimension >;
   typedef typename DisplacementFieldTransformType::DisplacementFieldType
     DisplacementFieldType;
 
   /** Typedefs for transform read from a file    */
-  typedef itk::TransformBaseTemplate< double >        BaseTransformType;
-  typedef std::list< BaseTransformType::Pointer >     BaseTransformListType;
+  using BaseTransformType = itk::TransformBaseTemplate< double >;
+  using BaseTransformListType = std::list< BaseTransformType::Pointer >;
 
   /** Run-time type information ( and related methods ).   */
   itkTypeMacro( ResampleTubesFilter,

--- a/src/Filtering/itktubeResampleTubesFilter.hxx
+++ b/src/Filtering/itktubeResampleTubesFilter.hxx
@@ -106,9 +106,8 @@ ResampleTubesFilter< ObjectDimension >
   typename SpatialObjectType::ConstPointer inSO = this->GetInput();
 
   /** Typedefs for Displacement field tranform filter.    */
-  typedef itk::tube::PointBasedSpatialObjectTransformFilter<
-    DisplacementFieldTransformType, ObjectDimension >
-    DisplacementFieldTransformFilterType;
+  using DisplacementFieldTransformFilterType = itk::tube::PointBasedSpatialObjectTransformFilter<
+    DisplacementFieldTransformType, ObjectDimension >;
 
   // Create new transform
   typename DisplacementFieldTransformType::Pointer transform =
@@ -139,12 +138,10 @@ ResampleTubesFilter< ObjectDimension >
   typename SpatialObjectType::ConstPointer inSO = this->GetInput();
 
   /** Typedefs for transform read from a file    */
-  typedef itk::MatrixOffsetTransformBase< double, ObjectDimension, ObjectDimension >
-    MatrixOffsetTransformType;
-  typedef itk::tube::PointBasedSpatialObjectTransformFilter<
+  using MatrixOffsetTransformType = itk::MatrixOffsetTransformBase< double, ObjectDimension, ObjectDimension >;
+  using MatrixOffsetTransformFilterType = itk::tube::PointBasedSpatialObjectTransformFilter<
     MatrixOffsetTransformType,
-    ObjectDimension >
-    MatrixOffsetTransformFilterType;
+    ObjectDimension >;
 
   BaseTransformListType::const_iterator tListIt;
   tListIt = m_ReadTransformList->begin();
@@ -184,12 +181,10 @@ ResampleTubesFilter< ObjectDimension >
   typename SpatialObjectType::ConstPointer inSO = this->GetInput();
 
   /** Typedefs for Affine Transform */
-  typedef itk::AffineTransform< double, ObjectDimension >
-    AffineTransformType;
-  typedef itk::tube::PointBasedSpatialObjectTransformFilter<
+  using AffineTransformType = itk::AffineTransform< double, ObjectDimension >;
+  using AffineTransformFilterType = itk::tube::PointBasedSpatialObjectTransformFilter<
     AffineTransformType,
-    ObjectDimension >
-    AffineTransformFilterType;
+    ObjectDimension >;
 
   typename AffineTransformType::Pointer identityAffineTransform =
     AffineTransformType::New();
@@ -249,8 +244,7 @@ ResampleTubesFilter< ObjectDimension >
   if( m_SamplingFactor != 1 )
     {
     /** Typedefs for Sub samppling filter     */
-    typedef itk::tube::SubSampleSpatialObjectFilter<ObjectDimension>
-      SubSampleFilterType;
+    using SubSampleFilterType = itk::tube::SubSampleSpatialObjectFilter<ObjectDimension>;
 
     typename SubSampleFilterType::Pointer subSampleFilter =
       SubSampleFilterType::New();

--- a/src/Filtering/itktubeRidgeFFTFilter.h
+++ b/src/Filtering/itktubeRidgeFFTFilter.h
@@ -34,14 +34,14 @@ class RidgeFFTFilter :
 {
 public:
 
-  typedef TInputImage                                       InputImageType;
+  using InputImageType = TInputImage;
 
-  typedef Image< float, TInputImage::ImageDimension >       OutputImageType;
+  using OutputImageType = Image< float, TInputImage::ImageDimension >;
 
-  typedef RidgeFFTFilter                                     Self;
-  typedef ImageToImageFilter< TInputImage, OutputImageType > Superclass;
-  typedef SmartPointer< Self >                               Pointer;
-  typedef SmartPointer< const Self >                         ConstPointer;
+  using Self = RidgeFFTFilter;
+  using Superclass = ImageToImageFilter< TInputImage, OutputImageType >;
+  using Pointer = SmartPointer< Self >;
+  using ConstPointer = SmartPointer< const Self >;
 
   itkNewMacro( Self );
 
@@ -75,8 +75,7 @@ private:
   RidgeFFTFilter( const Self & );
   void operator = ( const Self & );
 
-  typedef GaussianDerivativeFilter< InputImageType, OutputImageType >
-    DerivativeFilterType;
+  using DerivativeFilterType = GaussianDerivativeFilter< InputImageType, OutputImageType >;
 
   typename DerivativeFilterType::Pointer                m_DerivativeFilter;
 

--- a/src/Filtering/itktubeSheetnessMeasureImageFilter.h
+++ b/src/Filtering/itktubeSheetnessMeasureImageFilter.h
@@ -60,19 +60,19 @@ class SheetnessMeasureImageFilter : public
                       Image< TPixel, 3 > >
 {
 public:
-  /** Standard class typedefs. */
-  typedef SheetnessMeasureImageFilter Self;
-  typedef ImageToImageFilter<
+  /** Standard class type alias. */
+  using Self = SheetnessMeasureImageFilter;
+  using Superclass = ImageToImageFilter<
     Image< SymmetricSecondRankTensor< double, 3 >, 3 >,
-    Image< TPixel, 3 > >                    Superclass;
+    Image< TPixel, 3 > >;
 
-  typedef SmartPointer< Self >       Pointer;
-  typedef SmartPointer< const Self > ConstPointer;
+  using Pointer = SmartPointer< Self >;
+  using ConstPointer = SmartPointer< const Self >;
 
-  typedef typename Superclass::InputImageType  InputImageType;
-  typedef typename Superclass::OutputImageType OutputImageType;
-  typedef typename InputImageType::PixelType   InputPixelType;
-  typedef TPixel                               OutputPixelType;
+  using InputImageType = typename Superclass::InputImageType;
+  using OutputImageType = typename Superclass::OutputImageType;
+  using InputPixelType = typename InputImageType::PixelType;
+  using OutputPixelType = TPixel;
 
   /** Image dimension = 3. */
   itkStaticConstMacro( ImageDimension, unsigned int,
@@ -80,12 +80,12 @@ public:
   itkStaticConstMacro( InputPixelDimension, unsigned int,
     InputPixelType::Dimension );
 
-  typedef FixedArray< double,
-    itkGetStaticConstMacro( InputPixelDimension ) > EigenValueArrayType;
-  typedef Image< EigenValueArrayType,
-    itkGetStaticConstMacro( ImageDimension ) >      EigenValueImageType;
-  typedef SymmetricEigenAnalysisImageFilter<
-    InputImageType, EigenValueImageType >           EigenAnalysisFilterType;
+  using EigenValueArrayType = FixedArray< double,
+    itkGetStaticConstMacro( InputPixelDimension ) >;
+  using EigenValueImageType = Image< EigenValueArrayType,
+    itkGetStaticConstMacro( ImageDimension ) >;
+  using EigenAnalysisFilterType = SymmetricEigenAnalysisImageFilter<
+    InputImageType, EigenValueImageType >;
 
   /** Run-time type information ( and related methods ).   */
   itkTypeMacro( SheetnessMeasureImageFilter, ImageToImageFilter );

--- a/src/Filtering/itktubeShrinkWithBlendingImageFilter.h
+++ b/src/Filtering/itktubeShrinkWithBlendingImageFilter.h
@@ -63,11 +63,11 @@ class ITK_EXPORT ShrinkWithBlendingImageFilter :
   public ImageToImageFilter< TInputImage, TOutputImage >
 {
 public:
-  /** Standard class typedefs. */
-  typedef ShrinkWithBlendingImageFilter                   Self;
-  typedef ImageToImageFilter< TInputImage, TOutputImage > Superclass;
-  typedef SmartPointer< Self >                            Pointer;
-  typedef SmartPointer< const Self >                      ConstPointer;
+  /** Standard class type alias. */
+  using Self = ShrinkWithBlendingImageFilter;
+  using Superclass = ImageToImageFilter< TInputImage, TOutputImage >;
+  using Pointer = SmartPointer< Self >;
+  using ConstPointer = SmartPointer< const Self >;
 
   /** Method for creation through the object factory. */
   itkNewMacro( Self );
@@ -76,18 +76,18 @@ public:
   itkTypeMacro( ShrinkWithBlendingImageFilter, ShrinkImageFilter );
 
   /** Typedef to images */
-  typedef TOutputImage                          OutputImageType;
-  typedef TInputImage                           InputImageType;
-  typedef typename OutputImageType::Pointer     OutputImagePointer;
-  typedef typename InputImageType::Pointer      InputImagePointer;
-  typedef typename InputImageType::ConstPointer InputImageConstPointer;
+  using OutputImageType = TOutputImage;
+  using InputImageType = TInputImage;
+  using OutputImagePointer = typename OutputImageType::Pointer;
+  using InputImagePointer = typename InputImageType::Pointer;
+  using InputImageConstPointer = typename InputImageType::ConstPointer;
 
-  typedef typename TOutputImage::IndexType      OutputIndexType;
-  typedef typename TInputImage::IndexType       InputIndexType;
-  typedef typename TOutputImage::OffsetType     OutputOffsetType;
+  using OutputIndexType = typename TOutputImage::IndexType;
+  using InputIndexType = typename TInputImage::IndexType;
+  using OutputOffsetType = typename TOutputImage::OffsetType;
 
-  typedef typename TOutputImage::RegionType     OutputImageRegionType;
-  typedef typename TInputImage::SizeType        InputSizeType;
+  using OutputImageRegionType = typename TOutputImage::RegionType;
+  using InputSizeType = typename TInputImage::SizeType;
 
   itkStaticConstMacro( ImageDimension, unsigned int,
                        TInputImage::ImageDimension );
@@ -95,11 +95,10 @@ public:
   itkStaticConstMacro( OutputImageDimension, unsigned int,
                        TOutputImage::ImageDimension );
 
-  typedef Vector< float, ImageDimension >       PointImagePixelType;
-  typedef Image< PointImagePixelType, OutputImageDimension >
-                                                PointImageType;
+  using PointImagePixelType = Vector< float, ImageDimension >;
+  using PointImageType = Image< PointImagePixelType, OutputImageDimension >;
 
-  typedef FixedArray< unsigned int, ImageDimension > ShrinkFactorsType;
+  using ShrinkFactorsType = FixedArray< unsigned int, ImageDimension >;
 
   /** Set the shrink factors. Values are clamped to
    * a minimum value of 1. Default is 1 for all dimensions. */

--- a/src/Filtering/itktubeShrinkWithBlendingImageFilter.hxx
+++ b/src/Filtering/itktubeShrinkWithBlendingImageFilter.hxx
@@ -169,11 +169,11 @@ ShrinkWithBlendingImageFilter< TInputImage, TOutputImage >
 
   // Define/declare an iterator that will walk the output region for this
   // thread.
-  typedef ImageRegionIteratorWithIndex< TOutputImage > OutputIteratorType;
+  using OutputIteratorType = ImageRegionIteratorWithIndex< TOutputImage >;
   OutputIteratorType outIt( outputPtr, outputRegionForThread );
 
-  typedef ImageRegionConstIteratorWithIndex<
-    PointImageType > PointImageConstIteratorType;
+  using PointImageConstIteratorType = ImageRegionConstIteratorWithIndex<
+    PointImageType >;
 
   PointImageConstIteratorType * inputMipPointItPtr = NULL;
 
@@ -183,13 +183,13 @@ ShrinkWithBlendingImageFilter< TInputImage, TOutputImage >
       m_InputMipPointImage, outputRegionForThread );
     }
 
-  typedef ImageRegionIteratorWithIndex<
-    PointImageType > PointImageIteratorType;
+  using PointImageIteratorType = ImageRegionIteratorWithIndex<
+    PointImageType >;
 
   PointImageIteratorType outMipPointIt( m_OutputMipPointImage,
                                         outputRegionForThread );
 
-  typedef ImageRegionConstIteratorWithIndex< TInputImage > InputIteratorType;
+  using InputIteratorType = ImageRegionConstIteratorWithIndex< TInputImage >;
 
   typename TInputImage::RegionType inputRegion;
 

--- a/src/Filtering/itktubeSmoothingRecursiveGaussianImageFilter.h
+++ b/src/Filtering/itktubeSmoothingRecursiveGaussianImageFilter.h
@@ -43,17 +43,17 @@ class SmoothingRecursiveGaussianImageFilter:
   public InPlaceImageFilter< TInputImage, TOutputImage >
 {
 public:
-  /** Standard class typedefs. */
-  typedef SmoothingRecursiveGaussianImageFilter           Self;
-  typedef InPlaceImageFilter< TInputImage, TOutputImage > Superclass;
-  typedef SmartPointer< Self >                            Pointer;
-  typedef SmartPointer< const Self >                      ConstPointer;
+  /** Standard class type alias. */
+  using Self = SmoothingRecursiveGaussianImageFilter;
+  using Superclass = InPlaceImageFilter< TInputImage, TOutputImage >;
+  using Pointer = SmartPointer< Self >;
+  using ConstPointer = SmartPointer< const Self >;
 
   /** Pixel Type of the input image */
-  typedef TInputImage                                     InputImageType;
-  typedef TOutputImage                                    OutputImageType;
-  typedef typename TInputImage::PixelType                 PixelType;
-  typedef typename NumericTraits< PixelType >::RealType   RealType;
+  using InputImageType = TInputImage;
+  using OutputImageType = TOutputImage;
+  using PixelType = typename TInputImage::PixelType;
+  using RealType = typename NumericTraits< PixelType >::RealType;
 
   typedef typename NumericTraits< PixelType >::ScalarRealType
     ScalarRealType;
@@ -67,8 +67,8 @@ public:
     TInputImage::ImageDimension );
 
   /** Define the type for the sigma array */
-  typedef FixedArray< ScalarRealType,
-    itkGetStaticConstMacro( ImageDimension ) > SigmaArrayType;
+  using SigmaArrayType = FixedArray< ScalarRealType,
+    itkGetStaticConstMacro( ImageDimension ) >;
 
   /** Define the image type for internal computations
     RealType is usually 'double' in NumericTraits.
@@ -159,8 +159,7 @@ private:
 
   // implemented
 
-  typedef std::vector< typename InternalGaussianFilterType::Pointer >
-    SmoothingFiltersArrayType;
+  using SmoothingFiltersArrayType = std::vector< typename InternalGaussianFilterType::Pointer >;
   SmoothingFiltersArrayType m_SmoothingFilters;
 
   typename FirstGaussianFilterType::Pointer    m_FirstSmoothingFilter;

--- a/src/Filtering/itktubeSpatialObjectFilter.h
+++ b/src/Filtering/itktubeSpatialObjectFilter.h
@@ -41,17 +41,17 @@ class SpatialObjectFilter
     SpatialObject<ObjectDimension> >
 {
 public:
-  /** Standard class typedefs */
-  typedef SpatialObjectFilter                                  Self;
-  typedef SpatialObjectToSpatialObjectFilter< SpatialObject<ObjectDimension >,
-          SpatialObject<ObjectDimension> >                     Superclass;
-  typedef SmartPointer< Self >                                 Pointer;
-  typedef SmartPointer< const Self >                           ConstPointer;
+  /** Standard class type alias */
+  using Self = SpatialObjectFilter;
+  using Superclass = SpatialObjectToSpatialObjectFilter< SpatialObject<ObjectDimension >,
+          SpatialObject<ObjectDimension> >;
+  using Pointer = SmartPointer< Self >;
+  using ConstPointer = SmartPointer< const Self >;
 
   /** Run-time type information ( and related methods ). */
   itkTypeMacro( SpatialObjectFilter, SpatialObjectSource );
 
-  typedef SpatialObject<ObjectDimension>  SpatialObjectType;
+  using SpatialObjectType = SpatialObject<ObjectDimension>;
 
   virtual void SetInput( const SpatialObjectType * spatialObject ) override;
 

--- a/src/Filtering/itktubeSpatialObjectSource.h
+++ b/src/Filtering/itktubeSpatialObjectSource.h
@@ -43,16 +43,15 @@ template< class TOutputSpatialObject >
 class SpatialObjectSource : public ProcessObject
 {
 public:
-  /** Standard class typedefs. */
-  typedef SpatialObjectSource        Self;
-  typedef ProcessObject              Superclass;
-  typedef SmartPointer< Self >       Pointer;
-  typedef SmartPointer< const Self > ConstPointer;
+  /** Standard class type alias. */
+  using Self = SpatialObjectSource;
+  using Superclass = ProcessObject;
+  using Pointer = SmartPointer< Self >;
+  using ConstPointer = SmartPointer< const Self >;
 
-  typedef TOutputSpatialObject       OutputSpatialObjectType;
+  using OutputSpatialObjectType = TOutputSpatialObject;
 
-  typedef SpatialObject< TOutputSpatialObject::ObjectDimension >
-    SpatialObjectType;
+  using SpatialObjectType = SpatialObject< TOutputSpatialObject::ObjectDimension >;
   typedef Superclass::DataObjectIdentifierType
     DataObjectIdentifierType;
   typedef Superclass::DataObjectPointerArraySizeType

--- a/src/Filtering/itktubeSpatialObjectSource.hxx
+++ b/src/Filtering/itktubeSpatialObjectSource.hxx
@@ -140,7 +140,7 @@ SpatialObjectSource< TOutputSpatialObject >
   //    CopyInformation, so implementations are equivalent.
   outputObject->CopyInformation( graft );
 
-  typedef typename SpatialObjectType::ChildrenListType ChildrenListType;
+  using ChildrenListType = typename SpatialObjectType::ChildrenListType;
   ChildrenListType *children = graftObject->GetChildren();
   typename ChildrenListType::const_iterator it = children->begin();
   while( it != children->end() )

--- a/src/Filtering/itktubeSpatialObjectToSpatialObjectFilter.h
+++ b/src/Filtering/itktubeSpatialObjectToSpatialObjectFilter.h
@@ -40,17 +40,17 @@ class SpatialObjectToSpatialObjectFilter
   : public SpatialObjectSource< TOutputSpatialObject >
 {
 public:
-  /** Standard class typedefs */
-  typedef SpatialObjectToSpatialObjectFilter          Self;
-  typedef SpatialObjectSource< TOutputSpatialObject > Superclass;
-  typedef SmartPointer< Self >                        Pointer;
-  typedef SmartPointer< const Self >                  ConstPointer;
+  /** Standard class type alias */
+  using Self = SpatialObjectToSpatialObjectFilter;
+  using Superclass = SpatialObjectSource< TOutputSpatialObject >;
+  using Pointer = SmartPointer< Self >;
+  using ConstPointer = SmartPointer< const Self >;
 
   /** Run-time type information ( and related methods ). */
   itkTypeMacro( SpatialObjectToSpatialObjectFilter, SpatialObjectSource );
 
-  typedef TInputSpatialObject  InputSpatialObjectType;
-  typedef TOutputSpatialObject OutputSpatialObjectType;
+  using InputSpatialObjectType = TInputSpatialObject;
+  using OutputSpatialObjectType = TOutputSpatialObject;
 
   virtual void SetInput( const InputSpatialObjectType * spatialObject );
 

--- a/src/Filtering/itktubeStructureTensorRecursiveGaussianImageFilter.h
+++ b/src/Filtering/itktubeStructureTensorRecursiveGaussianImageFilter.h
@@ -52,19 +52,19 @@ class StructureTensorRecursiveGaussianImageFilter
   : public ImageToImageFilter< TInputImage, TOutputImage >
 {
 public:
-  /** Standard class typedefs. */
-  typedef StructureTensorRecursiveGaussianImageFilter     Self;
-  typedef ImageToImageFilter< TInputImage, TOutputImage > Superclass;
-  typedef SmartPointer< Self >                            Pointer;
-  typedef SmartPointer< const Self >                      ConstPointer;
+  /** Standard class type alias. */
+  using Self = StructureTensorRecursiveGaussianImageFilter;
+  using Superclass = ImageToImageFilter< TInputImage, TOutputImage >;
+  using Pointer = SmartPointer< Self >;
+  using ConstPointer = SmartPointer< const Self >;
 
   /** Method for creation through the object factory. */
   itkNewMacro( Self );
 
   /** Pixel Type of the input image */
-  typedef TInputImage                                     InputImageType;
-  typedef typename TInputImage::PixelType                 PixelType;
-  typedef typename NumericTraits<PixelType>::RealType     RealType;
+  using InputImageType = TInputImage;
+  using PixelType = typename TInputImage::PixelType;
+  using RealType = typename NumericTraits<PixelType>::RealType;
 
   /** Image dimension. */
   itkStaticConstMacro( ImageDimension,
@@ -74,35 +74,31 @@ public:
   /** Define the image type for internal computations
       RealType is usually 'double' in NumericTraits.
       Here we prefer float in order to save memory. */
-  typedef float                                           InternalRealType;
-  typedef Image< InternalRealType, itkGetStaticConstMacro( ImageDimension ) >
-      RealImageType;
+  using InternalRealType = float;
+  using RealImageType = Image< InternalRealType, itkGetStaticConstMacro( ImageDimension ) >;
 
   /**  Output Image Nth Element Adaptor
    *  This adaptor allows to use conventional scalar
    *  smoothing filters to compute each one of the
    *  components of the gradient image pixels. */
-  typedef NthElementImageAdaptor< TOutputImage, InternalRealType >
-      OutputImageAdaptorType;
+  using OutputImageAdaptorType = NthElementImageAdaptor< TOutputImage, InternalRealType >;
   typedef typename OutputImageAdaptorType::Pointer
       OutputImageAdaptorPointer;
 
   /**  Smoothing filter type */
-  typedef RecursiveGaussianImageFilter< RealImageType, RealImageType >
-      GaussianFilterType;
+  using GaussianFilterType = RecursiveGaussianImageFilter< RealImageType, RealImageType >;
   typedef typename GaussianFilterType::Pointer
       GaussianFilterPointer;
 
   /**  Derivative filter type, it will be the first in the pipeline  */
-  typedef RecursiveGaussianImageFilter< InputImageType, RealImageType >
-      DerivativeFilterType;
+  using DerivativeFilterType = RecursiveGaussianImageFilter< InputImageType, RealImageType >;
   typedef typename DerivativeFilterType::Pointer
       DerivativeFilterPointer;
 
   /** Type of the output image */
-  typedef TOutputImage                                    OutputImageType;
-  typedef typename OutputImageType::Pointer               OutputImagePointer;
-  typedef typename OutputImageType::PixelType             OutputPixelType;
+  using OutputImageType = TOutputImage;
+  using OutputImagePointer = typename OutputImageType::Pointer;
+  using OutputPixelType = typename OutputImageType::PixelType;
   typedef typename PixelTraits< OutputPixelType >::ValueType
       OutputComponentType;
 

--- a/src/Filtering/itktubeStructureTensorRecursiveGaussianImageFilter.hxx
+++ b/src/Filtering/itktubeStructureTensorRecursiveGaussianImageFilter.hxx
@@ -296,8 +296,7 @@ StructureTensorRecursiveGaussianImageFilter<TInputImage, TOutputImage >
     }
 
   //Finally, smooth the outer product components
-  typedef typename itk::Image<InternalRealType, ImageDimension>
-    ComponentImageType;
+  using ComponentImageType = typename itk::Image<InternalRealType, ImageDimension>;
 
   for( unsigned int i =0; i < numberTensorElements; i++ )
     {

--- a/src/Filtering/itktubeSubSampleSpatialObjectFilter.h
+++ b/src/Filtering/itktubeSubSampleSpatialObjectFilter.h
@@ -46,13 +46,13 @@ class SubSampleSpatialObjectFilter
   : public SpatialObjectFilter< ObjectDimension >
 {
 public:
-  /** Standard class typedefs. */
-  typedef SubSampleSpatialObjectFilter              Self;
-  typedef SpatialObjectFilter< ObjectDimension >    Superclass;
-  typedef SmartPointer< Self >                      Pointer;
-  typedef SmartPointer< const Self >                ConstPointer;
+  /** Standard class type alias. */
+  using Self = SubSampleSpatialObjectFilter;
+  using Superclass = SpatialObjectFilter< ObjectDimension >;
+  using Pointer = SmartPointer< Self >;
+  using ConstPointer = SmartPointer< const Self >;
 
-  typedef SpatialObject<ObjectDimension>            SpatialObjectType;
+  using SpatialObjectType = SpatialObject<ObjectDimension>;
 
   /** Run-time type information ( and related methods ).   */
   itkTypeMacro( SubSampleSpatialObjectFilter,
@@ -68,7 +68,7 @@ public:
   itkGetConstMacro( Sampling, SizeValueType );
 
 protected:
-  typedef TubeSpatialObject< ObjectDimension > TubeSpatialObjectType;
+  using TubeSpatialObjectType = TubeSpatialObject< ObjectDimension >;
 
   SubSampleSpatialObjectFilter( void );
   virtual ~SubSampleSpatialObjectFilter( void );

--- a/src/Filtering/itktubeSubSampleSpatialObjectFilter.hxx
+++ b/src/Filtering/itktubeSubSampleSpatialObjectFilter.hxx
@@ -62,8 +62,7 @@ SubSampleSpatialObjectFilter< ObjectDimension >
   typename SpatialObjectType::Pointer newParent;
   if( inputAsTube != NULL )
     {
-    typedef SubSampleTubeSpatialObjectFilter< ObjectDimension >
-      SubSampleTubeFilterType;
+    using SubSampleTubeFilterType = SubSampleTubeSpatialObjectFilter< ObjectDimension >;
     typename SubSampleTubeFilterType::Pointer subSampleTubeFilter
       = SubSampleTubeFilterType::New();
 
@@ -99,7 +98,7 @@ SubSampleSpatialObjectFilter< ObjectDimension >
       }
     }
 
-  typedef typename SpatialObjectType::ChildrenListType ChildrenListType;
+  using ChildrenListType = typename SpatialObjectType::ChildrenListType;
   ChildrenListType *children = input->GetChildren();
   typename ChildrenListType::const_iterator it = children->begin();
   while( it != children->end() )

--- a/src/Filtering/itktubeSubSampleTubeSpatialObjectFilter.h
+++ b/src/Filtering/itktubeSubSampleTubeSpatialObjectFilter.h
@@ -46,13 +46,13 @@ class SubSampleTubeSpatialObjectFilter
   : public SpatialObjectFilter< ObjectDimension >
 {
 public:
-  /** Standard class typedefs. */
-  typedef SubSampleTubeSpatialObjectFilter          Self;
-  typedef SpatialObjectFilter< ObjectDimension >    Superclass;
-  typedef SmartPointer< Self >                      Pointer;
-  typedef SmartPointer< const Self >                ConstPointer;
+  /** Standard class type alias. */
+  using Self = SubSampleTubeSpatialObjectFilter;
+  using Superclass = SpatialObjectFilter< ObjectDimension >;
+  using Pointer = SmartPointer< Self >;
+  using ConstPointer = SmartPointer< const Self >;
 
-  typedef TubeSpatialObject<ObjectDimension>        TubeSpatialObjectType;
+  using TubeSpatialObjectType = TubeSpatialObject<ObjectDimension>;
 
   /** Run-time type information ( and related methods ).   */
   itkTypeMacro( SubSampleTubeSpatialObjectFilter,

--- a/src/Filtering/itktubeSubSampleTubeSpatialObjectFilter.hxx
+++ b/src/Filtering/itktubeSubSampleTubeSpatialObjectFilter.hxx
@@ -59,7 +59,7 @@ SubSampleTubeSpatialObjectFilter< ObjectDimension >
   typename TubeSpatialObjectType::Pointer output =
     dynamic_cast<TubeSpatialObjectType *>( this->GetOutput() );
 
-  typedef typename TubeSpatialObjectType::TubePointListType TubePointListType;
+  using TubePointListType = typename TubeSpatialObjectType::TubePointListType;
   const TubePointListType & inputPoints = input->GetPoints();
   TubePointListType & outputPoints = output->GetPoints();
 

--- a/src/Filtering/itktubeSymmetricEigenVectorAnalysisImageFilter.h
+++ b/src/Filtering/itktubeSymmetricEigenVectorAnalysisImageFilter.h
@@ -53,7 +53,7 @@ class SymmetricEigenVectorAnalysisFunction
 public:
   SymmetricEigenVectorAnalysisFunction( void ) {}
   ~SymmetricEigenVectorAnalysisFunction( void ) {}
-  typedef SymmetricEigenAnalysis< TInput, TOutput, TMatrix > CalculatorType;
+  using CalculatorType = SymmetricEigenAnalysis< TInput, TOutput, TMatrix >;
   bool operator!=( const SymmetricEigenVectorAnalysisFunction & ) const
     {
     return false;
@@ -129,20 +129,20 @@ class SymmetricEigenVectorAnalysisImageFilter
       typename TOutputMatrix::PixelType > >
 {
 public:
-  /** Standard class typedefs. */
-  typedef SymmetricEigenVectorAnalysisImageFilter  Self;
-  typedef UnaryFunctorImageFilter<TInputImage, TOutputMatrix,
+  /** Standard class type alias. */
+  using Self = SymmetricEigenVectorAnalysisImageFilter;
+  using Superclass = UnaryFunctorImageFilter<TInputImage, TOutputMatrix,
     Functor::SymmetricEigenVectorAnalysisFunction<
       typename TInputImage::PixelType, typename TOutputImage::PixelType,
-      typename TOutputMatrix::PixelType > >        Superclass;
+      typename TOutputMatrix::PixelType > >;
 
-  typedef SmartPointer< Self >                     Pointer;
-  typedef SmartPointer< const Self >               ConstPointer;
+  using Pointer = SmartPointer< Self >;
+  using ConstPointer = SmartPointer< const Self >;
 
-  typedef typename Superclass::OutputImageType     OutputImageType;
-  typedef typename TOutputImage::PixelType         OutputPixelType;
-  typedef typename TInputImage::PixelType          InputPixelType;
-  typedef typename Superclass::FunctorType         FunctorType;
+  using OutputImageType = typename Superclass::OutputImageType;
+  using OutputPixelType = typename TOutputImage::PixelType;
+  using InputPixelType = typename TInputImage::PixelType;
+  using FunctorType = typename Superclass::FunctorType;
 
   /** Typedefs to order eigenvalues.
    * OrderByValue:      lambda_1 < lambda_2 < ....
@@ -150,7 +150,7 @@ public:
    * DoNotOrder:        Default order of eigenvalues obtained after QL
    *                    method
    */
-  //typedef typename FunctorType::EigenValueOrderEnum EigenValueOrderEnum;
+  //using EigenValueOrderEnum = typename FunctorType::EigenValueOrderEnum;
 
   /** Order eigenvalues. Default is to OrderByValue:
    * lambda_1 < lambda_2 < .... */

--- a/src/Filtering/itktubeTortuositySpatialObjectFilter.h
+++ b/src/Filtering/itktubeTortuositySpatialObjectFilter.h
@@ -50,16 +50,16 @@ class TortuositySpatialObjectFilter : public
   TTubeSpatialObject >
 {
 public:
-  /** Standard class typedefs. */
-  typedef TortuositySpatialObjectFilter     Self;
-  typedef SpatialObjectToSpatialObjectFilter< TTubeSpatialObject,
-    TTubeSpatialObject >                    Superclass;
-  typedef SmartPointer< Self >              Pointer;
-  typedef SmartPointer< const Self >        ConstPointer;
+  /** Standard class type alias. */
+  using Self = TortuositySpatialObjectFilter;
+  using Superclass = SpatialObjectToSpatialObjectFilter< TTubeSpatialObject,
+    TTubeSpatialObject >;
+  using Pointer = SmartPointer< Self >;
+  using ConstPointer = SmartPointer< const Self >;
 
-  typedef TTubeSpatialObject                TubeSpatialObject;
+  using TubeSpatialObject = TTubeSpatialObject;
 
-  typedef typename TTubeSpatialObject::VectorType SOVectorType;
+  using SOVectorType = typename TTubeSpatialObject::VectorType;
 
   typedef typename TubeSpatialObject::Pointer
     TubeSpatialObjectPointer;

--- a/src/Filtering/itktubeTortuositySpatialObjectFilter.hxx
+++ b/src/Filtering/itktubeTortuositySpatialObjectFilter.hxx
@@ -261,8 +261,8 @@ double SafeAcos( double x )
 template<typename VectorType >
 typename VectorType::RealValueType SafeNormalize( VectorType& v )
 {
-  typedef typename VectorType::RealValueType  RealType;
-  typedef typename VectorType::ValueType      ValueType;
+  using RealType = typename VectorType::RealValueType;
+  using ValueType = typename VectorType::ValueType;
 
   typename VectorType::RealValueType norm = v.GetNorm();
   if( norm != 0.0 )
@@ -641,11 +641,11 @@ TortuositySpatialObjectFilter< TTubeSpatialObject >
   if( p95m || chm || ic1m || ic2m )
     {
     // Histogram computation
-    typedef itk::Vector<double, 1> MeasurementVectorType;
-    typedef itk::Statistics::ListSample< MeasurementVectorType > SampleType;
+    using MeasurementVectorType = itk::Vector<double, 1>;
+    using SampleType = itk::Statistics::ListSample< MeasurementVectorType >;
 
-    typedef itk::Statistics::Histogram< double,
-      itk::Statistics::DenseFrequencyContainer2 > HistogramType;
+    using HistogramType = itk::Statistics::Histogram< double,
+      itk::Statistics::DenseFrequencyContainer2 >;
 
     SampleType::Pointer sample = SampleType::New();
     for( size_t i = 0; i < this->m_CurvatureScalar.size(); ++i )
@@ -655,8 +655,8 @@ TortuositySpatialObjectFilter< TTubeSpatialObject >
       sample->PushBack( mv );
       }
 
-    typedef itk::Statistics::SampleToHistogramFilter
-      <SampleType, HistogramType> SampleToHistogramFilterType;
+    using SampleToHistogramFilterType = itk::Statistics::SampleToHistogramFilter
+      <SampleType, HistogramType>;
     SampleToHistogramFilterType::Pointer sampleToHistogramFilter =
       SampleToHistogramFilterType::New();
     sampleToHistogramFilter->SetInput( sample );

--- a/src/Filtering/itktubeTubeEnhancingDiffusion2DImageFilter.h
+++ b/src/Filtering/itktubeTubeEnhancingDiffusion2DImageFilter.h
@@ -82,14 +82,14 @@ class TubeEnhancingDiffusion2DImageFilter
 
 public:
 
-  typedef float                                           Precision;
-  typedef Image<TPixel, VDimension>                       ImageType;
-  typedef Image<Precision, VDimension>                    PrecisionImageType;
+  using Precision = float;
+  using ImageType = Image<TPixel, VDimension>;
+  using PrecisionImageType = Image<Precision, VDimension>;
 
-  typedef TubeEnhancingDiffusion2DImageFilter             Self;
-  typedef ImageToImageFilter<ImageType, ImageType>        Superclass;
-  typedef SmartPointer< Self >                            Pointer;
-  typedef SmartPointer< const Self >                      ConstPointer;
+  using Self = TubeEnhancingDiffusion2DImageFilter;
+  using Superclass = ImageToImageFilter<ImageType, ImageType>;
+  using Pointer = SmartPointer< Self >;
+  using ConstPointer = SmartPointer< const Self >;
 
   itkNewMacro( Self );
   itkTypeMacro( TubeEnhancingDiffusion2DImageFilter, ImageToImageFilter );

--- a/src/Filtering/itktubeTubeEnhancingDiffusion2DImageFilter.hxx
+++ b/src/Filtering/itktubeTubeEnhancingDiffusion2DImageFilter.hxx
@@ -142,10 +142,10 @@ TubeEnhancingDiffusion2DImageFilter<TPixel, TDimension>
 
   // shapedneighborhood iter, zeroflux boundary condition
   // division into faces and inner region
-  typedef ZeroFluxNeumannBoundaryCondition<PrecisionImageType>     BT;
-  typedef ConstShapedNeighborhoodIterator<PrecisionImageType, BT>  NT;
-  typedef typename NeighborhoodAlgorithm::ImageBoundaryFacesCalculator<
-    PrecisionImageType>                                            FT;
+  using BT = ZeroFluxNeumannBoundaryCondition<PrecisionImageType>;
+  using NT = ConstShapedNeighborhoodIterator<PrecisionImageType, BT>;
+  using FT = typename NeighborhoodAlgorithm::ImageBoundaryFacesCalculator<
+    PrecisionImageType>;
 
   BT                      b;
   typename NT::RadiusType r;
@@ -338,8 +338,8 @@ TubeEnhancingDiffusion2DImageFilter<TPixel, TDimension>
 
   for( unsigned int i = 0; i < m_Scales.size(); ++i )
     {
-    typedef HessianRecursiveGaussianImageFilter<
-      PrecisionImageType > HessianType;
+    using HessianType = HessianRecursiveGaussianImageFilter<
+      PrecisionImageType >;
     typename HessianType::Pointer hessian = HessianType::New();
     hessian->SetInput( im );
     hessian->SetNormalizeAcrossScale( true );
@@ -500,7 +500,7 @@ TubeEnhancingDiffusion2DImageFilter<TPixel, TDimension>
 
   ProgressReporter progress( this, 0, m_Iterations+4 );
 
-  typedef MinimumMaximumImageFilter<ImageType> MinMaxType;
+  using MinMaxType = MinimumMaximumImageFilter<ImageType>;
   typename MinMaxType::Pointer minmax = MinMaxType::New();
 
   minmax->SetInput( this->GetInput() );
@@ -546,7 +546,7 @@ TubeEnhancingDiffusion2DImageFilter<TPixel, TDimension>
     }
 
   // cast to precision
-  typedef CastImageFilter<ImageType, PrecisionImageType> CT;
+  using CT = CastImageFilter<ImageType, PrecisionImageType>;
   typename CT::Pointer cast = CT::New();
   cast->SetInput( this->GetInput() );
   cast->Update();
@@ -568,7 +568,7 @@ TubeEnhancingDiffusion2DImageFilter<TPixel, TDimension>
     progress.CompletedPixel();
     }
 
-  typedef MinimumMaximumImageFilter<PrecisionImageType> MMT;
+  using MMT = MinimumMaximumImageFilter<PrecisionImageType>;
   typename MMT::Pointer mm = MMT::New();
   mm->SetInput( ci );
   mm->Update();
@@ -586,7 +586,7 @@ TubeEnhancingDiffusion2DImageFilter<TPixel, TDimension>
 
   // cast back to pixel type
   this->AllocateOutputs();
-  typedef CastImageFilter<PrecisionImageType, ImageType> CTI;
+  using CTI = CastImageFilter<PrecisionImageType, ImageType>;
   typename CTI::Pointer casti = CTI::New();
   casti->SetInput( ci );
   casti->GraftOutput( this->GetOutput() );

--- a/src/Filtering/itktubeTubeSpatialObjectToDensityImageFilter.h
+++ b/src/Filtering/itktubeTubeSpatialObjectToDensityImageFilter.h
@@ -45,52 +45,52 @@ class TubeSpatialObjectToDensityImageFilter : public Object
 {
 public:
 
-  typedef TubeSpatialObjectToDensityImageFilter   Self;
-  typedef Object                                  Superclass;
-  typedef SmartPointer< Self >                    Pointer;
+  using Self = TubeSpatialObjectToDensityImageFilter;
+  using Superclass = Object;
+  using Pointer = SmartPointer< Self >;
 
   itkNewMacro( Self );
   itkTypeMacro( TubeSpatialObjectToDensityImageFilter, Object );
 
   /** Typdefs */
-  typedef TDensityImageType                              DensityImageType;
-  typedef typename DensityImageType::PixelType           DensityPixelType;
-  typedef typename DensityImageType::Pointer             DensityImagePointer;
+  using DensityImageType = TDensityImageType;
+  using DensityPixelType = typename DensityImageType::PixelType;
+  using DensityImagePointer = typename DensityImageType::Pointer;
 
-  typedef TRadiusImageType                               RadiusImageType;
-  typedef typename RadiusImageType::PixelType            RadiusPixelType;
-  typedef typename RadiusImageType::Pointer              RadiusImagePointer;
+  using RadiusImageType = TRadiusImageType;
+  using RadiusPixelType = typename RadiusImageType::PixelType;
+  using RadiusImagePointer = typename RadiusImageType::Pointer;
 
-  typedef TTangentImageType                              TangentImageType;
-  typedef typename TangentImageType::PixelType           TangentPixelType;
-  typedef typename TangentImageType::Pointer             TangentImagePointer;
+  using TangentImageType = TTangentImageType;
+  using TangentPixelType = typename TangentImageType::PixelType;
+  using TangentImagePointer = typename TangentImageType::Pointer;
 
   /** Define the Dimension variable */
   itkStaticConstMacro( ImageDimension, unsigned int,
                        DensityImageType::ImageDimension );
 
-  typedef GroupSpatialObject<
-    itkGetStaticConstMacro( ImageDimension ) >  TubeGroupType;
-  typedef typename TubeGroupType::Pointer       TubeGroupPointer;
+  using TubeGroupType = GroupSpatialObject<
+    itkGetStaticConstMacro( ImageDimension ) >;
+  using TubeGroupPointer = typename TubeGroupType::Pointer;
 
-  typedef TubeSpatialObject<
-    itkGetStaticConstMacro( ImageDimension ) >  TubeType;
+  using TubeType = TubeSpatialObject<
+    itkGetStaticConstMacro( ImageDimension ) >;
 
-  typedef typename DensityImageType::OffsetType VectorPixelType;
-  typedef Image<
+  using VectorPixelType = typename DensityImageType::OffsetType;
+  using VectorImageType = Image<
     VectorPixelType,
-    itkGetStaticConstMacro( ImageDimension ) >  VectorImageType;
-  typedef typename VectorImageType::Pointer     VectorImagePointer;
+    itkGetStaticConstMacro( ImageDimension ) >;
+  using VectorImagePointer = typename VectorImageType::Pointer;
 
-  typedef typename DensityImageType::SizeType     SizeType;
-  typedef typename DensityImageType::SpacingType  SpacingType;
+  using SizeType = typename DensityImageType::SizeType;
+  using SpacingType = typename DensityImageType::SpacingType;
 
-  typedef TubeSpatialObjectToImageFilter<
+  using TubetoImageFilterType = TubeSpatialObjectToImageFilter<
     itkGetStaticConstMacro( ImageDimension ),
-    DensityImageType > TubetoImageFilterType;
+    DensityImageType >;
 
-  typedef DanielssonDistanceMapImageFilter<
-    DensityImageType, DensityImageType > DanielssonFilterType;
+  using DanielssonFilterType = DanielssonDistanceMapImageFilter<
+    DensityImageType, DensityImageType >;
 
   /** Retrieve Density map created by inverted Danielsson Distance Map */
   itkSetMacro( DensityMapImage, DensityImagePointer );

--- a/src/Filtering/itktubeTubeSpatialObjectToDensityImageFilter.hxx
+++ b/src/Filtering/itktubeTubeSpatialObjectToDensityImageFilter.hxx
@@ -82,8 +82,8 @@ TubeSpatialObjectToDensityImageFilter< TDensityImageType, TRadiusImageType,
 
     tubes->ComputeFamilyBoundingBox( 99999 );
 
-    typedef TubeSpatialObjectToImageFilter<ImageDimension, DensityImageType,
-      RadiusImageType, TangentImageType> FilterType;
+    using FilterType = TubeSpatialObjectToImageFilter<ImageDimension, DensityImageType,
+      RadiusImageType, TangentImageType>;
     typename FilterType::Pointer tubefilter = FilterType::New();
 
     //Set record radius value for filter
@@ -115,8 +115,8 @@ TubeSpatialObjectToDensityImageFilter< TDensityImageType, TRadiusImageType,
     m_TangentMapImage  = tubefilter->GetTangentImage();
     m_DensityMapImage  = danFilter->GetDistanceMap();
 
-    typedef ImageRegionIterator<VectorImageType>   VectorIteratorType;
-    typedef ImageRegionIterator<RadiusImageType>   RadiusIteratorType;
+    using VectorIteratorType = ImageRegionIterator<VectorImageType>;
+    using RadiusIteratorType = ImageRegionIterator<RadiusImageType>;
 
     VectorIteratorType it_vector( vectorImage,
       vectorImage->GetLargestPossibleRegion() );
@@ -145,7 +145,7 @@ TubeSpatialObjectToDensityImageFilter< TDensityImageType, TRadiusImageType,
 
     // Use Vector Image to find the closest vessel and add the tangent
     // direction
-    typedef ImageRegionIterator<TangentImageType>   TangentIteratorType;
+    using TangentIteratorType = ImageRegionIterator<TangentImageType>;
     TangentIteratorType it_tangent( m_TangentMapImage,
       m_TangentMapImage->GetLargestPossibleRegion() );
 

--- a/src/Filtering/itktubeTubeSpatialObjectToImageFilter.h
+++ b/src/Filtering/itktubeTubeSpatialObjectToImageFilter.h
@@ -50,27 +50,27 @@ class TubeSpatialObjectToImageFilter
 {
 public:
 
-  /** Standard class typedefs. */
-  typedef TubeSpatialObjectToImageFilter                 Self;
-  typedef SpatialObjectToImageFilter< SpatialObject< ObjectDimension >,
-                                      TOutputImage>      SuperClass;
-  typedef SmartPointer< Self >                           Pointer;
-  typedef SmartPointer< const Self >                     ConstPointer;
+  /** Standard class type alias. */
+  using Self = TubeSpatialObjectToImageFilter;
+  using SuperClass = SpatialObjectToImageFilter< SpatialObject< ObjectDimension >,
+                                      TOutputImage>;
+  using Pointer = SmartPointer< Self >;
+  using ConstPointer = SmartPointer< const Self >;
 
-  /** Tube class typedef */
-  typedef TOutputImage                                   OutputImageType;
+  /** Tube class type alias */
+  using OutputImageType = TOutputImage;
 
-  typedef SpatialObject<ObjectDimension>                 SpatialObjectType;
-  typedef typename SpatialObjectType::ChildrenListType   ChildrenListType;
-  typedef TubeSpatialObject<ObjectDimension>             TubeType;
+  using SpatialObjectType = SpatialObject<ObjectDimension>;
+  using ChildrenListType = typename SpatialObjectType::ChildrenListType;
+  using TubeType = TubeSpatialObject<ObjectDimension>;
 
-  typedef TRadiusImage                                   RadiusImage;
-  typedef typename TRadiusImage::Pointer                 RadiusImagePointer;
-  typedef typename TRadiusImage::PixelType               RadiusPixelType;
+  using RadiusImage = TRadiusImage;
+  using RadiusImagePointer = typename TRadiusImage::Pointer;
+  using RadiusPixelType = typename TRadiusImage::PixelType;
 
-  typedef TTangentImage                                  TangentImage;
-  typedef typename TTangentImage::Pointer                TangentImagePointer;
-  typedef typename TTangentImage::PixelType              TangentPixelType;
+  using TangentImage = TTangentImage;
+  using TangentImagePointer = typename TTangentImage::Pointer;
+  using TangentPixelType = typename TTangentImage::PixelType;
 
   /** Method for creation through the object factory. */
   itkNewMacro( Self );

--- a/src/Filtering/itktubeTubeSpatialObjectToImageFilter.hxx
+++ b/src/Filtering/itktubeTubeSpatialObjectToImageFilter.hxx
@@ -159,9 +159,9 @@ TubeSpatialObjectToImageFilter< ObjectDimension, TOutputImage, TRadiusImage,
   OutputImage->SetDirection( this->m_Direction );
   OutputImage->Allocate();
   OutputImage->FillBuffer( 0 );
-  typedef typename OutputImageType::PixelType PixelType;
+  using PixelType = typename OutputImageType::PixelType;
 
-  typedef itk::ContinuousIndex<double, ObjectDimension> ContinuousIndexType;
+  using ContinuousIndexType = itk::ContinuousIndex<double, ObjectDimension>;
   ContinuousIndexType pointI;
 
   m_RadiusImage = this->GetRadiusImage();
@@ -197,7 +197,7 @@ TubeSpatialObjectToImageFilter< ObjectDimension, TOutputImage, TRadiusImage,
 
   //int size = tubeList->size();
 
-  typedef typename ChildrenListType::iterator ChildrenIteratorType;
+  using ChildrenIteratorType = typename ChildrenListType::iterator;
   ChildrenIteratorType TubeIterator = tubeList->begin();
 
   typename OutputImageType::IndexType index;
@@ -220,7 +220,7 @@ TubeSpatialObjectToImageFilter< ObjectDimension, TOutputImage, TRadiusImage,
 
     for( unsigned int k=0; k < tube->GetNumberOfPoints(); k++ )
       {
-      typedef typename TubeType::TubePointType TubePointType;
+      using TubePointType = typename TubeType::TubePointType;
       const TubePointType* tubePoint = static_cast<const TubePointType*>(
         tube->GetPoint( k ) );
       bool isInside = OutputImage->TransformPhysicalPointToContinuousIndex(

--- a/src/Filtering/itktubeTubeSpatialObjectToTubeGraphFilter.h
+++ b/src/Filtering/itktubeTubeSpatialObjectToTubeGraphFilter.h
@@ -46,20 +46,20 @@ class TubeSpatialObjectToTubeGraphFilter
 {
 public:
 
-  /** Standard class typedefs. */
-  typedef TubeSpatialObjectToTubeGraphFilter             Self;
-  typedef Object                                         SuperClass;
-  typedef SmartPointer< Self >                           Pointer;
-  typedef SmartPointer< const Self >                     ConstPointer;
+  /** Standard class type alias. */
+  using Self = TubeSpatialObjectToTubeGraphFilter;
+  using SuperClass = Object;
+  using Pointer = SmartPointer< Self >;
+  using ConstPointer = SmartPointer< const Self >;
 
-  /** Tube class typedef */
-  typedef Image< TPixel, Dimension >                     InputImageType;
-  typedef typename InputImageType::Pointer               InputImagePointer;
-  typedef GroupSpatialObject< Dimension >                TubeGroupType;
-  typedef typename TubeGroupType::Pointer                TubeGroupPointer;
-  typedef TubeSpatialObject< Dimension >                 TubeSpatialObjectType;
-  typedef typename TubeSpatialObjectType::TubePointType  TubePointType;
-  typedef typename TubeSpatialObjectType::TransformType  TubeTransformType;
+  /** Tube class type alias */
+  using InputImageType = Image< TPixel, Dimension >;
+  using InputImagePointer = typename InputImageType::Pointer;
+  using TubeGroupType = GroupSpatialObject< Dimension >;
+  using TubeGroupPointer = typename TubeGroupType::Pointer;
+  using TubeSpatialObjectType = TubeSpatialObject< Dimension >;
+  using TubePointType = typename TubeSpatialObjectType::TubePointType;
+  using TubeTransformType = typename TubeSpatialObjectType::TransformType;
 
   /** Method for creation through the object factory. */
   itkNewMacro( Self );

--- a/src/Filtering/itktubeTubeSpatialObjectToTubeGraphFilter.hxx
+++ b/src/Filtering/itktubeTubeSpatialObjectToTubeGraphFilter.hxx
@@ -75,7 +75,7 @@ TubeSpatialObjectToTubeGraphFilter< TPixel, Dimension >
   itkDebugMacro( <<
     "TubeSpatialObjectToTubeGraphFilter::Update() called." );
 
-  typedef itk::MinimumMaximumImageFilter< InputImageType > MinMaxFilterType;
+  using MinMaxFilterType = itk::MinimumMaximumImageFilter< InputImageType >;
   typename MinMaxFilterType::Pointer mmFilter = MinMaxFilterType::New();
   mmFilter->SetInput( m_CVTImage );
   mmFilter->Update();

--- a/src/Filtering/tubeImageMathFilters.h
+++ b/src/Filtering/tubeImageMathFilters.h
@@ -34,8 +34,8 @@ template< unsigned int VDimension >
 class ImageMathFilters 
 {
 public:
-  typedef float                                    PixelType;
-  typedef itk::Image< PixelType, VDimension >      ImageType;
+  using PixelType = float;
+  using ImageType = itk::Image< PixelType, VDimension >;
 
   ImageMathFilters();
   ~ImageMathFilters();
@@ -90,7 +90,7 @@ public:
   /** Use mirroring to pad an image. */
   void MirrorAndPadImage( int numPadVoxels );
 
-  /** Normalize: = mean/std; 1 = FWHM ; 2 = FWHM mean ( shift ) only */
+  /** Normalize: = mean/std; 1 = FWHM; 2 = FWHM mean ( shift ) only */
   void NormalizeImage( int normType );
 
   /** Fuse two images by max, applying offset to second image. */

--- a/src/Filtering/tubeImageMathFilters.hxx
+++ b/src/Filtering/tubeImageMathFilters.hxx
@@ -154,8 +154,8 @@ ResampleImage( ImageType * ref )
 
   if( doResample )
     {
-    typedef typename itk::ResampleImageFilter< ImageType,
-      ImageType> ResampleFilterType;
+    using ResampleFilterType = typename itk::ResampleImageFilter< ImageType,
+      ImageType>;
     typename ResampleFilterType::Pointer filter =
       ResampleFilterType::New();
     typename ImageType::Pointer imTemp;
@@ -175,7 +175,7 @@ ImageMathFilters<VDimension>::
 AddUniformNoise( float valMin, float valMax, float noiseMin,
   float noiseMax, int seed )
 {
-  typedef itk::Statistics::MersenneTwisterRandomVariateGenerator UniformGenType;
+  using UniformGenType = itk::Statistics::MersenneTwisterRandomVariateGenerator;
   typename UniformGenType::Pointer uniformGen = UniformGenType::New();
   std::srand( seed );
   uniformGen->Initialize( ( int )seed );
@@ -202,7 +202,7 @@ ImageMathFilters<VDimension>::
 AddGaussianNoise( float valMin, float valMax, float noiseMean,
   float noiseStdDev, int seed )
 {
-  typedef itk::Statistics::NormalVariateGenerator GaussGenType;
+  using GaussGenType = itk::Statistics::NormalVariateGenerator;
   typename GaussGenType::Pointer gaussGen = GaussGenType::New();
   std::srand( seed );
   gaussGen->Initialize( ( int )seed );
@@ -272,7 +272,7 @@ void
 ImageMathFilters<VDimension>::
 MirrorAndPadImage( int numPadVoxels )
 {
-  typedef itk::MirrorPadImageFilter< ImageType, ImageType > PadFilterType;
+  using PadFilterType = itk::MirrorPadImageFilter< ImageType, ImageType >;
   typename PadFilterType::Pointer padFilter = PadFilterType::New();
   padFilter->SetInput( m_Input );
   typename PadFilterType::InputImageSizeType bounds;
@@ -290,8 +290,7 @@ NormalizeImage( int normType )
 {
   if( normType == 0 )
     {
-    typedef itk::NormalizeImageFilter< ImageType, ImageType >
-                                                  NormFilterType;
+    using NormFilterType = itk::NormalizeImageFilter< ImageType, ImageType >;
     typename NormFilterType::Pointer normFilter = NormFilterType::New();
     normFilter->SetInput( m_Input );
     normFilter->Update();
@@ -470,8 +469,7 @@ void
 ImageMathFilters<VDimension>::
 MedianImage( int filterSize )
 {
-  typedef itk::MedianImageFilter< ImageType, ImageType >
-    FilterType;
+  using FilterType = itk::MedianImageFilter< ImageType, ImageType >;
   typename ImageType::Pointer imTemp;
   typename FilterType::Pointer filter = FilterType::New();
   filter->SetInput( m_Input );
@@ -601,16 +599,13 @@ ImageMathFilters<VDimension>
 ::MorphImage( int mode, int radius, float foregroundValue,
   float backgroundValue )
 {
-  typedef itk::BinaryBallStructuringElement<PixelType, VDimension>
-    BallType;
+  using BallType = itk::BinaryBallStructuringElement<PixelType, VDimension>;
   BallType ball;
   ball.SetRadius( radius );
   ball.CreateStructuringElement();
 
-  typedef itk::BinaryErodeImageFilter<ImageType, ImageType, BallType>
-    ErodeFilterType;
-  typedef itk::BinaryDilateImageFilter<ImageType, ImageType, BallType>
-    DilateFilterType;
+  using ErodeFilterType = itk::BinaryErodeImageFilter<ImageType, ImageType, BallType>;
+  using DilateFilterType = itk::BinaryDilateImageFilter<ImageType, ImageType, BallType>;
   switch( mode )
     {
     case 0:
@@ -790,9 +785,8 @@ ImageMathFilters<VDimension>
 ::CorrectIntensitySliceBySliceUsingHistogramMatching(
     unsigned int numberOfBins, unsigned int numberOfMatchPoints )
 {
-  typedef itk::Image<PixelType, 2> ImageType2D;
-  typedef itk::HistogramMatchingImageFilter< ImageType2D, ImageType2D >
-      HistogramMatchFilterType;
+  using ImageType2D = itk::Image<PixelType, 2>;
+  using HistogramMatchFilterType = itk::HistogramMatchingImageFilter< ImageType2D, ImageType2D >;
   typename HistogramMatchFilterType::Pointer matchFilter;
   typename ImageType2D::Pointer im2DRef = ImageType2D::New();
   typename ImageType2D::Pointer im2DIn = ImageType2D::New();
@@ -880,8 +874,7 @@ ImageMathFilters<VDimension>
 ::CorrectIntensityUsingHistogramMatching( unsigned int numberOfBins,
   unsigned int numberOfMatchPoints, ImageType * ref )
 {
-  typedef itk::HistogramMatchingImageFilter< ImageType, ImageType >
-      HistogramMatchFilterType;
+  using HistogramMatchFilterType = itk::HistogramMatchingImageFilter< ImageType, ImageType >;
   typename HistogramMatchFilterType::Pointer matchFilter;
   matchFilter = HistogramMatchFilterType::New();
   matchFilter->SetReferenceImage( ref );
@@ -963,8 +956,7 @@ void
 ImageMathFilters<VDimension>
 ::ExtractSlice( unsigned int dimension, unsigned int slice )
 {
-  typedef itk::ExtractImageFilter<ImageType, ImageType>
-    ExtractSliceFilterType;
+  using ExtractSliceFilterType = itk::ExtractImageFilter<ImageType, ImageType>;
 
   typename ExtractSliceFilterType::Pointer filter =
     ExtractSliceFilterType::New();
@@ -1002,7 +994,7 @@ ImageMathFilters<VDimension>
   double logScaleStep = ( std::log( scaleMax ) - std::log( scaleMin ) )
     / ( numScales-1 );
 
-  typedef itk::tube::NJetImageFunction< ImageType > ImageFunctionType;
+  using ImageFunctionType = itk::tube::NJetImageFunction< ImageType >;
   typename ImageFunctionType::Pointer imFunc = ImageFunctionType::New();
   imFunc->SetInputImage( m_Input );
 
@@ -1077,8 +1069,7 @@ ImageMathFilters<VDimension>
 ::SegmentUsingConnectedThreshold( float threshLow, float threshHigh,
   float labelValue, float x, float y, float z )
 {
-  typedef itk::ConnectedThresholdImageFilter<ImageType, ImageType>
-             FilterType;
+  using FilterType = itk::ConnectedThresholdImageFilter<ImageType, ImageType>;
   typename FilterType::Pointer filter = FilterType::New();
 
   typename ImageType::IndexType seed;
@@ -1106,7 +1097,7 @@ ImageMathFilters<VDimension>
 ::ComputeVoronoiTessellation( unsigned int numberOfCentroids,
   unsigned int numberOfIterations, unsigned int numberOfSamples )
 {
-  typedef itk::tube::CVTImageFilter<ImageType, ImageType> FilterType;
+  using FilterType = itk::tube::CVTImageFilter<ImageType, ImageType>;
   typename FilterType::Pointer filter = FilterType::New();
   filter->SetInput( m_Input );
   filter->SetNumberOfSamples( numberOfSamples );

--- a/src/Filtering/tubeTubeMathFilters.h
+++ b/src/Filtering/tubeTubeMathFilters.h
@@ -33,21 +33,21 @@ template< unsigned int DimensionT, class ImagePixelT=float >
 class TubeMathFilters
 {
 public:
-  //typedefs
-  typedef itk::GroupSpatialObject< DimensionT >         TubeGroupType;
-  typedef typename TubeGroupType::ChildrenListPointer   TubeListPointerType;
+  //type alias
+  using TubeGroupType = itk::GroupSpatialObject< DimensionT >;
+  using TubeListPointerType = typename TubeGroupType::ChildrenListPointer;
 
-  typedef itk::TubeSpatialObject< DimensionT >          TubeType;
-  typedef typename TubeType::TubePointType              TubePointType;
+  using TubeType = itk::TubeSpatialObject< DimensionT >;
+  using TubePointType = typename TubeType::TubePointType;
 
-  typedef itk::Image< ImagePixelT, DimensionT >         ImageType;
-  typedef itk::Image< float, DimensionT >               FloatImageType;
-  typedef typename FloatImageType::OffsetType           VectorPixelType;
-  typedef itk::Image< VectorPixelType, DimensionT >     VectorImageType;
+  using ImageType = itk::Image< ImagePixelT, DimensionT >;
+  using FloatImageType = itk::Image< float, DimensionT >;
+  using VectorPixelType = typename FloatImageType::OffsetType;
+  using VectorImageType = itk::Image< VectorPixelType, DimensionT >;
 
-  typedef typename TubeType::PointType                  PositionType;
-  typedef itk::IndexValueType                           TubeIdType;
-  typedef typename TubeType::TubePointListType          TubePointListType;
+  using PositionType = typename TubeType::PointType;
+  using TubeIdType = itk::IndexValueType;
+  using TubePointListType = typename TubeType::TubePointListType;
 
   TubeMathFilters();
   ~TubeMathFilters();

--- a/src/Filtering/tubeTubeMathFilters.hxx
+++ b/src/Filtering/tubeTubeMathFilters.hxx
@@ -367,8 +367,8 @@ ComputeTubeRegions( const ImageType * referenceImage )
   this->RenumberTubes();
   this->RenumberPoints();
 
-  typedef itk::tube::TubeSpatialObjectToImageFilter< DimensionT,
-    FloatImageType > TubeToImageFilterType;
+  using TubeToImageFilterType = itk::tube::TubeSpatialObjectToImageFilter< DimensionT,
+    FloatImageType >;
   typename TubeToImageFilterType::Pointer tubeToImageFilter =
     TubeToImageFilterType::New();
   tubeToImageFilter->SetInput( m_InputTubeGroup );
@@ -382,8 +382,7 @@ ComputeTubeRegions( const ImageType * referenceImage )
   m_TubePointIdImage = tubeToImageFilter->GetOutput();
   m_TubeRadiusImage  = tubeToImageFilter->GetRadiusImage();
 
-  typedef itk::DanielssonDistanceMapImageFilter< FloatImageType, FloatImageType>
-    DanielssonFilterType;
+  using DanielssonFilterType = itk::DanielssonDistanceMapImageFilter< FloatImageType, FloatImageType>;
   typename DanielssonFilterType::Pointer distF = DanielssonFilterType::New();
   distF->SetInput( m_TubePointIdImage );
   distF->SetUseImageSpacing( true );
@@ -406,9 +405,9 @@ SetPointValuesFromTubeRegions(
 {
   this->SetPointValues( propertyId, 0 );
 
-  typedef itk::ImageRegionConstIterator<ImageType>    ImageConstIteratorType;
-  typedef itk::ImageRegionIterator<VectorImageType>   VectorImageIteratorType;
-  typedef itk::ImageRegionIterator<FloatImageType>    FloatImageIteratorType;
+  using ImageConstIteratorType = itk::ImageRegionConstIterator<ImageType>;
+  using VectorImageIteratorType = itk::ImageRegionIterator<VectorImageType>;
+  using FloatImageIteratorType = itk::ImageRegionIterator<FloatImageType>;
 
   FloatImageIteratorType itDistImage( m_TubeDistanceImage,
       m_TubeDistanceImage->GetLargestPossibleRegion() );
@@ -546,7 +545,7 @@ SetPointValuesFromTubeRadius(
 {
   this->SetPointValues( propertyId, 0 );
 
-  typedef itk::ContinuousIndex<double, DimensionT> ContinuousIndexType;
+  using ContinuousIndexType = itk::ContinuousIndex<double, DimensionT>;
 
   // Get the list of tubes
   TubeListPointerType inputTubeList = m_InputTubeGroup->GetChildren(
@@ -1286,7 +1285,7 @@ ComputeTubeLength( void )
         {
         continue;
         }
-      typedef typename PositionType::VectorType PositionVectorType;
+      using PositionVectorType = typename PositionType::VectorType;
     
       typename TubePointListType::const_iterator itTubePoints =
         curTube->GetPoints().begin();

--- a/src/IO/itktubePDFSegmenterParzenIO.h
+++ b/src/IO/itktubePDFSegmenterParzenIO.h
@@ -49,9 +49,9 @@ class PDFSegmenterParzenIO
 {
 public:
 
-  typedef PDFSegmenterParzenIO< TImage, TLabelMap >  PDFSegmenterIOType;
+  using PDFSegmenterIOType = PDFSegmenterParzenIO< TImage, TLabelMap >;
 
-  typedef PDFSegmenterParzen< TImage, TLabelMap >    PDFSegmenterType;
+  using PDFSegmenterType = PDFSegmenterParzen< TImage, TLabelMap >;
 
   PDFSegmenterParzenIO( void );
 

--- a/src/IO/itktubePDFSegmenterParzenIO.hxx
+++ b/src/IO/itktubePDFSegmenterParzenIO.hxx
@@ -452,7 +452,7 @@ Read( const char * _headerName )
 
   for( unsigned int i = 0; i < nObjects; ++i )
     {
-    typedef Image< float, PARZEN_MAX_NUMBER_OF_FEATURES >  pdfImageType;
+    using pdfImageType = Image< float, PARZEN_MAX_NUMBER_OF_FEATURES >;
 
     std::string filePath;
     MET_GetFilePath( _headerName, filePath );

--- a/src/IO/itktubeRidgeSeedFilterIO.h
+++ b/src/IO/itktubeRidgeSeedFilterIO.h
@@ -47,9 +47,9 @@ class RidgeSeedFilterIO
 {
 public:
 
-  typedef RidgeSeedFilterIO< TImage, TLabelMap >  RidgeSeedFilterIOType;
+  using RidgeSeedFilterIOType = RidgeSeedFilterIO< TImage, TLabelMap >;
 
-  typedef RidgeSeedFilter< TImage, TLabelMap >    RidgeSeedFilterType;
+  using RidgeSeedFilterType = RidgeSeedFilter< TImage, TLabelMap >;
 
   RidgeSeedFilterIO( void );
 

--- a/src/IO/itktubeRidgeSeedFilterIO.hxx
+++ b/src/IO/itktubeRidgeSeedFilterIO.hxx
@@ -196,7 +196,7 @@ Read( const char * _headerName )
   MET_GetFilePath( _headerName, pdfPath );
   pdfFileName = pdfPath + pdfFileName;
 
-  typedef PDFSegmenterParzen< TImage, TLabelMap > PDFSegmenterParzenType;
+  using PDFSegmenterParzenType = PDFSegmenterParzen< TImage, TLabelMap >;
   typename PDFSegmenterParzenType::Pointer pdfParzen = dynamic_cast<
     PDFSegmenterParzenType * >( m_RidgeSeedFilter->GetPDFSegmenter().
       GetPointer() );
@@ -272,7 +272,7 @@ Write( const char * _headerName )
 
   bool result = true;
 
-  typedef PDFSegmenterParzen< TImage, TLabelMap > PDFSegmenterParzenType;
+  using PDFSegmenterParzenType = PDFSegmenterParzen< TImage, TLabelMap >;
   typename PDFSegmenterParzenType::Pointer pdfParzen = dynamic_cast<
     PDFSegmenterParzenType * >( m_RidgeSeedFilter->
       GetPDFSegmenter().GetPointer() );

--- a/src/IO/itktubeTubeExtractorIO.h
+++ b/src/IO/itktubeTubeExtractorIO.h
@@ -48,7 +48,7 @@ class TubeExtractorIO
 {
 public:
 
-  typedef TubeExtractor< TImage >    TubeExtractorType;
+  using TubeExtractorType = TubeExtractor< TImage >;
 
   TubeExtractorIO( void );
 

--- a/src/IO/itktubeTubeXIO.h
+++ b/src/IO/itktubeTubeXIO.h
@@ -39,15 +39,15 @@ class TubeXIO : public Object
 {
 public:
 
-  typedef TubeXIO                                 Self;
-  typedef Object                                  Superclass;
-  typedef SmartPointer< Self >                    Pointer;
-  typedef SmartPointer< const Self >              ConstPointer;
+  using Self = TubeXIO;
+  using Superclass = Object;
+  using Pointer = SmartPointer< Self >;
+  using ConstPointer = SmartPointer< const Self >;
 
-  typedef TubeSpatialObject< TDimension >         TubeType;
-  typedef GroupSpatialObject< TDimension >        TubeGroupType;
+  using TubeType = TubeSpatialObject< TDimension >;
+  using TubeGroupType = GroupSpatialObject< TDimension >;
 
-  typedef Size< TDimension >                      SizeType;
+  using SizeType = Size< TDimension >;
 
   itkTypeMacro( TubeXIO, Object );
 

--- a/src/IO/itktubeTubeXIO.hxx
+++ b/src/IO/itktubeTubeXIO.hxx
@@ -471,7 +471,7 @@ TubeXIO< TDimension >
     tmpWriteStream << "Points:" << std::endl;
     for( unsigned int i=0; i<nPoints; ++i )
       {
-      typedef const typename TubeType::TubePointType  TubePointType;
+      using TubePointType = const typename TubeType::TubePointType;
       TubePointType * pnt;
       pnt = static_cast< TubePointType * >( tube->GetPoint( i ) );
       for( unsigned int k=0; k<TDimension; ++k )

--- a/src/MetaIO/itktubeMetaClassPDF.h
+++ b/src/MetaIO/itktubeMetaClassPDF.h
@@ -51,9 +51,9 @@ class MetaClassPDF : private MetaImage
 {
 public:
 
-  typedef std::vector< int >                    VectorIntType;
-  typedef std::vector< unsigned int >           VectorUIntType;
-  typedef std::vector< double >                 VectorDoubleType;
+  using VectorIntType = std::vector< int >;
+  using VectorUIntType = std::vector< unsigned int >;
+  using VectorDoubleType = std::vector< double >;
 
   MetaClassPDF( void );
 

--- a/src/MetaIO/itktubeMetaLDA.h
+++ b/src/MetaIO/itktubeMetaLDA.h
@@ -54,9 +54,9 @@ class MetaLDA : public MetaForm
 {
 public:
 
-  typedef std::vector< double >  ValueListType;
-  typedef vnl_vector< double >   LDAValuesType;
-  typedef vnl_matrix< double >   LDAMatrixType;
+  using ValueListType = std::vector< double >;
+  using LDAValuesType = vnl_vector< double >;
+  using LDAMatrixType = vnl_matrix< double >;
 
   MetaLDA( void );
 

--- a/src/MetaIO/itktubeMetaNJetLDA.h
+++ b/src/MetaIO/itktubeMetaNJetLDA.h
@@ -55,9 +55,9 @@ class MetaNJetLDA : public MetaLDA
 {
 public:
 
-  typedef std::vector< double >   NJetScalesType;
-  typedef MetaLDA::LDAValuesType  LDAValuesType;
-  typedef MetaLDA::LDAMatrixType  LDAMatrixType;
+  using NJetScalesType = std::vector< double >;
+  using LDAValuesType = MetaLDA::LDAValuesType;
+  using LDAMatrixType = MetaLDA::LDAMatrixType;
 
   MetaNJetLDA( void );
 

--- a/src/MetaIO/itktubeMetaRidgeSeed.h
+++ b/src/MetaIO/itktubeMetaRidgeSeed.h
@@ -55,11 +55,11 @@ class MetaRidgeSeed : public MetaLDA
 {
 public:
 
-  typedef std::vector< double >   RidgeSeedScalesType;
+  using RidgeSeedScalesType = std::vector< double >;
 
-  typedef MetaLDA::LDAValuesType  LDAValuesType;
+  using LDAValuesType = MetaLDA::LDAValuesType;
 
-  typedef MetaLDA::LDAMatrixType  LDAMatrixType;
+  using LDAMatrixType = MetaLDA::LDAMatrixType;
 
   MetaRidgeSeed( void );
 

--- a/src/MetaIO/itktubeMetaTubeExtractor.h
+++ b/src/MetaIO/itktubeMetaTubeExtractor.h
@@ -53,11 +53,11 @@ class MetaTubeExtractor : public MetaForm
 {
 public:
 
-  typedef std::vector< double >   ValueListType;
+  using ValueListType = std::vector< double >;
 
-  typedef vnl_vector< double >    VectorType;
+  using VectorType = vnl_vector< double >;
 
-  typedef vnl_matrix< double >    MatrixType;
+  using MatrixType = vnl_matrix< double >;
 
   MetaTubeExtractor( void );
 

--- a/src/Numerics/itktubeBasisFeatureVectorGenerator.h
+++ b/src/Numerics/itktubeBasisFeatureVectorGenerator.h
@@ -44,42 +44,42 @@ class BasisFeatureVectorGenerator : public FeatureVectorGenerator< TImage >
 {
 public:
 
-  typedef BasisFeatureVectorGenerator            Self;
-  typedef FeatureVectorGenerator< TImage >       Superclass;
-  typedef SmartPointer< Self >                   Pointer;
-  typedef SmartPointer< const Self >             ConstPointer;
+  using Self = BasisFeatureVectorGenerator;
+  using Superclass = FeatureVectorGenerator< TImage >;
+  using Pointer = SmartPointer< Self >;
+  using ConstPointer = SmartPointer< const Self >;
 
   itkTypeMacro( BasisFeatureVectorGenerator, FeatureVectorGenerator );
 
   itkNewMacro( Self );
 
   //
-  typedef typename Superclass::ImageType         ImageType;
+  using ImageType = typename Superclass::ImageType;
 
-  typedef TLabelMap                              LabelMapType;
+  using LabelMapType = TLabelMap;
 
   itkStaticConstMacro( ImageDimension, unsigned int,
     TImage::ImageDimension );
 
-  typedef typename Superclass::IndexType         IndexType;
+  using IndexType = typename Superclass::IndexType;
 
-  typedef typename Superclass::FeatureValueType  FeatureValueType;
-  typedef typename Superclass::FeatureVectorType FeatureVectorType;
-  typedef typename Superclass::FeatureImageType  FeatureImageType;
+  using FeatureValueType = typename Superclass::FeatureValueType;
+  using FeatureVectorType = typename Superclass::FeatureVectorType;
+  using FeatureImageType = typename Superclass::FeatureImageType;
 
-  typedef FeatureVectorGenerator< TImage >       FeatureVectorGeneratorType;
+  using FeatureVectorGeneratorType = FeatureVectorGenerator< TImage >;
 
-  typedef typename TLabelMap::PixelType          ObjectIdType;
-  typedef std::vector< ObjectIdType >            ObjectIdListType;
+  using ObjectIdType = typename TLabelMap::PixelType;
+  using ObjectIdListType = std::vector< ObjectIdType >;
 
-  typedef typename Superclass::ValueType         ValueType;
-  typedef typename Superclass::ValueListType     ValueListType;
+  using ValueType = typename Superclass::ValueType;
+  using ValueListType = typename Superclass::ValueListType;
 
-  typedef vnl_vector< ValueType >                VectorType;
-  typedef std::vector< VectorType >              VectorListType;
+  using VectorType = vnl_vector< ValueType >;
+  using VectorListType = std::vector< VectorType >;
 
-  typedef vnl_matrix< ValueType >                MatrixType;
-  typedef std::vector< MatrixType >              MatrixListType;
+  using MatrixType = vnl_matrix< ValueType >;
+  using MatrixListType = std::vector< MatrixType >;
 
   void         SetInputFeatureVectorGenerator( FeatureVectorGeneratorType
                  * fGen );

--- a/src/Numerics/itktubeBasisFeatureVectorGenerator.hxx
+++ b/src/Numerics/itktubeBasisFeatureVectorGenerator.hxx
@@ -319,8 +319,7 @@ BasisFeatureVectorGenerator< TImage, TLabelMap >
 {
   if( featureNum < m_InputFeatureVectorGenerator->GetNumberOfFeatures() )
     {
-    typedef itk::ImageRegionIteratorWithIndex< FeatureImageType >
-      ImageIteratorType;
+    using ImageIteratorType = itk::ImageRegionIteratorWithIndex< FeatureImageType >;
 
     typename FeatureImageType::RegionType region;
     region = this->m_InputImageList[0]->GetLargestPossibleRegion();
@@ -337,8 +336,7 @@ BasisFeatureVectorGenerator< TImage, TLabelMap >
     if( m_LabelMap.IsNotNull() )
       {
       const unsigned int numClasses = this->GetNumberOfObjectIds();
-      typedef itk::ImageRegionConstIteratorWithIndex< LabelMapType >
-        ConstLabelMapIteratorType;
+      using ConstLabelMapIteratorType = itk::ImageRegionConstIteratorWithIndex< LabelMapType >;
       ConstLabelMapIteratorType itInMask( m_LabelMap,
         m_LabelMap->GetLargestPossibleRegion() );
       bool found = false;
@@ -460,8 +458,7 @@ void
 BasisFeatureVectorGenerator< TImage, TLabelMap >
 ::Update( void )
 {
-  typedef itk::ImageRegionConstIteratorWithIndex< LabelMapType >
-    ConstLabelMapIteratorType;
+  using ConstLabelMapIteratorType = itk::ImageRegionConstIteratorWithIndex< LabelMapType >;
   ConstLabelMapIteratorType itInMask( m_LabelMap,
     m_LabelMap->GetLargestPossibleRegion() );
 

--- a/src/Numerics/itktubeBlurImageFunction.h
+++ b/src/Numerics/itktubeBlurImageFunction.h
@@ -44,26 +44,26 @@ class BlurImageFunction
 {
 public:
   /**
-   * Standard "Self" typedef */
-  typedef BlurImageFunction                            Self;
-  typedef ImageFunction<TInputImage, double, double>   Superclass;
-  typedef SmartPointer< Self >                         Pointer;
-  typedef SmartPointer< const Self >                   ConstPointer;
+   * Standard "Self" type alias */
+  using Self = BlurImageFunction;
+  using Superclass = ImageFunction<TInputImage, double, double>;
+  using Pointer = SmartPointer< Self >;
+  using ConstPointer = SmartPointer< const Self >;
 
   itkTypeMacro( BlurImageFunction, ImageFunction );
 
   itkNewMacro( Self );
 
   /**
-   * InputImageType typedef support. */
-  typedef TInputImage                                InputImageType;
-  typedef typename InputImageType::SpacingType       SpacingType;
-  typedef typename InputImageType::SpacingType       SizeType;
+   * InputImageType type alias support. */
+  using InputImageType = TInputImage;
+  using SpacingType = typename InputImageType::SpacingType;
+  using SizeType = typename InputImageType::SpacingType;
 
   /**
-   * IndexType typedef support. */
-  typedef typename InputImageType::IndexType         IndexType;
-  typedef typename Superclass::ContinuousIndexType   ContinuousIndexType;
+   * IndexType type alias support. */
+  using IndexType = typename InputImageType::IndexType;
+  using ContinuousIndexType = typename Superclass::ContinuousIndexType;
 
   /**
    * Dimension of the underlying image. */
@@ -71,8 +71,8 @@ public:
     InputImageType::ImageDimension );
 
   /**
-   * Point typedef support. */
-  typedef typename Superclass::PointType             PointType;
+   * Point type alias support. */
+  using PointType = typename Superclass::PointType;
 
   /**
    * Set the input image. */
@@ -131,9 +131,9 @@ private:
   BlurImageFunction( const Self& );
   void operator=( const Self& );
 
-  typedef std::list< double > KernelWeightsListType;
+  using KernelWeightsListType = std::list< double >;
 
-  typedef std::list< typename InputImageType::IndexType > KernelXListType;
+  using KernelXListType = std::list< typename InputImageType::IndexType >;
 
   bool                    m_UseRelativeSpacing;
   SpacingType             m_Spacing;

--- a/src/Numerics/itktubeComputeImageSimilarityMetrics.h
+++ b/src/Numerics/itktubeComputeImageSimilarityMetrics.h
@@ -45,14 +45,14 @@ class ComputeImageSimilarityMetrics
 {
 public:
 
-  /** Standard class typedefs. */
-  typedef ComputeImageSimilarityMetrics               Self;
-  typedef Object                                      SuperClass;
-  typedef SmartPointer< Self >                        Pointer;
-  typedef SmartPointer< const Self >                  ConstPointer;
+  /** Standard class type alias. */
+  using Self = ComputeImageSimilarityMetrics;
+  using SuperClass = Object;
+  using Pointer = SmartPointer< Self >;
+  using ConstPointer = SmartPointer< const Self >;
 
-  /** custom typedefs */
-  typedef TInputImage                                 ImageType;
+  /** custom type alias */
+  using ImageType = TInputImage;
 
   /** Method for creation through the object factory. */
   itkNewMacro( Self );

--- a/src/Numerics/itktubeComputeImageSimilarityMetrics.hxx
+++ b/src/Numerics/itktubeComputeImageSimilarityMetrics.hxx
@@ -67,7 +67,7 @@ ComputeImageSimilarityMetrics< TInputImage >
     }
 
   // Normalize the images
-  typedef itk::NormalizeImageFilter< ImageType, ImageType > NormFilterType;
+  using NormFilterType = itk::NormalizeImageFilter< ImageType, ImageType >;
 
   typename NormFilterType::Pointer norm1 = NormFilterType::New();
   norm1->SetInput( m_Input1 );
@@ -78,28 +78,27 @@ ComputeImageSimilarityMetrics< TInputImage >
   norm2->Update();
 
   // Compute similarity
-  typedef itk::ImageToImageMetric< ImageType, ImageType > MetricType;
+  using MetricType = itk::ImageToImageMetric< ImageType, ImageType >;
   typename MetricType::Pointer metric;
 
-  typedef itk::IdentityTransform< double,
-    TInputImage::ImageDimension > TransformType;
+  using TransformType = itk::IdentityTransform< double,
+    TInputImage::ImageDimension >;
   typename TransformType::Pointer transform = TransformType::New();
 
-  typedef itk::LinearInterpolateImageFunction< ImageType, double >
-    InterpolatorType;
+  using InterpolatorType = itk::LinearInterpolateImageFunction< ImageType, double >;
   typename InterpolatorType::Pointer interpolator = InterpolatorType::New();
   interpolator->SetInputImage( norm2->GetOutput() );
 
   if( !m_UseCorrelation )
     {
-    typedef itk::MutualInformationImageToImageMetric< ImageType,
-      ImageType >                                          MIMetricType;
+    using MIMetricType = itk::MutualInformationImageToImageMetric< ImageType,
+      ImageType >;
     metric = MIMetricType::New();
     }
   else
     {
-    typedef itk::NormalizedCorrelationImageToImageMetric< ImageType,
-      ImageType >                                          CorMetricType;
+    using CorMetricType = itk::NormalizedCorrelationImageToImageMetric< ImageType,
+      ImageType >;
     metric = CorMetricType::New();
     }
 

--- a/src/Numerics/itktubeComputeImageStatistics.h
+++ b/src/Numerics/itktubeComputeImageStatistics.h
@@ -45,17 +45,17 @@ class ComputeImageStatistics
 {
 public:
 
-  /** Standard class typedefs. */
-  typedef ComputeImageStatistics                   Self;
-  typedef itk::ImageToImageFilter< itk::Image< float, VDimension >,
-      itk::Image< float, VDimension > >            Superclass;
-  typedef SmartPointer< Self >                     Pointer;
-  typedef SmartPointer< const Self >               ConstPointer;
+  /** Standard class type alias. */
+  using Self = ComputeImageStatistics;
+  using Superclass = itk::ImageToImageFilter< itk::Image< float, VDimension >,
+      itk::Image< float, VDimension > >;
+  using Pointer = SmartPointer< Self >;
+  using ConstPointer = SmartPointer< const Self >;
 
-  /** Custom typedefs */
-  typedef itk::Image< TPixel, VDimension >         MaskType;
-  typedef itk::Image< unsigned int, VDimension >   ConnCompType;
-  typedef itk::Image< float, VDimension >          VolumeType;
+  /** Custom type alias */
+  using MaskType = itk::Image< TPixel, VDimension >;
+  using ConnCompType = itk::Image< unsigned int, VDimension >;
+  using VolumeType = itk::Image< float, VDimension >;
 
   /** Method for creation through the object factory. */
   itkNewMacro( Self );

--- a/src/Numerics/itktubeComputeImageStatistics.hxx
+++ b/src/Numerics/itktubeComputeImageStatistics.hxx
@@ -84,7 +84,7 @@ ComputeImageStatistics< TPixel, VDimension >
     this->GetInput()->GetLargestPossibleRegion() );
   this->GetOutput()->Allocate();
 
-  typedef std::map< TPixel, unsigned int > MapType;
+  using MapType = std::map< TPixel, unsigned int >;
   MapType maskMap;
 
   itk::ImageRegionIterator< MaskType > maskIter( m_InputMask,

--- a/src/Numerics/itktubeFeatureVectorGenerator.h
+++ b/src/Numerics/itktubeFeatureVectorGenerator.h
@@ -42,30 +42,30 @@ class FeatureVectorGenerator : public LightProcessObject
 {
 public:
 
-  typedef FeatureVectorGenerator               Self;
-  typedef LightProcessObject                   Superclass;
-  typedef SmartPointer< Self >                 Pointer;
-  typedef SmartPointer< const Self >           ConstPointer;
+  using Self = FeatureVectorGenerator;
+  using Superclass = LightProcessObject;
+  using Pointer = SmartPointer< Self >;
+  using ConstPointer = SmartPointer< const Self >;
 
   itkTypeMacro( FeatureVectorGenerator, LightProcessObject );
 
   itkNewMacro( Self );
 
-  typedef TImage                                             ImageType;
-  typedef std::vector< typename ImageType::ConstPointer >    ImageListType;
+  using ImageType = TImage;
+  using ImageListType = std::vector< typename ImageType::ConstPointer >;
 
-  typedef typename TImage::IndexType                    IndexType;
+  using IndexType = typename TImage::IndexType;
 
   itkStaticConstMacro( ImageDimension, unsigned int,
     TImage::ImageDimension );
 
-  typedef float                                         FeatureValueType;
-  typedef vnl_vector< FeatureValueType >                FeatureVectorType;
+  using FeatureValueType = float;
+  using FeatureVectorType = vnl_vector< FeatureValueType >;
 
-  typedef Image< FeatureValueType, TImage::ImageDimension > FeatureImageType;
+  using FeatureImageType = Image< FeatureValueType, TImage::ImageDimension >;
 
-  typedef double                                        ValueType;
-  typedef std::vector< ValueType >                      ValueListType;
+  using ValueType = double;
+  using ValueListType = std::vector< ValueType >;
 
   virtual void SetInput( const ImageType * img );
   virtual void SetInput( unsigned int id, const ImageType * img );

--- a/src/Numerics/itktubeFeatureVectorGenerator.hxx
+++ b/src/Numerics/itktubeFeatureVectorGenerator.hxx
@@ -264,8 +264,7 @@ FeatureVectorGenerator< TImage >
   const unsigned int numFeatures = this->GetNumberOfFeatures();
   if( featureNum < numFeatures )
     {
-    typedef itk::ImageRegionIteratorWithIndex< FeatureImageType >
-      ImageIteratorType;
+    using ImageIteratorType = itk::ImageRegionIteratorWithIndex< FeatureImageType >;
 
     typename FeatureImageType::Pointer fi;
 
@@ -336,8 +335,7 @@ UpdateWhitenStatistics( void )
     }
   unsigned int imCount = 0;
 
-  typedef itk::ImageRegionConstIteratorWithIndex< TImage >
-    ImageConstIteratorType;
+  using ImageConstIteratorType = itk::ImageRegionConstIteratorWithIndex< TImage >;
   ImageConstIteratorType itIm( m_InputImageList[0],
     m_InputImageList[0]->GetLargestPossibleRegion() );
 

--- a/src/Numerics/itktubeImageRegionMomentsCalculator.h
+++ b/src/Numerics/itktubeImageRegionMomentsCalculator.h
@@ -70,11 +70,11 @@ template< class TImage >
 class ImageRegionMomentsCalculator : public Object
 {
 public:
-  /** Standard class typedefs. */
-  typedef ImageRegionMomentsCalculator<TImage>   Self;
-  typedef Object                                 Superclass;
-  typedef SmartPointer< Self >                   Pointer;
-  typedef SmartPointer< const Self >             ConstPointer;
+  /** Standard class type alias. */
+  using Self = ImageRegionMomentsCalculator<TImage>;
+  using Superclass = Object;
+  using Pointer = SmartPointer< Self >;
+  using ConstPointer = SmartPointer< const Self >;
 
   /** Method for creation through the object factory. */
   itkNewMacro( Self );
@@ -87,17 +87,15 @@ public:
                       TImage::ImageDimension );
 
   /** Standard scalar type within this class. */
-  typedef double                       ScalarType;
+  using ScalarType = double;
 
-  typedef typename TImage::PointType   PointType;
+  using PointType = typename TImage::PointType;
 
   /** Standard vector type within this class. */
-  typedef Vector<ScalarType, itkGetStaticConstMacro( ImageDimension )>
-                                       VectorType;
+  using VectorType = Vector<ScalarType, itkGetStaticConstMacro( ImageDimension )>;
 
   /** Spatial Object type within this class. */
-  typedef SpatialObject< itkGetStaticConstMacro( ImageDimension ) >
-                                       SpatialObjectType;
+  using SpatialObjectType = SpatialObject< itkGetStaticConstMacro( ImageDimension ) >;
 
   /** Spatial Object member types used within this class. */
   typedef typename SpatialObjectType::Pointer
@@ -106,20 +104,19 @@ public:
                                        SpatialObjectConstPointer;
 
   /** Standard matrix type within this class. */
-  typedef Matrix<ScalarType,
+  using MatrixType = Matrix<ScalarType,
                  itkGetStaticConstMacro( ImageDimension ),
-                 itkGetStaticConstMacro( ImageDimension )>   MatrixType;
+                 itkGetStaticConstMacro( ImageDimension )>;
 
   /** Standard image type within this class. */
-  typedef TImage ImageType;
+  using ImageType = TImage;
 
   /** Standard image type pointer within this class. */
-  typedef typename ImageType::Pointer      ImagePointer;
-  typedef typename ImageType::ConstPointer ImageConstPointer;
+  using ImagePointer = typename ImageType::Pointer;
+  using ImageConstPointer = typename ImageType::ConstPointer;
 
   /** Affine transform for mapping to and from principal axis */
-  typedef AffineTransform<double, itkGetStaticConstMacro( ImageDimension )>
-                                           AffineTransformType;
+  using AffineTransformType = AffineTransform<double, itkGetStaticConstMacro( ImageDimension )>;
   typedef typename AffineTransformType::Pointer
                                            AffineTransformPointer;
 

--- a/src/Numerics/itktubeImageRegionMomentsCalculator.hxx
+++ b/src/Numerics/itktubeImageRegionMomentsCalculator.hxx
@@ -126,7 +126,7 @@ Compute( void )
   m_Cg.Fill( NumericTraits<typename VectorType::ValueType>::Zero );
   m_Cm.Fill( NumericTraits<typename MatrixType::ValueType>::Zero );
 
-  typedef typename ImageType::IndexType IndexType;
+  using IndexType = typename ImageType::IndexType;
 
   if( !m_Image )
     {

--- a/src/Numerics/itktubeJointHistogramImageFunction.h
+++ b/src/Numerics/itktubeJointHistogramImageFunction.h
@@ -48,17 +48,17 @@ class JointHistogramImageFunction
 {
 public:
 
-  /** Class typedefs */
-  typedef JointHistogramImageFunction                   Self;
-  typedef ImageFunction<TInputImage, double, TCoordRep> Superclass;
-  typedef SmartPointer< Self >                          Pointer;
-  typedef SmartPointer< const Self >                    ConstPointer;
-  typedef typename Superclass::InputImageType           InputImageType;
-  typedef typename TInputImage::PixelType               PixelType;
-  typedef typename Superclass::PointType                PointType;
-  typedef typename Superclass::IndexType                IndexType;
-  typedef typename Superclass::ContinuousIndexType      ContinuousIndexType;
-  typedef itk::Image<float, 2>                          HistogramType;
+  /** Class type alias */
+  using Self = JointHistogramImageFunction;
+  using Superclass = ImageFunction<TInputImage, double, TCoordRep>;
+  using Pointer = SmartPointer< Self >;
+  using ConstPointer = SmartPointer< const Self >;
+  using InputImageType = typename Superclass::InputImageType;
+  using PixelType = typename TInputImage::PixelType;
+  using PointType = typename Superclass::PointType;
+  using IndexType = typename Superclass::IndexType;
+  using ContinuousIndexType = typename Superclass::ContinuousIndexType;
+  using HistogramType = itk::Image<float, 2>;
 
   /** Run-time type information ( and related methods ). */
   itkTypeMacro( JointHistogramImageFunction, ImageFunction );

--- a/src/Numerics/itktubeJointHistogramImageFunction.hxx
+++ b/src/Numerics/itktubeJointHistogramImageFunction.hxx
@@ -122,7 +122,7 @@ JointHistogramImageFunction<TInputImage, TCoordRep>
 {
   this->Superclass::SetInputImage( ptr );
 
-  typedef itk::MinimumMaximumImageCalculator<InputImageType> MinMaxType;
+  using MinMaxType = itk::MinimumMaximumImageCalculator<InputImageType>;
   typename MinMaxType::Pointer calculator = MinMaxType::New();
   calculator->SetImage( this->GetInputImage() );
   calculator->Compute();
@@ -139,7 +139,7 @@ JointHistogramImageFunction<TInputImage, TCoordRep>
 {
   m_InputMask = mask;
 
-  typedef itk::MinimumMaximumImageCalculator<InputImageType> MinMaxType;
+  using MinMaxType = itk::MinimumMaximumImageCalculator<InputImageType>;
   typename MinMaxType::Pointer calculator = MinMaxType::New();
   calculator->SetImage( m_InputMask );
   calculator->Compute();
@@ -203,8 +203,8 @@ void
 JointHistogramImageFunction<TInputImage, TCoordRep>
 ::ComputeMeanAndStandardDeviation( void ) const
 {
-  typedef itk::DiscreteGaussianImageFilter< HistogramType,
-          HistogramType > SmootherType;
+  using SmootherType = itk::DiscreteGaussianImageFilter< HistogramType,
+          HistogramType >;
 
   SmootherType::Pointer sumSmoother = SmootherType::New();
   sumSmoother->SetInput( m_SumHistogram );
@@ -221,7 +221,7 @@ JointHistogramImageFunction<TInputImage, TCoordRep>
   m_SumOfSquaresHistogram = sumSquaresSmoother->GetOutput();
 
     // Calculate the mean
-  typedef itk::ImageRegionIterator<HistogramType>  HistIteratorType;
+  using HistIteratorType = itk::ImageRegionIterator<HistogramType>;
   HistIteratorType sumItr( m_SumHistogram,
     m_SumHistogram->GetLargestPossibleRegion() );
   HistIteratorType sumOfSquaresItr( m_SumOfSquaresHistogram,
@@ -291,7 +291,7 @@ JointHistogramImageFunction<TInputImage, TCoordRep>
   typename HistogramType::Pointer hist;
   hist = this->ComputeHistogramAtIndex( index, true );
 
-  typedef itk::ImageRegionConstIterator<HistogramType>  HistIteratorType;
+  using HistIteratorType = itk::ImageRegionConstIterator<HistogramType>;
   HistIteratorType histItr( hist, hist->GetLargestPossibleRegion() );
   HistIteratorType meanItr( m_MeanHistogram,
                              m_MeanHistogram->GetLargestPossibleRegion() );
@@ -333,7 +333,7 @@ JointHistogramImageFunction<TInputImage, TCoordRep>
 {
   m_Histogram->FillBuffer( 0 );
 
-  typedef itk::ImageRegionConstIterator<InputImageType> ConstIteratorType;
+  using ConstIteratorType = itk::ImageRegionConstIterator<InputImageType>;
 
   typename InputImageType::IndexType minIndex;
   typename InputImageType::IndexType maxIndex;
@@ -401,8 +401,8 @@ JointHistogramImageFunction<TInputImage, TCoordRep>
 
   if( blur )
     {
-    typedef itk::DiscreteGaussianImageFilter< HistogramType,
-            HistogramType > SmootherType;
+    using SmootherType = itk::DiscreteGaussianImageFilter< HistogramType,
+            HistogramType >;
     SmootherType::Pointer smoother = SmootherType::New();
     smoother->SetInput( m_Histogram );
     smoother->SetVariance( 2 );

--- a/src/Numerics/itktubeNJetFeatureVectorGenerator.h
+++ b/src/Numerics/itktubeNJetFeatureVectorGenerator.h
@@ -46,10 +46,10 @@ class NJetFeatureVectorGenerator
 {
 public:
 
-  typedef NJetFeatureVectorGenerator           Self;
-  typedef FeatureVectorGenerator< TImage >     Superclass;
-  typedef SmartPointer< Self >                 Pointer;
-  typedef SmartPointer< const Self >           ConstPointer;
+  using Self = NJetFeatureVectorGenerator;
+  using Superclass = FeatureVectorGenerator< TImage >;
+  using Pointer = SmartPointer< Self >;
+  using ConstPointer = SmartPointer< const Self >;
 
   itkTypeMacro( NJetFeatureVectorGenerator, FeatureVectorGenerator );
 
@@ -58,15 +58,15 @@ public:
   itkStaticConstMacro( ImageDimension, unsigned int,
     TImage::ImageDimension );
 
-  typedef typename Superclass::FeatureValueType   FeatureValueType;
+  using FeatureValueType = typename Superclass::FeatureValueType;
 
-  typedef typename Superclass::FeatureVectorType  FeatureVectorType;
+  using FeatureVectorType = typename Superclass::FeatureVectorType;
 
-  typedef typename Superclass::ImageType          ImageType;
+  using ImageType = typename Superclass::ImageType;
 
-  typedef typename Superclass::IndexType          IndexType;
+  using IndexType = typename Superclass::IndexType;
 
-  typedef std::vector< double >                   NJetScalesType;
+  using NJetScalesType = std::vector< double >;
 
   virtual unsigned int GetNumberOfFeatures( void ) const override;
 

--- a/src/Numerics/itktubeNJetFeatureVectorGenerator.hxx
+++ b/src/Numerics/itktubeNJetFeatureVectorGenerator.hxx
@@ -88,7 +88,7 @@ NJetFeatureVectorGenerator< TImage >
 
   const unsigned int numInputImages = this->GetNumberOfInputImages();
 
-  typedef NJetImageFunction< ImageType > NJetFunctionType;
+  using NJetFunctionType = NJetImageFunction< ImageType >;
   typename NJetFunctionType::Pointer njet = NJetFunctionType::New();
   typename NJetFunctionType::VectorType v;
   typename NJetFunctionType::MatrixType m;
@@ -206,7 +206,7 @@ NJetFeatureVectorGenerator< TImage >
 {
   const unsigned int numInputImages = this->GetNumberOfInputImages();
 
-  typedef NJetImageFunction< ImageType > NJetFunctionType;
+  using NJetFunctionType = NJetImageFunction< ImageType >;
   typename NJetFunctionType::Pointer njet = NJetFunctionType::New();
   typename NJetFunctionType::VectorType v;
   typename NJetFunctionType::MatrixType m;

--- a/src/Numerics/itktubeNJetImageFunction.h
+++ b/src/Numerics/itktubeNJetImageFunction.h
@@ -50,18 +50,18 @@ public:
   /**
    * Standard "Self" typedef
    */
-  typedef NJetImageFunction Self;
+  using Self = NJetImageFunction;
 
   /**
    * Standard "Superclass" typedef
    */
-  typedef Object Superclass; // ImageFunction<TInputImage, double> Superclass;
+  using Superclass = Object; // ImageFunction<TInputImage, double>;
 
   /**
-   * Smart pointer typedef support.
+   * Smart pointer type alias support
    */
-  typedef SmartPointer< Self >        Pointer;
-  typedef SmartPointer< const Self >  ConstPointer;
+  using Pointer = SmartPointer< Self >;
+  using ConstPointer = SmartPointer< const Self >;
 
   /**
    * Method for creation through the object factory.
@@ -78,22 +78,22 @@ public:
                       unsigned int,
                       TInputImage::ImageDimension );
 
-  typedef TInputImage                                      InputImageType;
-  typedef typename InputImageType::Pointer                 InputImagePointer;
+  using InputImageType = TInputImage;
+  using InputImagePointer = typename InputImageType::Pointer;
 
-  typedef Point<double, ImageDimension >                   PointType;
-  typedef Vector< double, ImageDimension >                 VectorType;
-  typedef Matrix< double, ImageDimension, ImageDimension > MatrixType;
+  using PointType = Point<double, ImageDimension >;
+  using VectorType = Vector< double, ImageDimension >;
+  using MatrixType = Matrix< double, ImageDimension, ImageDimension >;
 
-  typedef typename InputImageType::IndexType               IndexType;
+  using IndexType = typename InputImageType::IndexType;
 
-  typedef ContinuousIndex<double, ImageDimension >         ContinuousIndexType;
+  using ContinuousIndexType = ContinuousIndex<double, ImageDimension >;
 
-  typedef typename InputImageType::SpacingType             SpacingType;
+  using SpacingType = typename InputImageType::SpacingType;
 
-  typedef Size< ImageDimension >                           SizeType;
+  using SizeType = Size< ImageDimension >;
 
-  typedef Array< VectorType >                              ArrayVectorType;
+  using ArrayVectorType = Array< VectorType >;
 
   /**
    * Set the input image.

--- a/src/Numerics/itktubeNJetImageFunction.hxx
+++ b/src/Numerics/itktubeNJetImageFunction.hxx
@@ -1993,7 +1993,7 @@ ScaleSubsample( double factor )
 {
   if( m_InputImage )
     {
-    typedef typename InputImageType::PixelType PixelType;
+    using PixelType = typename InputImageType::PixelType;
     typename InputImageType::SizeType size;
     size = m_InputImage->GetLargestPossibleRegion().GetSize();
     typename InputImageType::SpacingType spacing;
@@ -2010,7 +2010,7 @@ ScaleSubsample( double factor )
     newImage->SetOrigin( m_InputImage->GetOrigin() );
     newImage->Allocate();
 
-    typedef ImageRegionIteratorWithIndex<InputImageType> IteratorType;
+    using IteratorType = ImageRegionIteratorWithIndex<InputImageType>;
     IteratorType
         imageIt( newImage,
                 newImage->GetLargestPossibleRegion() );

--- a/src/Numerics/itktubeRidgeFFTFeatureVectorGenerator.h
+++ b/src/Numerics/itktubeRidgeFFTFeatureVectorGenerator.h
@@ -45,10 +45,10 @@ class RidgeFFTFeatureVectorGenerator
 {
 public:
 
-  typedef RidgeFFTFeatureVectorGenerator       Self;
-  typedef FeatureVectorGenerator< TImage >     Superclass;
-  typedef SmartPointer< Self >                 Pointer;
-  typedef SmartPointer< const Self >           ConstPointer;
+  using Self = RidgeFFTFeatureVectorGenerator;
+  using Superclass = FeatureVectorGenerator< TImage >;
+  using Pointer = SmartPointer< Self >;
+  using ConstPointer = SmartPointer< const Self >;
 
   itkTypeMacro( RidgeFFTFeatureVectorGenerator, FeatureVectorGenerator );
 
@@ -58,22 +58,21 @@ public:
   itkStaticConstMacro( ImageDimension, unsigned int,
     TImage::ImageDimension );
 
-  typedef typename Superclass::FeatureValueType      FeatureValueType;
+  using FeatureValueType = typename Superclass::FeatureValueType;
 
-  typedef typename Superclass::FeatureVectorType     FeatureVectorType;
+  using FeatureVectorType = typename Superclass::FeatureVectorType;
 
-  typedef typename Superclass::FeatureImageType      FeatureImageType;
+  using FeatureImageType = typename Superclass::FeatureImageType;
 
-  typedef typename Superclass::ValueListType         ValueListType;
+  using ValueListType = typename Superclass::ValueListType;
 
-  typedef typename Superclass::ImageType             ImageType;
+  using ImageType = typename Superclass::ImageType;
 
-  typedef typename Superclass::IndexType             IndexType;
+  using IndexType = typename Superclass::IndexType;
 
-  typedef std::vector< double >                      RidgeScalesType;
+  using RidgeScalesType = std::vector< double >;
 
-  typedef std::vector< typename FeatureImageType::Pointer >
-                                                     FeatureImageListType;
+  using FeatureImageListType = std::vector< typename FeatureImageType::Pointer >;
 
   //
   virtual unsigned int GetNumberOfImageFeaturesPerScale( void ) const;

--- a/src/Numerics/itktubeRidgeFFTFeatureVectorGenerator.hxx
+++ b/src/Numerics/itktubeRidgeFFTFeatureVectorGenerator.hxx
@@ -122,7 +122,7 @@ RidgeFFTFeatureVectorGenerator< TImage >
 
   this->m_WhitenMean.resize(numFeatureImages);
   this->m_WhitenStdDev.resize(numFeatureImages);
-  typedef itk::StatisticsImageFilter<FeatureImageType> StatsFilterType;
+  using StatsFilterType = itk::StatisticsImageFilter<FeatureImageType>;
   for( unsigned int f=0; f<numFeatureImages; ++f )
     {
     typename StatsFilterType::Pointer stats = StatsFilterType::New();
@@ -159,8 +159,7 @@ RidgeFFTFeatureVectorGenerator< TImage >
     unsigned int imageFirstFeat = feat;
     if( m_UseIntensityOnly )
       {
-      typedef itk::DiscreteGaussianImageFilter<TImage, FeatureImageType>
-        BlurFilterType;
+      using BlurFilterType = itk::DiscreteGaussianImageFilter<TImage, FeatureImageType>;
       for( unsigned int s=0; s<m_Scales.size(); ++s )
         {
         typename BlurFilterType::Pointer blurFilter = BlurFilterType::New();
@@ -171,8 +170,7 @@ RidgeFFTFeatureVectorGenerator< TImage >
         m_FeatureImageList[feat++] = blurFilter->GetOutput();
         if( s == 0 )
           {
-          typedef itk::SubtractImageFilter< FeatureImageType, TImage >
-            DiffFilterType;
+          using DiffFilterType = itk::SubtractImageFilter< FeatureImageType, TImage >;
           typename DiffFilterType::Pointer diffFilter = DiffFilterType::New();
           diffFilter->SetInput1(m_FeatureImageList[feat-1]);
           diffFilter->SetInput2(this->m_InputImageList[img]);
@@ -181,8 +179,7 @@ RidgeFFTFeatureVectorGenerator< TImage >
           }
         else
           {
-          typedef itk::SubtractImageFilter< FeatureImageType, FeatureImageType >
-            DiffFilterType;
+          using DiffFilterType = itk::SubtractImageFilter< FeatureImageType, FeatureImageType >;
           typename DiffFilterType::Pointer diffFilter = DiffFilterType::New();
           diffFilter->SetInput1(m_FeatureImageList[feat-1]);
           diffFilter->SetInput2(m_FeatureImageList[feat-numFeaturesPerScale-1]);
@@ -193,7 +190,7 @@ RidgeFFTFeatureVectorGenerator< TImage >
       }
     else
       {
-      typedef RidgeFFTFilter< TImage > RidgeFilterType;
+      using RidgeFilterType = RidgeFFTFilter< TImage >;
       typename RidgeFilterType::Pointer ridgeF = RidgeFilterType::New();
       ridgeF->SetInput( this->m_InputImageList[img] );
       ridgeF->SetUseIntensityOnly( false );
@@ -209,7 +206,7 @@ RidgeFFTFeatureVectorGenerator< TImage >
         }
       }
 
-    typedef ImageRegionIterator< FeatureImageType >  IterType;
+    using IterType = ImageRegionIterator< FeatureImageType >;
     unsigned int numIterators = numFeaturesPerScale * m_Scales.size() +
       numFeaturesPerScale + 1;
     std::vector< IterType > iterF( numIterators );

--- a/src/Numerics/itktubeSingleValuedCostFunctionImageSource.h
+++ b/src/Numerics/itktubeSingleValuedCostFunctionImageSource.h
@@ -45,20 +45,19 @@ class SingleValuedCostFunctionImageSource
   VNumberOfParameters > >
 {
 public:
-  typedef Image< typename TCostFunction::MeasureType, VNumberOfParameters >
-    CostFunctionImageType;
+  using CostFunctionImageType = Image< typename TCostFunction::MeasureType, VNumberOfParameters >;
 
-  typedef SingleValuedCostFunctionImageSource       Self;
-  typedef ImageSource< CostFunctionImageType >      Superclass;
-  typedef SmartPointer< Self >                      Pointer;
-  typedef SmartPointer< const Self >                ConstPointer;
+  using Self = SingleValuedCostFunctionImageSource;
+  using Superclass = ImageSource< CostFunctionImageType >;
+  using Pointer = SmartPointer< Self >;
+  using ConstPointer = SmartPointer< const Self >;
 
-  typedef TCostFunction                             CostFunctionType;
-  typedef typename CostFunctionType::MeasureType    MeasureType;
-  typedef typename CostFunctionType::ParametersType ParametersType;
+  using CostFunctionType = TCostFunction;
+  using MeasureType = typename CostFunctionType::MeasureType;
+  using ParametersType = typename CostFunctionType::ParametersType;
 
-  typedef typename Superclass::OutputImageType       OutputImageType;
-  typedef typename Superclass::OutputImageRegionType OutputImageRegionType;
+  using OutputImageType = typename Superclass::OutputImageType;
+  using OutputImageRegionType = typename Superclass::OutputImageRegionType;
 
   /** Dimensionality of the output image. */
   itkStaticConstMacro( NumberOfParameters, unsigned int, VNumberOfParameters );

--- a/src/Numerics/itktubeSingleValuedCostFunctionImageSource.hxx
+++ b/src/Numerics/itktubeSingleValuedCostFunctionImageSource.hxx
@@ -209,7 +209,7 @@ SingleValuedCostFunctionImageSource< TCostFunction, VNumberOfParameters >
   ProgressReporter progress( this, threadId,
     outputRegionForThread.GetNumberOfPixels() );
 
-  typedef ImageRegionIteratorWithIndex< OutputImageType > ImageIteratorType;
+  using ImageIteratorType = ImageRegionIteratorWithIndex< OutputImageType >;
   ImageIteratorType imageIt( outputImage, outputRegionForThread );
   for( imageIt.GoToBegin(); !imageIt.IsAtEnd(); ++imageIt )
     {

--- a/src/Numerics/itktubeVectorImageToListGenerator.h
+++ b/src/Numerics/itktubeVectorImageToListGenerator.h
@@ -67,11 +67,11 @@ template< class TImage, class TMaskImage >
 class VectorImageToListGenerator : public ProcessObject
 {
 public:
-  /** Standard class typedefs */
-  typedef VectorImageToListGenerator        Self;
-  typedef ProcessObject                     Superclass;
-  typedef SmartPointer< Self >              Pointer;
-  typedef SmartPointer< const Self >        ConstPointer;
+  /** Standard class type alias */
+  using Self = VectorImageToListGenerator;
+  using Superclass = ProcessObject;
+  using Pointer = SmartPointer< Self >;
+  using ConstPointer = SmartPointer< const Self >;
 
   /** Run-time type information ( and related methods ). */
   itkTypeMacro( VectorImageToListGenerator, ProcessObject );
@@ -79,33 +79,33 @@ public:
   /** Method for creation through the object factory. */
   itkNewMacro( Self );
 
-  /** Image typedefs */
-  typedef TImage                           ImageType;
-  typedef typename ImageType::Pointer      ImagePointer;
-  typedef typename ImageType::ConstPointer ImageConstPointer;
-  typedef typename ImageType::PixelType    PixelType;
-  typedef PixelType                        MeasurementVectorType;
+  /** Image type alias */
+  using ImageType = TImage;
+  using ImagePointer = typename ImageType::Pointer;
+  using ImageConstPointer = typename ImageType::ConstPointer;
+  using PixelType = typename ImageType::PixelType;
+  using MeasurementVectorType = PixelType;
 
-  /** Mask Image typedefs */
-  typedef TMaskImage                           MaskImageType;
-  typedef typename MaskImageType::Pointer      MaskImagePointer;
-  typedef typename MaskImageType::ConstPointer MaskImageConstPointer;
-  typedef typename MaskImageType::PixelType    MaskPixelType;
+  /** Mask Image type alias */
+  using MaskImageType = TMaskImage;
+  using MaskImagePointer = typename MaskImageType::Pointer;
+  using MaskImageConstPointer = typename MaskImageType::ConstPointer;
+  using MaskPixelType = typename MaskImageType::PixelType;
 
    /** Type of the output list sample */
-  typedef itk::Statistics::ListSample< MeasurementVectorType >  ListSampleType;
+  using ListSampleType = itk::Statistics::ListSample< MeasurementVectorType >;
 
-  /** Superclass typedefs for Measurement vector, measurement,
+  /** Superclass type alias for Measurement vector, measurement,
    * Instance Identifier, frequency, size, size element value */
-  typedef PixelTraits< typename ImageType::PixelType > PixelTraitsType;
+  using PixelTraitsType = PixelTraits< typename ImageType::PixelType >;
   typedef typename ListSampleType::MeasurementVectorSizeType
                                      MeasurementVectorSizeType;
 
-  typedef DataObject::Pointer DataObjectPointer;
+  using DataObjectPointer = DataObject::Pointer;
 
   /** ListSample is not a DataObject, we need to decorate it to push it down
    * a ProcessObject's pipeline */
-  typedef DataObjectDecorator< ListSampleType >  ListSampleOutputType;
+  using ListSampleOutputType = DataObjectDecorator< ListSampleType >;
 
   /** the number of components in a measurement vector */
   itkStaticConstMacro( MeasurementVectorSize, unsigned int,

--- a/src/Numerics/itktubeVectorImageToListGenerator.hxx
+++ b/src/Numerics/itktubeVectorImageToListGenerator.hxx
@@ -160,7 +160,7 @@ VectorImageToListGenerator< TImage, TMaskImage >
     maskImage = const_cast< MaskImageType * >( this->GetMaskImage() );
     }
 
-  typedef ImageRegionConstIterator< ImageType >     IteratorType;
+  using IteratorType = ImageRegionConstIterator< ImageType >;
   IteratorType it( input, input->GetBufferedRegion() );
   it.GoToBegin();
 
@@ -168,7 +168,7 @@ VectorImageToListGenerator< TImage, TMaskImage >
     {
     if( m_UseSingleMaskValue )
       {
-      typedef ImageRegionConstIterator< MaskImageType > MaskIteratorType;
+      using MaskIteratorType = ImageRegionConstIterator< MaskImageType >;
       MaskIteratorType mit( maskImage, maskImage->GetBufferedRegion() );
       mit.GoToBegin();
       while( !it.IsAtEnd() )
@@ -185,7 +185,7 @@ VectorImageToListGenerator< TImage, TMaskImage >
       }
     else
       {
-      typedef ImageRegionConstIterator< MaskImageType > MaskIteratorType;
+      using MaskIteratorType = ImageRegionConstIterator< MaskImageType >;
       MaskIteratorType mit( maskImage, maskImage->GetBufferedRegion() );
       mit.GoToBegin();
       while( !it.IsAtEnd() )

--- a/src/Numerics/itktubeVotingResampleImageFunction.h
+++ b/src/Numerics/itktubeVotingResampleImageFunction.h
@@ -54,11 +54,11 @@ class VotingResampleImageFunction
   : public InterpolateImageFunction< TInputImage, TCoordRep >
 {
 public:
-  /** Standard class typedefs. */
-  typedef VotingResampleImageFunction                      Self;
-  typedef InterpolateImageFunction<TInputImage, TCoordRep> Superclass;
-  typedef SmartPointer< Self >                             Pointer;
-  typedef SmartPointer< const Self >                       ConstPointer;
+  /** Standard class type alias. */
+  using Self = VotingResampleImageFunction;
+  using Superclass = InterpolateImageFunction<TInputImage, TCoordRep>;
+  using Pointer = SmartPointer< Self >;
+  using ConstPointer = SmartPointer< const Self >;
 
   /** Run-time type information ( and related methods ). */
   itkTypeMacro( VotingResampleImageFunction, InterpolateImageFunction );
@@ -66,27 +66,27 @@ public:
   /** Method for creation through the object factory. */
   itkNewMacro( Self );
 
-  /** OutputType typedef support. */
-  typedef typename Superclass::OutputType OutputType;
+  /** OutputType type alias support. */
+  using OutputType = typename Superclass::OutputType;
 
-  /** InputImageType typedef support. */
-  typedef typename Superclass::InputImageType InputImageType;
+  /** InputImageType type alias support. */
+  using InputImageType = typename Superclass::InputImageType;
 
-  /** SizeType typedef support. */
-  typedef typename Superclass::SizeType SizeType;
+  /** SizeType type alias support. */
+  using SizeType = typename Superclass::SizeType;
 
-  /** RealType typedef support. */
-  typedef typename Superclass::RealType RealType;
+  /** RealType type alias support. */
+  using RealType = typename Superclass::RealType;
 
   /** Dimension underlying input image. */
   itkStaticConstMacro( ImageDimension, unsigned int,
     Superclass::ImageDimension );
 
-  /** Index typedef support. */
-  typedef typename Superclass::IndexType IndexType;
+  /** Index type alias support. */
+  using IndexType = typename Superclass::IndexType;
 
-  /** ContinuousIndex typedef support. */
-  typedef typename Superclass::ContinuousIndexType ContinuousIndexType;
+  /** ContinuousIndex type alias support. */
+  using ContinuousIndexType = typename Superclass::ContinuousIndexType;
 
   /** Evaluate the function at a ContinuousIndex position
    *

--- a/src/Numerics/itktubeVotingResampleImageFunction.hxx
+++ b/src/Numerics/itktubeVotingResampleImageFunction.hxx
@@ -80,8 +80,7 @@ VotingResampleImageFunction< TInputImage, TCoordRep >
 ::EvaluateAtContinuousIndex(
   const ContinuousIndexType& index ) const
 {
-  typedef itk::ConstNeighborhoodIterator< TInputImage >
-    NeighborhoodIteratorType;
+  using NeighborhoodIteratorType = itk::ConstNeighborhoodIterator< TInputImage >;
 
   NeighborhoodIteratorType it( m_Radius, this->GetInputImage(),
     this->GetInputImage()->GetRequestedRegion() );

--- a/src/Numerics/tubeBrentOptimizer1D.h
+++ b/src/Numerics/tubeBrentOptimizer1D.h
@@ -39,13 +39,13 @@ class BrentOptimizer1D : public Optimizer1D
 {
 public:
 
-  typedef BrentOptimizer1D                    Self;
-  typedef Optimizer1D                         Superclass;
-  typedef Self *                              Pointer;
-  typedef const Self *                        ConstPointer;
+  using Self = BrentOptimizer1D;
+  using Superclass = Optimizer1D;
+  using Pointer = Self *;
+  using ConstPointer = const Self *;
 
-  typedef Superclass::ValueFunctionType       ValueFunctionType;
-  typedef Superclass::DerivativeFunctionType  DerivativeFunctionType;
+  using ValueFunctionType = Superclass::ValueFunctionType;
+  using DerivativeFunctionType = Superclass::DerivativeFunctionType;
 
   /** Return the type of this object. */
   tubeTypeMacro( BrentOptimizer1D );

--- a/src/Numerics/tubeGoldenMeanOptimizer1D.h
+++ b/src/Numerics/tubeGoldenMeanOptimizer1D.h
@@ -39,12 +39,12 @@ class GoldenMeanOptimizer1D : public Optimizer1D
 {
 public:
 
-  typedef GoldenMeanOptimizer1D          Self;
-  typedef Optimizer1D                    Superclass;
-  typedef Self *                         Pointer;
-  typedef const Self *                   ConstPointer;
+  using Self = GoldenMeanOptimizer1D;
+  using Superclass = Optimizer1D;
+  using Pointer = Self *;
+  using ConstPointer = const Self *;
 
-  typedef Superclass::ValueFunctionType  ValueFunctionType;
+  using ValueFunctionType = Superclass::ValueFunctionType;
 
   /** Return the type of this object. */
   tubeTypeMacro( GoldenMeanOptimizer1D );

--- a/src/Numerics/tubeOptimizer1D.h
+++ b/src/Numerics/tubeOptimizer1D.h
@@ -48,13 +48,13 @@ class Optimizer1D : public Object
 {
 public:
 
-  typedef Optimizer1D                     Self;
-  typedef Object                          Superclass;
-  typedef Self *                          Pointer;
-  typedef const Self *                    ConstPointer;
+  using Self = Optimizer1D;
+  using Superclass = Object;
+  using Pointer = Self *;
+  using ConstPointer = const Self *;
 
-  typedef UserFunction< double, double >  ValueFunctionType;
-  typedef UserFunction< double, double >  DerivativeFunctionType;
+  using ValueFunctionType = UserFunction< double, double >;
+  using DerivativeFunctionType = UserFunction< double, double >;
 
   /** Return the type of this object. */
   tubeTypeMacro( Optimizer1D );

--- a/src/Numerics/tubeOptimizerND.cxx
+++ b/src/Numerics/tubeOptimizerND.cxx
@@ -30,13 +30,13 @@ class OptimizerNDValueFunction : public UserFunction< double, double >
 {
 public:
 
-  typedef OptimizerNDValueFunction        Self;
-  typedef UserFunction< double, double >  Superclass;
-  typedef Self *                          Pointer;
-  typedef const Self *                    ConstPointer;
+  using Self = OptimizerNDValueFunction;
+  using Superclass = UserFunction< double, double >;
+  using Pointer = Self *;
+  using ConstPointer = const Self *;
 
-  typedef double                    InputType;
-  typedef double                    OutputType;
+  using InputType = double;
+  using OutputType = double;
 
   tubeTypeMacro( OptimizerNDValueFunction );
 
@@ -66,13 +66,13 @@ class OptimizerNDDerivativeFunction : public UserFunction< double, double >
 {
 public:
 
-  typedef OptimizerNDDerivativeFunction    Self;
-  typedef UserFunction< double, double >   Superclass;
-  typedef Self *                           Pointer;
-  typedef const Self *                     ConstPointer;
+  using Self = OptimizerNDDerivativeFunction;
+  using Superclass = UserFunction< double, double >;
+  using Pointer = Self *;
+  using ConstPointer = const Self *;
 
-  typedef double                           InputType;
-  typedef double                           OutputType;
+  using InputType = double;
+  using OutputType = double;
 
   tubeTypeMacro( OptimizerNDDerivativeFunction );
 

--- a/src/Numerics/tubeOptimizerND.h
+++ b/src/Numerics/tubeOptimizerND.h
@@ -38,18 +38,18 @@ class OptimizerND : public Object
 {
 public:
 
-  typedef OptimizerND                             Self;
-  typedef Object                                  Superclass;
-  typedef Self *                                  Pointer;
-  typedef const Self *                            ConstPointer;
+  using Self = OptimizerND;
+  using Superclass = Object;
+  using Pointer = Self *;
+  using ConstPointer = const Self *;
 
-  typedef vnl_matrix< double >                    MatrixType;
-  typedef vnl_vector< double >                    VectorType;
-  typedef UserFunction< VectorType, double >      ValueFunctionType;
-  typedef UserFunction< VectorType, VectorType >  DerivativeFunctionType;
+  using MatrixType = vnl_matrix< double >;
+  using VectorType = vnl_vector< double >;
+  using ValueFunctionType = UserFunction< VectorType, double >;
+  using DerivativeFunctionType = UserFunction< VectorType, VectorType >;
 
-  typedef UserFunction< double, double >    OptimizerValueFunctionType;
-  typedef UserFunction< double, double >    OptimizerDerivativeFunctionType;
+  using OptimizerValueFunctionType = UserFunction< double, double >;
+  using OptimizerDerivativeFunctionType = UserFunction< double, double >;
 
   /** Return the type of this object. */
   tubeTypeMacro( OptimizerND );

--- a/src/Numerics/tubeParabolicFitOptimizer1D.h
+++ b/src/Numerics/tubeParabolicFitOptimizer1D.h
@@ -39,12 +39,12 @@ class ParabolicFitOptimizer1D : public Optimizer1D
 {
 public:
 
-  typedef ParabolicFitOptimizer1D        Self;
-  typedef Optimizer1D                    Superclass;
-  typedef Self *                         Pointer;
-  typedef const Self *                   ConstPointer;
+  using Self = ParabolicFitOptimizer1D;
+  using Superclass = Optimizer1D;
+  using Pointer = Self *;
+  using ConstPointer = const Self *;
 
-  typedef Superclass::ValueFunctionType  ValueFunctionType;
+  using ValueFunctionType = Superclass::ValueFunctionType;
 
   /** Return the type of this object. */
   tubeTypeMacro( ParabolicFitOptimizer1D );

--- a/src/Numerics/tubeSpline1D.cxx
+++ b/src/Numerics/tubeSpline1D.cxx
@@ -30,13 +30,13 @@ class Spline1DValueFunction : public UserFunction< double, double >
 {
 public:
 
-  typedef Spline1DValueFunction           Self;
-  typedef UserFunction< double, double >  Superclass;
-  typedef Self *                          Pointer;
-  typedef const Self *                    ConstPointer;
+  using Self = Spline1DValueFunction;
+  using Superclass = UserFunction< double, double >;
+  using Pointer = Self *;
+  using ConstPointer = const Self *;
 
-  typedef double                          InputType;
-  typedef double                          OutputType;
+  using InputType = double;
+  using OutputType = double;
 
   tubeTypeMacro( Spline1DValueFunction );
 
@@ -66,13 +66,13 @@ class Spline1DDerivativeFunction : public UserFunction< double, double >
 {
 public:
 
-  typedef Spline1DDerivativeFunction      Self;
-  typedef UserFunction< double, double >  Superclass;
-  typedef Self *                          Pointer;
-  typedef const Self *                    ConstPointer;
+  using Self = Spline1DDerivativeFunction;
+  using Superclass = UserFunction< double, double >;
+  using Pointer = Self *;
+  using ConstPointer = const Self *;
 
-  typedef double                          InputType;
-  typedef double                          OutputType;
+  using InputType = double;
+  using OutputType = double;
 
   tubeTypeMacro( Spline1DDerivativeFunction );
 

--- a/src/Numerics/tubeSpline1D.h
+++ b/src/Numerics/tubeSpline1D.h
@@ -50,15 +50,15 @@ class Spline1D : public Object
 {
 public:
 
-  typedef Spline1D                        Self;
-  typedef Object                          Superclass;
-  typedef Self *                          Pointer;
-  typedef const Self *                    ConstPointer;
+  using Self = Spline1D;
+  using Superclass = Object;
+  using Pointer = Self *;
+  using ConstPointer = const Self *;
 
-  typedef vnl_vector< double >            VectorType;
-  typedef UserFunction< int, double >     ValueFunctionType;
-  typedef UserFunction< double, double >  OptimizerValueFunctionType;
-  typedef UserFunction< double, double >  OptimizerDerivativeFunctionType;
+  using VectorType = vnl_vector< double >;
+  using ValueFunctionType = UserFunction< int, double >;
+  using OptimizerValueFunctionType = UserFunction< double, double >;
+  using OptimizerDerivativeFunctionType = UserFunction< double, double >;
 
   /** Return the type of this object. */
   tubeTypeMacro( Spline1D );

--- a/src/Numerics/tubeSplineApproximation1D.h
+++ b/src/Numerics/tubeSplineApproximation1D.h
@@ -38,14 +38,14 @@ class SplineApproximation1D : public Spline1D
 {
 public:
 
-  typedef SplineApproximation1D             Self;
-  typedef Spline1D                          Superclass;
-  typedef Self *                            Pointer;
-  typedef const Self *                      ConstPointer;
+  using Self = SplineApproximation1D;
+  using Superclass = Spline1D;
+  using Pointer = Self *;
+  using ConstPointer = const Self *;
 
-  typedef vnl_matrix_fixed< double, 4, 4 >  MatrixType;
-  typedef Superclass::VectorType            VectorType;
-  typedef Superclass::ValueFunctionType     ValueFunctionType;
+  using MatrixType = vnl_matrix_fixed< double, 4, 4 >;
+  using VectorType = Superclass::VectorType;
+  using ValueFunctionType = Superclass::ValueFunctionType;
 
   /** Return the type of this object. */
   tubeTypeMacro( SplineApproximation1D );

--- a/src/Numerics/tubeSplineND.cxx
+++ b/src/Numerics/tubeSplineND.cxx
@@ -33,14 +33,14 @@ class SplineNDValueFunction
 {
 public:
 
-  typedef SplineNDValueFunction                         Self;
-  typedef UserFunction< vnl_vector< double >, double >  Superclass;
-  typedef Self *                                        Pointer;
-  typedef const Self *                                  ConstPointer;
+  using Self = SplineNDValueFunction;
+  using Superclass = UserFunction< vnl_vector< double >, double >;
+  using Pointer = Self *;
+  using ConstPointer = const Self *;
 
-  typedef SplineND::VectorType                          VectorType;
-  typedef VectorType                                    InputType;
-  typedef double                                        OutputType;
+  using VectorType = SplineND::VectorType;
+  using InputType = VectorType;
+  using OutputType = double;
 
   tubeTypeMacro( SplineNDValueFunction );
 
@@ -71,15 +71,14 @@ class SplineNDDerivativeFunction
 {
 public:
 
-  typedef SplineNDDerivativeFunction  Self;
-  typedef UserFunction< vnl_vector< double >, vnl_vector< double > >
-                                      Superclass;
-  typedef Self *                      Pointer;
-  typedef const Self *                ConstPointer;
+  using Self = SplineNDDerivativeFunction;
+  using Superclass = UserFunction< vnl_vector< double >, vnl_vector< double > >;
+  using Pointer = Self *;
+  using ConstPointer = const Self *;
 
-  typedef SplineND::VectorType        VectorType;
-  typedef VectorType                  InputType;
-  typedef VectorType                  OutputType;
+  using VectorType = SplineND::VectorType;
+  using InputType = VectorType;
+  using OutputType = VectorType;
 
   tubeTypeMacro( SplineNDDerivativeFunction );
 

--- a/src/Numerics/tubeSplineND.h
+++ b/src/Numerics/tubeSplineND.h
@@ -49,21 +49,19 @@ class SplineND : public Object
 {
 public:
 
-  typedef SplineND                                Self;
-  typedef Object                                  Superclass;
-  typedef Self *                                  Pointer;
-  typedef const Self *                            ConstPointer;
+  using Self = SplineND;
+  using Superclass = Object;
+  using Pointer = Self *;
+  using ConstPointer = const Self *;
 
-  typedef itk::Image< double, 4 >                 ImageType;
-  typedef vnl_vector< int >                       IntVectorType;
-  typedef vnl_matrix< double >                    MatrixType;
-  typedef vnl_vector< double >                    VectorType;
-  typedef UserFunction< IntVectorType, double >   ValueFunctionType;
+  using ImageType = itk::Image< double, 4 >;
+  using IntVectorType = vnl_vector< int >;
+  using MatrixType = vnl_matrix< double >;
+  using VectorType = vnl_vector< double >;
+  using ValueFunctionType = UserFunction< IntVectorType, double >;
 
-  typedef UserFunction< VectorType, double >
-    OptimizerValueFunctionType;
-  typedef UserFunction< VectorType, VectorType >
-    OptimizerDerivativeFunctionType;
+  using OptimizerValueFunctionType = UserFunction< VectorType, double >;
+  using OptimizerDerivativeFunctionType = UserFunction< VectorType, VectorType >;
 
   /** Return the type of this object. */
   tubeTypeMacro( SplineND );
@@ -250,8 +248,7 @@ public:
 
 protected:
 
-  typedef itk::VectorContainer< unsigned int, ImageType::Pointer >
-    VectorImageType;
+  using VectorImageType = itk::VectorContainer< unsigned int, ImageType::Pointer >;
 
   /** Print out information about this object. */
   void PrintSelf( std::ostream & os, Indent indent ) const override;

--- a/src/Numerics/tubeUserFunction.h
+++ b/src/Numerics/tubeUserFunction.h
@@ -35,12 +35,12 @@ class UserFunction
 {
 public:
 
-  typedef UserFunction  Self;
-  typedef Self *        Pointer;
-  typedef const Self *  ConstPointer;
+  using Self = UserFunction;
+  using Pointer = Self *;
+  using ConstPointer = const Self *;
 
-  typedef TInput        InputType;
-  typedef TOutput       OutputType;
+  using InputType = TInput;
+  using OutputType = TOutput;
 
   /** Return the type of this object. */
   tubeTypeMacroNoOverride( UserFunction );

--- a/src/ObjectDocuments/itktubeBlobSpatialObjectDocument.h
+++ b/src/ObjectDocuments/itktubeBlobSpatialObjectDocument.h
@@ -44,12 +44,12 @@ class BlobSpatialObjectDocument : public SpatialObjectDocument
 {
 public:
 
-  typedef BlobSpatialObjectDocument          Self;
-  typedef SpatialObjectDocument              Superclass;
-  typedef SmartPointer< Self >               Pointer;
-  typedef SmartPointer< const Self >         ConstPointer;
+  using Self = BlobSpatialObjectDocument;
+  using Superclass = SpatialObjectDocument;
+  using Pointer = SmartPointer< Self >;
+  using ConstPointer = SmartPointer< const Self >;
 
-  typedef Superclass::TransformNameListType  TransformNameListType;
+  using TransformNameListType = Superclass::TransformNameListType;
 
   itkNewMacro( Self );
   itkTypeMacro( BlobSpatialObjectDocument, SpatialObjectDocument );

--- a/src/ObjectDocuments/itktubeDocument.h
+++ b/src/ObjectDocuments/itktubeDocument.h
@@ -42,10 +42,10 @@ class Document : public DataObject
 {
 public:
 
-  typedef Document                    Self;
-  typedef DataObject                  Superclass;
-  typedef SmartPointer< Self >        Pointer;
-  typedef SmartPointer< const Self >  ConstPointer;
+  using Self = Document;
+  using Superclass = DataObject;
+  using Pointer = SmartPointer< Self >;
+  using ConstPointer = SmartPointer< const Self >;
 
   itkNewMacro( Self );
   itkTypeMacro( Document, DataObject );

--- a/src/ObjectDocuments/itktubeImageDocument.h
+++ b/src/ObjectDocuments/itktubeImageDocument.h
@@ -43,12 +43,12 @@ class ImageDocument : public ObjectDocument
 {
 public:
 
-  typedef ImageDocument                      Self;
-  typedef ObjectDocument                     Superclass;
-  typedef SmartPointer< Self >               Pointer;
-  typedef SmartPointer< const Self >         ConstPointer;
+  using Self = ImageDocument;
+  using Superclass = ObjectDocument;
+  using Pointer = SmartPointer< Self >;
+  using ConstPointer = SmartPointer< const Self >;
 
-  typedef Superclass::TransformNameListType  TransformNameListType;
+  using TransformNameListType = Superclass::TransformNameListType;
 
   itkNewMacro( Self );
   itkTypeMacro( ImageDocument, ObjectDocument );

--- a/src/ObjectDocuments/itktubeObjectDocument.h
+++ b/src/ObjectDocuments/itktubeObjectDocument.h
@@ -41,12 +41,12 @@ class ObjectDocument : public Document
 {
 public:
 
-  typedef ObjectDocument                   Self;
-  typedef Document                         Superclass;
-  typedef SmartPointer< Self >             Pointer;
-  typedef SmartPointer< const Self >       ConstPointer;
+  using Self = ObjectDocument;
+  using Superclass = Document;
+  using Pointer = SmartPointer< Self >;
+  using ConstPointer = SmartPointer< const Self >;
 
-  typedef std::vector< std::string >       TransformNameListType;
+  using TransformNameListType = std::vector< std::string >;
 
   itkNewMacro( Self );
   itkTypeMacro( ObjectDocument, Document );

--- a/src/ObjectDocuments/itktubeObjectDocumentToImageFilter.h
+++ b/src/ObjectDocuments/itktubeObjectDocumentToImageFilter.h
@@ -51,23 +51,22 @@ public:
 
   enum { Dimension = 3 };
 
-  typedef ObjectDocumentToImageFilter                     Self;
-  typedef ObjectDocumentToObjectSource< TObjectDocument,
-    TImageType::ImageDimension >                           Superclass;
-  typedef SmartPointer< Self >                            Pointer;
-  typedef SmartPointer< const Self >                      ConstPointer;
+  using Self = ObjectDocumentToImageFilter;
+  using Superclass = ObjectDocumentToObjectSource< TObjectDocument,
+    TImageType::ImageDimension >;
+  using Pointer = SmartPointer< Self >;
+  using ConstPointer = SmartPointer< const Self >;
 
-  typedef TObjectDocument                      DocumentType;
-  typedef typename DocumentType::ConstPointer  ConstDocumentPointer;
+  using DocumentType = TObjectDocument;
+  using ConstDocumentPointer = typename DocumentType::ConstPointer;
 
-  typedef TImageType                           ImageType;
-  typedef typename ImageType::Pointer          ImagePointer;
+  using ImageType = TImageType;
+  using ImagePointer = typename ImageType::Pointer;
 
-  typedef typename Superclass::TransformType   TransformType;
-  typedef typename TransformType::Pointer      TransformPointer;
+  using TransformType = typename Superclass::TransformType;
+  using TransformPointer = typename TransformType::Pointer;
 
-  typedef InterpolateImageFunction< ImageType, double >
-    InterpolateImageFunctionType;
+  using InterpolateImageFunctionType = InterpolateImageFunction< ImageType, double >;
   typedef typename InterpolateImageFunctionType::Pointer
     InterpolateImageFunctionPointer;
 
@@ -86,10 +85,10 @@ public:
 
 protected:
 
-  typedef ImageFileReader< ImageType >                ImageFileReaderType;
-  typedef ResampleImageFilter< ImageType, ImageType > ResampleImageFilterType;
-  typedef typename ImageType::SizeType                SizeType;
-  typedef typename ImageType::PointType               PointType;
+  using ImageFileReaderType = ImageFileReader< ImageType >;
+  using ResampleImageFilterType = ResampleImageFilter< ImageType, ImageType >;
+  using SizeType = typename ImageType::SizeType;
+  using PointType = typename ImageType::PointType;
 
   /** Constructor. */
   ObjectDocumentToImageFilter( void );

--- a/src/ObjectDocuments/itktubeObjectDocumentToObjectSource.h
+++ b/src/ObjectDocuments/itktubeObjectDocumentToObjectSource.h
@@ -47,19 +47,19 @@ class ObjectDocumentToObjectSource : public ProcessObject
 {
 public:
 
-  typedef ObjectDocumentToObjectSource         Self;
-  typedef ProcessObject                        Superclass;
-  typedef SmartPointer< Self >                 Pointer;
-  typedef SmartPointer< const Self >           ConstPointer;
+  using Self = ObjectDocumentToObjectSource;
+  using Superclass = ProcessObject;
+  using Pointer = SmartPointer< Self >;
+  using ConstPointer = SmartPointer< const Self >;
 
-  typedef typename DataObject::Pointer         DataObjectPointer;
+  using DataObjectPointer = typename DataObject::Pointer;
 
-  typedef TObjectDocument                      DocumentType;
-  typedef typename DocumentType::ConstPointer  ConstDocumentPointer;
+  using DocumentType = TObjectDocument;
+  using ConstDocumentPointer = typename DocumentType::ConstPointer;
 
   typedef typename SpatialObject< VDimension >::TransformType
                                                TransformType;
-  typedef typename TransformType::Pointer      TransformPointer;
+  using TransformPointer = typename TransformType::Pointer;
 
   itkNewMacro( Self );
   itkTypeMacro( ObjectDocumentToObjectSource, ProcessObject );
@@ -109,8 +109,8 @@ public:
 
 protected:
 
-  typedef SpatialObject<>                    OutputType;
-  typedef SpatialObjectReader< VDimension >  TransformReaderType;
+  using OutputType = SpatialObject<>;
+  using TransformReaderType = SpatialObjectReader< VDimension >;
 
   /** Constructor. */
   ObjectDocumentToObjectSource( void );

--- a/src/ObjectDocuments/itktubeObjectDocumentToObjectSource.hxx
+++ b/src/ObjectDocuments/itktubeObjectDocumentToObjectSource.hxx
@@ -153,7 +153,7 @@ ObjectDocumentToObjectSource< TObjectDocument, VDimension >
 ::ComposeTransforms( ConstDocumentPointer document, int startIndex,
                      int endIndex ) const
 {
-  typedef typename DocumentType::TransformNameListType  TransformNameListType;
+  using TransformNameListType = typename DocumentType::TransformNameListType;
 
   TransformNameListType transformNames = document->GetTransformNames();
   typename TransformNameListType::const_iterator iter = transformNames.begin();

--- a/src/ObjectDocuments/itktubeSpatialObjectDocument.h
+++ b/src/ObjectDocuments/itktubeSpatialObjectDocument.h
@@ -44,12 +44,12 @@ class SpatialObjectDocument : public ObjectDocument
 {
 public:
 
-  typedef SpatialObjectDocument              Self;
-  typedef ObjectDocument                     Superclass;
-  typedef SmartPointer< Self >               Pointer;
-  typedef SmartPointer< const Self >         ConstPointer;
+  using Self = SpatialObjectDocument;
+  using Superclass = ObjectDocument;
+  using Pointer = SmartPointer< Self >;
+  using ConstPointer = SmartPointer< const Self >;
 
-  typedef Superclass::TransformNameListType  TransformNameListType;
+  using TransformNameListType = Superclass::TransformNameListType;
 
   itkNewMacro( Self );
   itkTypeMacro( SpatialObjectDocument, ObjectDocument );

--- a/src/ObjectDocuments/tubeMetaDocument.h
+++ b/src/ObjectDocuments/tubeMetaDocument.h
@@ -41,13 +41,13 @@ class MetaDocument : public Object
 {
 public:
 
-  typedef MetaDocument                Self;
-  typedef Object                      Superclass;
-  typedef Self *                      Pointer;
-  typedef const Self *                ConstPointer;
+  using Self = MetaDocument;
+  using Superclass = Object;
+  using Pointer = Self *;
+  using ConstPointer = const Self *;
 
-  typedef MET_FieldRecordType         FieldType;
-  typedef std::vector< FieldType * >  FieldListType;
+  using FieldType = MET_FieldRecordType;
+  using FieldListType = std::vector< FieldType * >;
 
   /** Constructor. */
   MetaDocument( void );

--- a/src/ObjectDocuments/tubeMetaObjectDocument.h
+++ b/src/ObjectDocuments/tubeMetaObjectDocument.h
@@ -38,20 +38,19 @@ class MetaObjectDocument : public MetaDocument
 {
 public:
 
-  typedef MetaObjectDocument Self;
-  typedef MetaDocument       Superclass;
-  typedef Self *             Pointer;
-  typedef const Self *       ConstPointer;
+  using Self = MetaObjectDocument;
+  using Superclass = MetaDocument;
+  using Pointer = Self *;
+  using ConstPointer = const Self *;
 
-  typedef Superclass::FieldType                FieldType;
-  typedef Superclass::FieldListType            FieldListType;
+  using FieldType = Superclass::FieldType;
+  using FieldListType = Superclass::FieldListType;
 
-  typedef itk::tube::BlobSpatialObjectDocument BlobSpatialObjectDocumentType;
-  typedef itk::tube::ImageDocument             ImageDocumentType;
-  typedef itk::tube::ObjectDocument            ObjectDocumentType;
-  typedef itk::tube::SpatialObjectDocument     SpatialObjectDocumentType;
-  typedef std::vector< ObjectDocumentType::Pointer >
-                                               ObjectDocumentListType;
+  using BlobSpatialObjectDocumentType = itk::tube::BlobSpatialObjectDocument;
+  using ImageDocumentType = itk::tube::ImageDocument;
+  using ObjectDocumentType = itk::tube::ObjectDocument;
+  using SpatialObjectDocumentType = itk::tube::SpatialObjectDocument;
+  using ObjectDocumentListType = std::vector< ObjectDocumentType::Pointer >;
 
   /** Constructor. */
   MetaObjectDocument( void );

--- a/src/ObjectDocuments/tubeOptionList.cxx
+++ b/src/ObjectDocuments/tubeOptionList.cxx
@@ -94,7 +94,7 @@ OptionList
 {
   values.clear();
 
-  typedef OptionMapType::const_iterator OptionIterator;
+  using OptionIterator = OptionMapType::const_iterator;
 
   std::pair< OptionIterator, OptionIterator > bound
     = m_OptionMap.equal_range( tag );
@@ -114,7 +114,7 @@ int
 OptionList
 ::DumpOptions( const std::string & tag, bool withTag, bool withNewLine ) const
 {
-  typedef OptionMapType::const_iterator OptionIterator;
+  using OptionIterator = OptionMapType::const_iterator;
 
   std::pair< OptionIterator, OptionIterator > bound
     = m_OptionMap.equal_range( tag );

--- a/src/ObjectDocuments/tubeOptionList.h
+++ b/src/ObjectDocuments/tubeOptionList.h
@@ -60,12 +60,12 @@ class OptionList : public Object
 {
 public:
 
-  typedef OptionList                                 Self;
-  typedef Object                                     Superclass;
-  typedef Self *                                     Pointer;
-  typedef const Self *                               ConstPointer;
+  using Self = OptionList;
+  using Superclass = Object;
+  using Pointer = Self *;
+  using ConstPointer = const Self *;
 
-  typedef std::multimap< std::string, std::string >  OptionMapType;
+  using OptionMapType = std::multimap< std::string, std::string >;
 
   /** Encodes a required option that is missing.  */
   class RequiredOptionMissing

--- a/src/Registration/Deprecated/itktubeSpatialObjectRegionMomentsCalculator.h
+++ b/src/Registration/Deprecated/itktubeSpatialObjectRegionMomentsCalculator.h
@@ -59,11 +59,11 @@ template <unsigned int ObjectDimension>
 class SpatialObjectMomentsCalculator : public Object
 {
 public:
-  /** Standard class typedefs. */
-  typedef SpatialObjectMomentsCalculator<TImage> Self;
-  typedef Object                               Superclass;
-  typedef SmartPointer<Self>                   Pointer;
-  typedef SmartPointer<const Self>             ConstPointer;
+  /** Standard class type alias. */
+  using Self = SpatialObjectMomentsCalculator<TImage>;
+  using Superclass = Object;
+  using Pointer = SmartPointer<Self>;
+  using ConstPointer = SmartPointer<const Self>;
 
   /** Method for creation through the object factory. */
   itkNewMacro( Self );
@@ -72,26 +72,26 @@ public:
   itkTypeMacro( SpatialObjectMomentsCalculator, Object );
 
   /** Standard scalar type within this class. */
-  typedef double ScalarType;
+  using ScalarType = double;
 
-  typedef typename TImage::PointType PointType;
+  using PointType = typename TImage::PointType;
 
   /** Standard vector type within this class. */
-  typedef Vector<ScalarType, ObjectDimension> VectorType;
+  using VectorType = Vector<ScalarType, ObjectDimension>;
 
   /** Spatial Object type within this class. */
-  typedef SpatialObject<ObjectDimension> SpatialObjectType;
+  using SpatialObjectType = SpatialObject<ObjectDimension>;
 
   /** Spatial Object member types used within this class. */
-  typedef typename SpatialObjectType::Pointer      SpatialObjectPointer;
-  typedef typename SpatialObjectType::ConstPointer SpatialObjectConstPointer;
+  using SpatialObjectPointer = typename SpatialObjectType::Pointer;
+  using SpatialObjectConstPointer = typename SpatialObjectType::ConstPointer;
 
   /** Standard matrix type within this class. */
-  typedef Matrix<ScalarType, ObjectDimension, ObjectDimension>      MatrixType;
+  using MatrixType = Matrix<ScalarType, ObjectDimension, ObjectDimension>;
 
   /** Affine transform for mapping to and from principal axis */
-  typedef AffineTransform<double, ObjectDimension> AffineTransformType;
-  typedef typename AffineTransformType::Pointer    AffineTransformPointer;
+  using AffineTransformType = AffineTransform<double, ObjectDimension>;
+  using AffineTransformPointer = typename AffineTransformType::Pointer;
 
   /** Set the spatial object. */
   virtual void SetSpatialObject( const SpatialObject<ObjectDimension> * so )

--- a/src/Registration/Deprecated/itktubeSpatialObjectRegionMomentsCalculator.hxx
+++ b/src/Registration/Deprecated/itktubeSpatialObjectRegionMomentsCalculator.hxx
@@ -116,7 +116,7 @@ SpatialObjectRegionMomentsCalculator<ObjectDimension>::Compute()
   m_Cg.Fill(NumericTraits<typename VectorType::ValueType>::Zero);
   m_Cm.Fill(NumericTraits<typename MatrixType::ValueType>::Zero);
 
-  typedef typename ImageType::IndexType IndexType;
+  using IndexType = typename ImageType::IndexType;
 
   if( !m_Image )
     {

--- a/src/Registration/itkAffineImageToImageRegistrationMethod.h
+++ b/src/Registration/itkAffineImageToImageRegistrationMethod.h
@@ -38,10 +38,10 @@ class AffineImageToImageRegistrationMethod
 
 public:
 
-  typedef AffineImageToImageRegistrationMethod            Self;
-  typedef OptimizedImageToImageRegistrationMethod<TImage> Superclass;
-  typedef SmartPointer<Self>                              Pointer;
-  typedef SmartPointer<const Self>                        ConstPointer;
+  using Self = AffineImageToImageRegistrationMethod;
+  using Superclass = OptimizedImageToImageRegistrationMethod<TImage>;
+  using Pointer = SmartPointer<Self>;
+  using ConstPointer = SmartPointer<const Self>;
 
   itkTypeMacro( AffineImageToImageRegistrationMethod,
                 OptimizedImageToImageRegistrationMethod );
@@ -56,10 +56,9 @@ public:
   //
 
   // Overrides the superclass' TransformType typedef
-  typedef AffineTransform<double, itkGetStaticConstMacro( ImageDimension )>
-                                                AffineTransformType;
-  typedef typename AffineTransformType::Pointer AffineTransformPointer;
-  typedef AffineTransformType                   TransformType;
+  using AffineTransformType = AffineTransform<double, itkGetStaticConstMacro( ImageDimension )>;
+  using AffineTransformPointer = typename AffineTransformType::Pointer;
+  using TransformType = AffineTransformType;
 
   //
   // Superclass Methods

--- a/src/Registration/itkAnisotropicSimilarity3DTransform.h
+++ b/src/Registration/itkAnisotropicSimilarity3DTransform.h
@@ -58,11 +58,11 @@ class AnisotropicSimilarity3DTransform :
   public VersorRigid3DTransform<TScalarType>
 {
 public:
-  /** Standard class typedefs. */
-  typedef AnisotropicSimilarity3DTransform    Self;
-  typedef VersorRigid3DTransform<TScalarType> Superclass;
-  typedef SmartPointer<Self>                  Pointer;
-  typedef SmartPointer<const Self>            ConstPointer;
+  /** Standard class type alias. */
+  using Self = AnisotropicSimilarity3DTransform;
+  using Superclass = VersorRigid3DTransform<TScalarType>;
+  using Pointer = SmartPointer<Self>;
+  using ConstPointer = SmartPointer<const Self>;
 
   /** New macro for creation of through a Smart Pointer. */
   itkNewMacro( Self );
@@ -77,32 +77,32 @@ public:
   itkStaticConstMacro( ParametersDimension, unsigned int, 9 );
 
   /** Parameters Type   */
-  typedef typename Superclass::ParametersType      ParametersType;
-  typedef typename Superclass::JacobianType        JacobianType;
-  typedef typename Superclass::ScalarType          ScalarType;
-  typedef typename Superclass::InputPointType      InputPointType;
-  typedef typename Superclass::OutputPointType     OutputPointType;
-  typedef typename Superclass::InputVectorType     InputVectorType;
-  typedef typename Superclass::OutputVectorType    OutputVectorType;
-  typedef typename Superclass::InputVnlVectorType  InputVnlVectorType;
-  typedef typename Superclass::OutputVnlVectorType OutputVnlVectorType;
+  using ParametersType = typename Superclass::ParametersType;
+  using JacobianType = typename Superclass::JacobianType;
+  using ScalarType = typename Superclass::ScalarType;
+  using InputPointType = typename Superclass::InputPointType;
+  using OutputPointType = typename Superclass::OutputPointType;
+  using InputVectorType = typename Superclass::InputVectorType;
+  using OutputVectorType = typename Superclass::OutputVectorType;
+  using InputVnlVectorType = typename Superclass::InputVnlVectorType;
+  using OutputVnlVectorType = typename Superclass::OutputVnlVectorType;
 
   typedef typename Superclass::InputCovariantVectorType
                                                  InputCovariantVectorType;
   typedef typename Superclass::OutputCovariantVectorType
                                                  OutputCovariantVectorType;
-  typedef typename Superclass::MatrixType        MatrixType;
-  typedef typename Superclass::InverseMatrixType InverseMatrixType;
-  typedef typename Superclass::CenterType        CenterType;
-  typedef typename Superclass::OffsetType        OffsetType;
-  typedef typename Superclass::TranslationType   TranslationType;
+  using MatrixType = typename Superclass::MatrixType;
+  using InverseMatrixType = typename Superclass::InverseMatrixType;
+  using CenterType = typename Superclass::CenterType;
+  using OffsetType = typename Superclass::OffsetType;
+  using TranslationType = typename Superclass::TranslationType;
 
   /** Versor type. */
-  typedef typename Superclass::VersorType      VersorType;
-  typedef typename Superclass::AxisType        AxisType;
-  typedef typename Superclass::AngleType       AngleType;
-  typedef typename Superclass::InputVectorType VectorType;
-  typedef          TScalarType                 ScaleType;
+  using VersorType = typename Superclass::VersorType;
+  using AxisType = typename Superclass::AxisType;
+  using AngleType = typename Superclass::AngleType;
+  using VectorType = typename Superclass::InputVectorType;
+  using ScaleType = TScalarType;
 
   /** Directly set the rotation matrix of the transform.
    * \warning The input matrix must be orthogonal with isotropic scaling

--- a/src/Registration/itkAnisotropicSimilarity3DTransform.hxx
+++ b/src/Registration/itkAnisotropicSimilarity3DTransform.hxx
@@ -135,7 +135,7 @@ AnisotropicSimilarity3DTransform<TScalarType>
       );
     }
 
-  typedef MatrixOffsetTransformBase<TScalarType, 3> Baseclass;
+  using Baseclass = MatrixOffsetTransformBase<TScalarType, 3>;
   this->Baseclass::SetMatrix( matrix );
 }
 
@@ -245,7 +245,7 @@ AnisotropicSimilarity3DTransform<TScalarType>
 ::ComputeJacobianWithRespectToParameters(const InputPointType & p,
   JacobianType & jacobian) const
 {
-  typedef typename VersorType::ValueType ValueType;
+  using ValueType = typename VersorType::ValueType;
 
   // compute derivatives with respect to rotation
   const ValueType vx = this->GetVersor().GetX();

--- a/src/Registration/itkAnisotropicSimilarityLandmarkBasedTransformInitializer.h
+++ b/src/Registration/itkAnisotropicSimilarityLandmarkBasedTransformInitializer.h
@@ -66,11 +66,11 @@ class AnisotropicSimilarityLandmarkBasedTransformInitializer :
   public Object
 {
 public:
-  /** Standard class typedefs. */
-  typedef AnisotropicSimilarityLandmarkBasedTransformInitializer Self;
-  typedef Object                                                 Superclass;
-  typedef SmartPointer<Self>                                     Pointer;
-  typedef SmartPointer<const Self>                               ConstPointer;
+  /** Standard class type alias. */
+  using Self = AnisotropicSimilarityLandmarkBasedTransformInitializer;
+  using Superclass = Object;
+  using Pointer = SmartPointer<Self>;
+  using ConstPointer = SmartPointer<const Self>;
 
   /** New macro for creation of through a Smart Pointer. */
   itkNewMacro( Self );
@@ -80,8 +80,8 @@ public:
     Object );
 
   /** Type of the transform to initialize */
-  typedef TTransform                      TransformType;
-  typedef typename TransformType::Pointer TransformPointer;
+  using TransformType = TTransform;
+  using TransformPointer = typename TransformType::Pointer;
 
   /** Dimension of parameters. */
   itkStaticConstMacro( InputSpaceDimension, unsigned int,
@@ -93,11 +93,11 @@ public:
   itkSetObjectMacro( Transform, TransformType );
 
   /** Image Types to use in the initialization of the transform */
-  typedef   TFixedImage  FixedImageType;
-  typedef   TMovingImage MovingImageType;
+  using FixedImageType = TFixedImage;
+  using MovingImageType = TMovingImage;
 
-  typedef   typename FixedImageType::ConstPointer  FixedImagePointer;
-  typedef   typename MovingImageType::ConstPointer MovingImagePointer;
+  using FixedImagePointer = typename FixedImageType::ConstPointer;
+  using MovingImagePointer = typename MovingImageType::ConstPointer;
 
   /** \deprecated
    * Set the fixed image.
@@ -127,15 +127,13 @@ public:
   itkStaticConstMacro( ImageDimension, unsigned int,
     FixedImageType::ImageDimension );
 
-  /** Convenience typedefs */
+  /** Convenience type alias */
   typedef typename TransformType::InputPointType
     InputPointType;
   typedef typename TransformType::OutputVectorType
     OutputVectorType;
-  typedef Point<double, itkGetStaticConstMacro( ImageDimension )>
-    LandmarkPointType;
-  typedef std::vector<LandmarkPointType>
-    LandmarkPointContainer;
+  using LandmarkPointType = Point<double, itkGetStaticConstMacro( ImageDimension )>;
+  using LandmarkPointContainer = std::vector<LandmarkPointType>;
   typedef typename  LandmarkPointContainer::const_iterator
     PointsContainerConstIterator;
   typedef typename TransformType::ParametersType
@@ -155,11 +153,10 @@ public:
     this->m_MovingLandmarks = movingLandmarks;
     }
 
-  /**  Supported Transform typedefs */
-  typedef AnisotropicSimilarity3DTransform<ParameterValueType>
-  AnisotropicSimilarity3DTransformType;
-  typedef VersorRigid3DTransform<ParameterValueType> VersorRigid3DTransformType;
-  typedef Rigid2DTransform<ParameterValueType> Rigid2DTransformType;
+  /**  Supported Transform type alias */
+  using AnisotropicSimilarity3DTransformType = AnisotropicSimilarity3DTransform<ParameterValueType>;
+  using VersorRigid3DTransformType = VersorRigid3DTransform<ParameterValueType>;
+  using Rigid2DTransformType = Rigid2DTransform<ParameterValueType>;
 
   /** Initialize the transform from the landmarks */
   virtual void InitializeTransform();

--- a/src/Registration/itkAnisotropicSimilarityLandmarkBasedTransformInitializer.hxx
+++ b/src/Registration/itkAnisotropicSimilarityLandmarkBasedTransformInitializer.hxx
@@ -286,10 +286,10 @@ AnisotropicSimilarityLandmarkBasedTransformInitializer<
           vnl_matrix< double > eigenVectors( 4, 4 );
           vnl_vector< double > eigenValues( 4 );
 
-          typedef itk::SymmetricEigenAnalysis<
+          using SymmetricEigenAnalysisType = itk::SymmetricEigenAnalysis<
             itk::Matrix< double, 4, 4 >,
             vnl_vector< double >,
-            vnl_matrix< double > > SymmetricEigenAnalysisType;
+            vnl_matrix< double > >;
           SymmetricEigenAnalysisType symmetricEigenSystem( 4 );
 
           symmetricEigenSystem.ComputeEigenValuesAndVectors( N,
@@ -645,10 +645,10 @@ AnisotropicSimilarityLandmarkBasedTransformInitializer<
         vnl_matrix< double > eigenVectors( 4, 4 );
         vnl_vector< double > eigenValues( 4 );
 
-        typedef itk::SymmetricEigenAnalysis<
+        using SymmetricEigenAnalysisType = itk::SymmetricEigenAnalysis<
           itk::Matrix< double, 4, 4 >,
           vnl_vector< double >,
-          vnl_matrix< double > > SymmetricEigenAnalysisType;
+          vnl_matrix< double > >;
         SymmetricEigenAnalysisType symmetricEigenSystem( 4 );
 
         symmetricEigenSystem.ComputeEigenValuesAndVectors( N,
@@ -710,8 +710,8 @@ AnisotropicSimilarityLandmarkBasedTransformInitializer<
       Rigid2DTransformType *transform = dynamic_cast<
         Rigid2DTransformType * >( this->m_Transform.GetPointer() );
 
-      typedef typename Rigid2DTransformType::OutputVectorType VectorType;
-      typedef typename Rigid2DTransformType::OutputPointType  PointType;
+      using VectorType = typename Rigid2DTransformType::OutputVectorType;
+      using PointType = typename Rigid2DTransformType::OutputPointType;
 
       // Initialize the transform to identity
       transform->SetIdentity();

--- a/src/Registration/itkBSplineImageToImageRegistrationMethod.h
+++ b/src/Registration/itkBSplineImageToImageRegistrationMethod.h
@@ -38,10 +38,10 @@ class BSplineImageToImageRegistrationMethod
 
 public:
 
-  typedef BSplineImageToImageRegistrationMethod           Self;
-  typedef OptimizedImageToImageRegistrationMethod<TImage> Superclass;
-  typedef SmartPointer<Self>                              Pointer;
-  typedef SmartPointer<const Self>                        ConstPointer;
+  using Self = BSplineImageToImageRegistrationMethod;
+  using Superclass = OptimizedImageToImageRegistrationMethod<TImage>;
+  using Pointer = SmartPointer<Self>;
+  using ConstPointer = SmartPointer<const Self>;
 
   itkTypeMacro( BSplineImageToImageRegistrationMethod,
                 OptimizedImageToImageRegistrationMethod );
@@ -51,18 +51,17 @@ public:
   //
   // Typedefs from Superclass
   //
-  typedef TImage ImageType;
+  using ImageType = TImage;
   itkStaticConstMacro( ImageDimension, unsigned int, TImage::ImageDimension );
 
   // Overrides the superclass' TransformType typedef
-  typedef BSplineTransform<double, itkGetStaticConstMacro( ImageDimension ), 3>
-      BSplineTransformType;
+  using BSplineTransformType = BSplineTransform<double, itkGetStaticConstMacro( ImageDimension ), 3>;
 
-  typedef typename BSplineTransformType::Pointer BSplineTransformPointer;
+  using BSplineTransformPointer = typename BSplineTransformType::Pointer;
 
-  typedef BSplineTransformType TransformType;
+  using TransformType = BSplineTransformType;
 
-  typedef typename BSplineTransformType::ParametersType ParametersType;
+  using ParametersType = typename BSplineTransformType::ParametersType;
 
   //
   // Methods from Superclass
@@ -111,8 +110,8 @@ protected:
   BSplineImageToImageRegistrationMethod( void );
   virtual ~BSplineImageToImageRegistrationMethod( void );
 
-  typedef InterpolateImageFunction<TImage, double> InterpolatorType;
-  typedef ImageToImageMetric<TImage, TImage>       MetricType;
+  using InterpolatorType = InterpolateImageFunction<TImage, double>;
+  using MetricType = ImageToImageMetric<TImage, TImage>;
 
   virtual void Optimize( MetricType * metric, InterpolatorType * interpolator )
     override;

--- a/src/Registration/itkBSplineImageToImageRegistrationMethod.hxx
+++ b/src/Registration/itkBSplineImageToImageRegistrationMethod.hxx
@@ -45,15 +45,15 @@ class BSplineImageRegistrationViewer
   : public Command
 {
 public:
-  typedef BSplineImageRegistrationViewer Self;
-  typedef Command                        Superclass;
-  typedef SmartPointer<Self>             Pointer;
+  using Self = BSplineImageRegistrationViewer;
+  using Superclass = Command;
+  using Pointer = SmartPointer<Self>;
 
   itkTypeMacro( BSplineImageRegistrationViewer, Command );
 
   itkNewMacro( BSplineImageRegistrationViewer );
 
-  typedef SingleValuedNonLinearOptimizer OptimizerType;
+  using OptimizerType = SingleValuedNonLinearOptimizer;
 
   itkSetMacro(DontShowParameters, bool);
   itkSetMacro(UpdateInterval, int);
@@ -232,7 +232,7 @@ BSplineImageToImageRegistrationMethod<TImage>
     }
 
   /* Setup FRPR - set params specific to this optimizer
-  typedef FRPROptimizer GradOptimizerType;
+  using GradOptimizerType = FRPROptimizer;
   GradOptimizerType::Pointer gradOpt;
   gradOpt = GradOptimizerType::New();
   gradOpt->SetMaximize( false );
@@ -247,7 +247,7 @@ BSplineImageToImageRegistrationMethod<TImage>
   gradOpt->SetToFletchReeves();*/
 
   /* GradientDescent */
-  typedef GradientDescentOptimizer         GradOptimizerType;
+  using GradOptimizerType = GradientDescentOptimizer;
   GradOptimizerType::Pointer gradOpt;
   gradOpt = GradOptimizerType::New();
   gradOpt->SetLearningRate( 0.25 );
@@ -257,7 +257,7 @@ BSplineImageToImageRegistrationMethod<TImage>
   /* LBFGSB */
   /*
   int numberOfParameters = this->GetTransform()->GetNumberOfParameters();
-  typedef LBFGSBOptimizer                  GradOptimizerType;
+  using GradOptimizerType = LBFGSBOptimizer;
   GradOptimizerType::Pointer gradOpt;
   gradOpt = GradOptimizerType::New();
   GradOptimizerType::Pointer tmpOpt = static_cast<GradOptimizerType *>(
@@ -284,7 +284,7 @@ BSplineImageToImageRegistrationMethod<TImage>
   /**/
   //if( this->GetReportProgress() )
     {
-    typedef BSplineImageRegistrationViewer ViewerCommandType;
+    using ViewerCommandType = BSplineImageRegistrationViewer;
     typename ViewerCommandType::Pointer command = ViewerCommandType::New();
     if( this->GetTransform()->GetNumberOfParameters() > 16 )
       {
@@ -302,7 +302,7 @@ BSplineImageToImageRegistrationMethod<TImage>
   /* Setup a standard itk::ImageToImageRegistration method
    *  and plug-in optimizer, interpolator, etc. */
   /**/
-  typedef ImageRegistrationMethod<TImage, TImage> ImageRegistrationType;
+  using ImageRegistrationType = ImageRegistrationMethod<TImage, TImage>;
   typename ImageRegistrationType::Pointer reg =
     ImageRegistrationType::New();
   typename ImageType::ConstPointer fixedImage = this->GetFixedImage();
@@ -435,9 +435,8 @@ BSplineImageToImageRegistrationMethod<TImage>
     std::cout << "BSpline MULTIRESOLUTION START" << std::endl;
     }
 
-  typedef RecursiveMultiResolutionPyramidImageFilter<ImageType,
-                                                     ImageType>
-  PyramidType;
+  using PyramidType = RecursiveMultiResolutionPyramidImageFilter<ImageType,
+                                                     ImageType>;
   typename PyramidType::Pointer fixedPyramid = PyramidType::New();
   typename PyramidType::Pointer movingPyramid = PyramidType::New();
 
@@ -558,7 +557,7 @@ BSplineImageToImageRegistrationMethod<TImage>
       movingPyramid->GetOutput(level);
 
     /*
-    typedef itk::ImageFileWriter< ImageType > FileWriterType;
+    using FileWriterType = itk::ImageFileWriter< ImageType >;
     typename FileWriterType::Pointer writer = FileWriterType::New();
     std::stringstream ss;
     std::string name;
@@ -610,8 +609,7 @@ BSplineImageToImageRegistrationMethod<TImage>
      * will perform gradient optimization (instead of pyramid
      * optimization). */
     /**/
-    typedef BSplineImageToImageRegistrationMethod<ImageType>
-      BSplineRegType;
+    using BSplineRegType = BSplineImageToImageRegistrationMethod<ImageType>;
     typename BSplineRegType::Pointer reg = BSplineRegType::New();
     reg->SetReportProgress( this->GetReportProgress() );
     reg->SetFixedImage( fixedImage );
@@ -792,12 +790,9 @@ BSplineImageToImageRegistrationMethod<TImage>
 
   typedef typename BSplineTransformType::ImageType
     ParametersImageType;
-  typedef ResampleImageFilter<ParametersImageType, ParametersImageType>
-    ResamplerType;
-  typedef BSplineResampleImageFunction<ParametersImageType, double>
-    ResamplerFunctionType;
-  typedef IdentityTransform<double, ImageDimension>
-    IdentityTransformType;
+  using ResamplerType = ResampleImageFilter<ParametersImageType, ParametersImageType>;
+  using ResamplerFunctionType = BSplineResampleImageFunction<ParametersImageType, double>;
+  using IdentityTransformType = IdentityTransform<double, ImageDimension>;
   for( unsigned int k = 0; k < ImageDimension; k++ )
     {
     typename ResamplerType::Pointer upsampler = ResamplerType::New();
@@ -812,7 +807,7 @@ BSplineImageToImageRegistrationMethod<TImage>
     /*
     if( this->GetReportProgress() )
       {
-      /typedef itk::ImageFileWriter<ParametersImageType> WriterType;
+      /using WriterType = itk::ImageFileWriter<ParametersImageType>;
       typename WriterType::Pointer writer = WriterType::New();
       std::stringstream ss;
       std::string name;
@@ -858,9 +853,8 @@ BSplineImageToImageRegistrationMethod<TImage>
       std::cout << "Uncaught exception in upsampler" << std::endl;
       }
 
-    typedef BSplineDecompositionImageFilter<ParametersImageType,
-                                            ParametersImageType>
-    DecompositionType;
+    using DecompositionType = BSplineDecompositionImageFilter<ParametersImageType,
+                                            ParametersImageType>;
     typename DecompositionType::Pointer decomposition =
       DecompositionType::New();
 
@@ -885,7 +879,7 @@ BSplineImageToImageRegistrationMethod<TImage>
     /*
     if( this->GetReportProgress() )
       {
-      /typedef itk::ImageFileWriter<ParametersImageType> WriterType;
+      /using WriterType = itk::ImageFileWriter<ParametersImageType>;
       typename WriterType::Pointer writer = WriterType::New();
       std::stringstream ss;
       std::string name;
@@ -907,7 +901,7 @@ BSplineImageToImageRegistrationMethod<TImage>
 
     std::cout << "Copying new coefficients for dim " << k << std::endl;
     // copy the coefficients into the parameter array
-    typedef ImageRegionIterator<ParametersImageType> Iterator;
+    using Iterator = ImageRegionIterator<ParametersImageType>;
     Iterator it( newCoefficients,
                  newCoefficients->GetLargestPossibleRegion() );
     while( !it.IsAtEnd() )

--- a/src/Registration/itkImageRegionMomentsCalculator.h
+++ b/src/Registration/itkImageRegionMomentsCalculator.h
@@ -67,11 +67,11 @@ template <class TImage>
 class ImageRegionMomentsCalculator : public Object
 {
 public:
-  /** Standard class typedefs. */
-  typedef ImageRegionMomentsCalculator<TImage> Self;
-  typedef Object                               Superclass;
-  typedef SmartPointer<Self>                   Pointer;
-  typedef SmartPointer<const Self>             ConstPointer;
+  /** Standard class type alias. */
+  using Self = ImageRegionMomentsCalculator<TImage>;
+  using Superclass = Object;
+  using Pointer = SmartPointer<Self>;
+  using ConstPointer = SmartPointer<const Self>;
 
   /** Method for creation through the object factory. */
   itkNewMacro( Self );
@@ -84,36 +84,33 @@ public:
                       TImage::ImageDimension );
 
   /** Standard scalar type within this class. */
-  typedef double ScalarType;
+  using ScalarType = double;
 
-  typedef typename TImage::PointType PointType;
+  using PointType = typename TImage::PointType;
 
   /** Standard vector type within this class. */
-  typedef Vector<ScalarType, itkGetStaticConstMacro( ImageDimension )>
-    VectorType;
+  using VectorType = Vector<ScalarType, itkGetStaticConstMacro( ImageDimension )>;
 
   /** Spatial Object type within this class. */
-  typedef SpatialObject<itkGetStaticConstMacro( ImageDimension )>
-    SpatialObjectType;
+  using SpatialObjectType = SpatialObject<itkGetStaticConstMacro( ImageDimension )>;
 
   /** Spatial Object member types used within this class. */
-  typedef typename SpatialObjectType::Pointer      SpatialObjectPointer;
-  typedef typename SpatialObjectType::ConstPointer SpatialObjectConstPointer;
+  using SpatialObjectPointer = typename SpatialObjectType::Pointer;
+  using SpatialObjectConstPointer = typename SpatialObjectType::ConstPointer;
 
   /** Standard matrix type within this class. */
-  typedef Matrix<ScalarType, itkGetStaticConstMacro( ImageDimension ),
-    itkGetStaticConstMacro( ImageDimension )>      MatrixType;
+  using MatrixType = Matrix<ScalarType, itkGetStaticConstMacro( ImageDimension ),
+    itkGetStaticConstMacro( ImageDimension )>;
 
   /** Standard image type within this class. */
-  typedef TImage ImageType;
+  using ImageType = TImage;
 
   /** Standard image type pointer within this class. */
-  typedef typename ImageType::Pointer      ImagePointer;
-  typedef typename ImageType::ConstPointer ImageConstPointer;
+  using ImagePointer = typename ImageType::Pointer;
+  using ImageConstPointer = typename ImageType::ConstPointer;
 
   /** Affine transform for mapping to and from principal axis */
-  typedef AffineTransform<double, itkGetStaticConstMacro( ImageDimension )>
-    AffineTransformType;
+  using AffineTransformType = AffineTransform<double, itkGetStaticConstMacro( ImageDimension )>;
   typedef typename AffineTransformType::Pointer
     AffineTransformPointer;
 

--- a/src/Registration/itkImageRegionMomentsCalculator.hxx
+++ b/src/Registration/itkImageRegionMomentsCalculator.hxx
@@ -112,7 +112,7 @@ ImageRegionMomentsCalculator<TImage>::Compute()
   m_Cg.Fill(NumericTraits<typename VectorType::ValueType>::Zero);
   m_Cm.Fill(NumericTraits<typename MatrixType::ValueType>::Zero);
 
-  typedef typename ImageType::IndexType IndexType;
+  using IndexType = typename ImageType::IndexType;
 
   if( !m_Image )
     {

--- a/src/Registration/itkImageToImageRegistrationHelper.h
+++ b/src/Registration/itkImageToImageRegistrationHelper.h
@@ -44,10 +44,10 @@ class ImageToImageRegistrationHelper : public Object
 
 public:
 
-  typedef ImageToImageRegistrationHelper Self;
-  typedef Object                         Superclass;
-  typedef SmartPointer<Self>             Pointer;
-  typedef SmartPointer<const Self>       ConstPointer;
+  using Self = ImageToImageRegistrationHelper;
+  using Superclass = Object;
+  using Pointer = SmartPointer<Self>;
+  using ConstPointer = SmartPointer<const Self>;
 
   itkTypeMacro( ImageToImageRegistrationHelper, Object );
 
@@ -56,9 +56,9 @@ public:
   //
   // Custom Typedefs
   //
-  typedef TImage ImageType;
+  using ImageType = TImage;
 
-  typedef typename TImage::PixelType PixelType;
+  using PixelType = typename TImage::PixelType;
 
   itkStaticConstMacro( ImageDimension, unsigned int,
                        TImage::ImageDimension );
@@ -66,29 +66,21 @@ public:
   //
   // Available Registration Methods
   //
-  typedef ImageToImageRegistrationMethod<TImage>
-  RegistrationMethodType;
+  using RegistrationMethodType = ImageToImageRegistrationMethod<TImage>;
 
-  typedef InitialImageToImageRegistrationMethod<TImage>
-  InitialRegistrationMethodType;
+  using InitialRegistrationMethodType = InitialImageToImageRegistrationMethod<TImage>;
 
-  typedef OptimizedImageToImageRegistrationMethod<TImage>
-  OptimizedRegistrationMethodType;
+  using OptimizedRegistrationMethodType = OptimizedImageToImageRegistrationMethod<TImage>;
 
-  typedef RigidImageToImageRegistrationMethod<TImage>
-  RigidRegistrationMethodType;
+  using RigidRegistrationMethodType = RigidImageToImageRegistrationMethod<TImage>;
 
-  typedef AffineImageToImageRegistrationMethod<TImage>
-  AffineRegistrationMethodType;
+  using AffineRegistrationMethodType = AffineImageToImageRegistrationMethod<TImage>;
 
-  typedef ScaleSkewAngle2DImageToImageRegistrationMethod<TImage>
-  Affine2DRegistrationMethodType;
+  using Affine2DRegistrationMethodType = ScaleSkewAngle2DImageToImageRegistrationMethod<TImage>;
 
-  typedef ScaleSkewVersor3DImageToImageRegistrationMethod<TImage>
-  Affine3DRegistrationMethodType;
+  using Affine3DRegistrationMethodType = ScaleSkewVersor3DImageToImageRegistrationMethod<TImage>;
 
-  typedef BSplineImageToImageRegistrationMethod<TImage>
-  BSplineRegistrationMethodType;
+  using BSplineRegistrationMethodType = BSplineImageToImageRegistrationMethod<TImage>;
 
   //
   // Typedefs for the parameters of the registration methods
@@ -129,9 +121,9 @@ public:
   typedef typename InitialRegistrationMethodType::TransformType
   InitialTransformType;
 
-  typedef std::vector<std::vector<float>  > LandmarkVectorType;
+  using LandmarkVectorType = std::vector<std::vector<float>  >;
 
-  typedef typename TImage::PointType PointType;
+  using PointType = typename TImage::PointType;
 
   typedef typename RigidRegistrationMethodType::TransformType
   RigidTransformType;
@@ -145,7 +137,7 @@ public:
   typedef typename Affine3DRegistrationMethodType::TransformType
   Affine3DTransformType;
 
-  typedef AffineTransformType MatrixTransformType;
+  using MatrixTransformType = AffineTransformType;
 
   typedef typename BSplineRegistrationMethodType::TransformType
   BSplineTransformType;

--- a/src/Registration/itkImageToImageRegistrationHelper.hxx
+++ b/src/Registration/itkImageToImageRegistrationHelper.hxx
@@ -112,7 +112,7 @@ ImageToImageRegistrationHelper<TImage>
 
   m_MinimizeMemory = false;
   // Optimizer
-  m_UseEvolutionaryOptimization = true ;
+  m_UseEvolutionaryOptimization = true;
   // Loaded
   m_LoadedMatrixTransform = NULL;
   m_LoadedBSplineTransform = NULL;
@@ -168,7 +168,7 @@ void
 ImageToImageRegistrationHelper<TImage>
 ::LoadFixedImage( const std::string & filename )
 {
-  typedef ImageFileReader<TImage> ImageReaderType;
+  using ImageReaderType = ImageFileReader<TImage>;
 
   typename ImageReaderType::Pointer imageReader = ImageReaderType::New();
 
@@ -189,7 +189,7 @@ void
 ImageToImageRegistrationHelper<TImage>
 ::LoadMovingImage( const std::string & filename )
 {
-  typedef ImageFileReader<TImage> ImageReaderType;
+  using ImageReaderType = ImageFileReader<TImage>;
 
   typename ImageReaderType::Pointer imageReader = ImageReaderType::New();
 
@@ -210,7 +210,7 @@ void
 ImageToImageRegistrationHelper<TImage>
 ::SaveImage( const std::string & filename, const TImage * image )
 {
-  typedef ImageFileWriter<TImage> FileWriterType;
+  using FileWriterType = ImageFileWriter<TImage>;
 
   typename FileWriterType::Pointer fileWriter = FileWriterType::New();
   fileWriter->SetUseCompression( true );
@@ -449,7 +449,7 @@ ImageToImageRegistrationHelper<TImage>
     }
   if( m_SampleIntensityPortion > 0 )
     {
-    typedef MinimumMaximumImageCalculator<ImageType> MinMaxCalcType;
+    using MinMaxCalcType = MinimumMaximumImageCalculator<ImageType>;
     typename MinMaxCalcType::Pointer calc = MinMaxCalcType::New();
     calc->SetImage( m_FixedImage );
     calc->Compute();
@@ -551,7 +551,7 @@ ImageToImageRegistrationHelper<TImage>
     }
   if( m_SampleIntensityPortion > 0 )
     {
-    typedef MinimumMaximumImageCalculator<ImageType> MinMaxCalcType;
+    using MinMaxCalcType = MinimumMaximumImageCalculator<ImageType>;
     typename MinMaxCalcType::Pointer calc = MinMaxCalcType::New();
     calc->SetImage( m_FixedImage );
     calc->Compute();
@@ -780,7 +780,7 @@ ImageToImageRegistrationHelper<TImage>
       }
     if( m_SampleIntensityPortion > 0 )
       {
-      typedef MinimumMaximumImageCalculator<ImageType> MinMaxCalcType;
+      using MinMaxCalcType = MinimumMaximumImageCalculator<ImageType>;
       typename MinMaxCalcType::Pointer calc = MinMaxCalcType::New();
       calc->SetImage( m_FixedImage );
       calc->Compute();
@@ -915,7 +915,7 @@ ImageToImageRegistrationHelper<TImage>
       }
     if( m_SampleIntensityPortion > 0 )
       {
-      typedef MinimumMaximumImageCalculator<ImageType> MinMaxCalcType;
+      using MinMaxCalcType = MinimumMaximumImageCalculator<ImageType>;
       typename MinMaxCalcType::Pointer calc = MinMaxCalcType::New();
       calc->SetImage( m_FixedImage );
       calc->Compute();
@@ -960,20 +960,14 @@ ImageToImageRegistrationHelper<TImage>
                  const BSplineTransformType * bsplineTransform,
                  PixelType defaultPixelValue, double portion)
 {
-  typedef InterpolateImageFunction<TImage, double>
-    InterpolatorType;
-  typedef NearestNeighborInterpolateImageFunction<TImage, double>
-    NearestNeighborInterpolatorType;
-  typedef LinearInterpolateImageFunction<TImage, double>
-    LinearInterpolatorType;
-  typedef BSplineInterpolateImageFunction<TImage, double>
-    BSplineInterpolatorType;
-  typedef WindowedSincInterpolateImageFunction<TImage, 4,
+  using InterpolatorType = InterpolateImageFunction<TImage, double>;
+  using NearestNeighborInterpolatorType = NearestNeighborInterpolateImageFunction<TImage, double>;
+  using LinearInterpolatorType = LinearInterpolateImageFunction<TImage, double>;
+  using BSplineInterpolatorType = BSplineInterpolateImageFunction<TImage, double>;
+  using SincInterpolatorType = WindowedSincInterpolateImageFunction<TImage, 4,
     Function::HammingWindowFunction<4>, ConstantBoundaryCondition<TImage>,
-    double>
-    SincInterpolatorType;
-  typedef ResampleImageFilter<TImage, TImage, double>
-    ResampleImageFilterType;
+    double>;
+  using ResampleImageFilterType = ResampleImageFilter<TImage, TImage, double>;
 
   typename InterpolatorType::Pointer interpolator = nullptr;
 
@@ -1285,7 +1279,7 @@ void
 ImageToImageRegistrationHelper<TImage>
 ::LoadBaselineImage( const std::string & filename )
 {
-  typedef ImageFileReader<TImage> ImageReaderType;
+  using ImageReaderType = ImageFileReader<TImage>;
 
   typename ImageReaderType::Pointer imageReader = ImageReaderType::New();
 
@@ -1313,8 +1307,7 @@ ImageToImageRegistrationHelper<TImage>
     return;
     }
 
-  typedef Testing::ComparisonImageFilter<TImage, TImage>
-    ComparisonFilterType;
+  using ComparisonFilterType = Testing::ComparisonImageFilter<TImage, TImage>;
 
   typename TImage::ConstPointer imTemp = this->GetFixedImage();
   this->SetFixedImage( this->m_BaselineImage );
@@ -1363,8 +1356,8 @@ void
 ImageToImageRegistrationHelper<TImage>
 ::LoadTransform( const std::string & filename, bool invert )
 {
-  typedef TransformFileReader                    TransformReaderType;
-  typedef TransformReaderType::TransformListType TransformListType;
+  using TransformReaderType = TransformFileReader;
+  using TransformListType = TransformReaderType::TransformListType;
 
   TransformReaderType::Pointer transformReader = TransformReaderType::New();
   transformReader->SetFileName( filename );
@@ -1405,7 +1398,7 @@ void
 ImageToImageRegistrationHelper<TImage>
 ::SaveTransform( const std::string & filename )
 {
-  typedef TransformFileWriter TransformWriterType;
+  using TransformWriterType = TransformFileWriter;
 
   TransformWriterType::Pointer transformWriter = TransformWriterType::New();
   transformWriter->SetFileName( filename );
@@ -1433,9 +1426,9 @@ void
 ImageToImageRegistrationHelper<TImage>
 ::SaveDisplacementField( const std::string &filename )
 {
-  typedef itk::Vector<PixelType,TImage::ImageDimension>  VectorType;
-  typedef itk::Image<VectorType,TImage::ImageDimension>  DisplacementFieldType;
-  typedef itk::ImageRegionIterator< DisplacementFieldType > FieldIterator;
+  using VectorType = itk::Vector<PixelType,TImage::ImageDimension>;
+  using DisplacementFieldType = itk::Image<VectorType,TImage::ImageDimension>;
+  using FieldIterator = itk::ImageRegionIterator< DisplacementFieldType >;
 
   typename TImage::RegionType fixedImageRegion =
     m_FixedImage->GetBufferedRegion();
@@ -1483,7 +1476,7 @@ ImageToImageRegistrationHelper<TImage>
     ++it;
     }
 
-  typedef itk::ImageFileWriter< DisplacementFieldType >  FieldWriterType;
+  using FieldWriterType = itk::ImageFileWriter< DisplacementFieldType >;
   typename FieldWriterType::Pointer fieldWriter = FieldWriterType::New();
 
   fieldWriter->SetInput( field );

--- a/src/Registration/itkImageToImageRegistrationMethod.h
+++ b/src/Registration/itkImageToImageRegistrationMethod.h
@@ -47,10 +47,10 @@ class ImageToImageRegistrationMethod
 
 public:
 
-  typedef ImageToImageRegistrationMethod Self;
-  typedef ProcessObject                  Superclass;
-  typedef SmartPointer<Self>             Pointer;
-  typedef SmartPointer<const Self>       ConstPointer;
+  using Self = ImageToImageRegistrationMethod;
+  using Superclass = ProcessObject;
+  using Pointer = SmartPointer<Self>;
+  using ConstPointer = SmartPointer<const Self>;
 
   itkTypeMacro( ImageToImageRegistrationMethod, ProcessObject );
 
@@ -62,23 +62,21 @@ public:
   itkStaticConstMacro( ImageDimension, unsigned int,
                        TImage::ImageDimension );
 
-  typedef Transform<double,
+  using TransformType = Transform<double,
                     itkGetStaticConstMacro( ImageDimension ),
-                    itkGetStaticConstMacro( ImageDimension )>
-  TransformType;
+                    itkGetStaticConstMacro( ImageDimension )>;
 
-  typedef DataObjectDecorator<TransformType> TransformOutputType;
+  using TransformOutputType = DataObjectDecorator<TransformType>;
 
-  typedef typename DataObject::Pointer DataObjectPointer;
+  using DataObjectPointer = typename DataObject::Pointer;
   typedef Superclass::DataObjectPointerArraySizeType
                                        DataObjectPointerArraySizeType;
 
-  typedef TImage ImageType;
+  using ImageType = TImage;
 
-  typedef typename TImage::PointType PointType;
+  using PointType = typename TImage::PointType;
 
-  typedef SpatialObject<itkGetStaticConstMacro( ImageDimension )>
-  MaskObjectType;
+  using MaskObjectType = SpatialObject<itkGetStaticConstMacro( ImageDimension )>;
 
   //
   // Custom Methods

--- a/src/Registration/itkInitialImageToImageRegistrationMethod.h
+++ b/src/Registration/itkInitialImageToImageRegistrationMethod.h
@@ -43,10 +43,10 @@ class InitialImageToImageRegistrationMethod
 
 public:
 
-  typedef InitialImageToImageRegistrationMethod  Self;
-  typedef ImageToImageRegistrationMethod<TImage> Superclass;
-  typedef SmartPointer<Self>                     Pointer;
-  typedef SmartPointer<const Self>               ConstPointer;
+  using Self = InitialImageToImageRegistrationMethod;
+  using Superclass = ImageToImageRegistrationMethod<TImage>;
+  using Pointer = SmartPointer<Self>;
+  using ConstPointer = SmartPointer<const Self>;
 
   itkTypeMacro( InitialImageToImageRegistrationMethod,
                 ImageToImageRegistrationMethod );
@@ -59,17 +59,15 @@ public:
   itkStaticConstMacro( ImageDimension, unsigned int,
                        TImage::ImageDimension );
 
-  typedef AffineTransform<double, itkGetStaticConstMacro( ImageDimension )>
-  TransformType;
+  using TransformType = AffineTransform<double, itkGetStaticConstMacro( ImageDimension )>;
 
-  typedef typename TransformType::Pointer TransformPointer;
+  using TransformPointer = typename TransformType::Pointer;
 
   //
   // Local Typedefs
   //
-  typedef Point<double, itkGetStaticConstMacro( ImageDimension )>
-  LandmarkPointType;
-  typedef std::vector<LandmarkPointType> LandmarkPointContainer;
+  using LandmarkPointType = Point<double, itkGetStaticConstMacro( ImageDimension )>;
+  using LandmarkPointContainer = std::vector<LandmarkPointType>;
 
   //
   // Custom Methods

--- a/src/Registration/itkInitialImageToImageRegistrationMethod.hxx
+++ b/src/Registration/itkInitialImageToImageRegistrationMethod.hxx
@@ -71,10 +71,9 @@ InitialImageToImageRegistrationMethod<TImage>
 
     if( TImage::ImageDimension == 3 )
       {
-      typedef VersorRigid3DTransform<double> LandmarkTransformType;
-      typedef AnisotropicSimilarityLandmarkBasedTransformInitializer<LandmarkTransformType,
-                                                                     TImage, TImage>
-      LandmarkTransformCalculatorType;
+      using LandmarkTransformType = VersorRigid3DTransform<double>;
+      using LandmarkTransformCalculatorType = AnisotropicSimilarityLandmarkBasedTransformInitializer<LandmarkTransformType,
+                                                                     TImage, TImage>;
 
       typename LandmarkTransformCalculatorType::Pointer landmarkCalc;
       landmarkCalc = LandmarkTransformCalculatorType::New();
@@ -98,10 +97,9 @@ InitialImageToImageRegistrationMethod<TImage>
       }
     else if( TImage::ImageDimension == 2 )
       {
-      typedef Rigid2DTransform<double> LandmarkTransformType;
-      typedef AnisotropicSimilarityLandmarkBasedTransformInitializer<LandmarkTransformType,
-                                                                     TImage, TImage>
-      LandmarkTransformCalculatorType;
+      using LandmarkTransformType = Rigid2DTransform<double>;
+      using LandmarkTransformCalculatorType = AnisotropicSimilarityLandmarkBasedTransformInitializer<LandmarkTransformType,
+                                                                     TImage, TImage>;
 
       typename LandmarkTransformCalculatorType::Pointer landmarkCalc;
       landmarkCalc = LandmarkTransformCalculatorType::New();
@@ -158,7 +156,7 @@ InitialImageToImageRegistrationMethod<TImage>
     return;
     }
 
-  typedef ImageRegionMomentsCalculator<TImage> MomentsCalculatorType;
+  using MomentsCalculatorType = ImageRegionMomentsCalculator<TImage>;
 
   typename MomentsCalculatorType::AffineTransformType::Pointer newTransform;
   newTransform = MomentsCalculatorType::AffineTransformType::New();

--- a/src/Registration/itkOptimizedImageToImageRegistrationMethod.h
+++ b/src/Registration/itkOptimizedImageToImageRegistrationMethod.h
@@ -37,10 +37,10 @@ class OptimizedImageToImageRegistrationMethod
 
 public:
 
-  typedef OptimizedImageToImageRegistrationMethod Self;
-  typedef ImageToImageRegistrationMethod<TImage>  Superclass;
-  typedef SmartPointer<Self>                      Pointer;
-  typedef SmartPointer<const Self>                ConstPointer;
+  using Self = OptimizedImageToImageRegistrationMethod;
+  using Superclass = ImageToImageRegistrationMethod<TImage>;
+  using Pointer = SmartPointer<Self>;
+  using ConstPointer = SmartPointer<const Self>;
 
   itkTypeMacro( OptimizedImageToImageRegistrationMethod,
                 ImageToImageRegistrationMethod );
@@ -50,15 +50,15 @@ public:
   //
   // Typedefs from Superclass
   //
-  typedef TImage ImageType;
+  using ImageType = TImage;
 
-  typedef typename ImageType::PixelType PixelType;
+  using PixelType = typename ImageType::PixelType;
 
-  typedef typename Superclass::TransformType TransformType;
+  using TransformType = typename Superclass::TransformType;
 
-  typedef typename TransformType::ParametersType TransformParametersType;
+  using TransformParametersType = typename TransformType::ParametersType;
 
-  typedef typename TransformType::ParametersType TransformParametersScalesType;
+  using TransformParametersScalesType = typename TransformType::ParametersType;
 
   itkStaticConstMacro( ImageDimension, unsigned int,
                        TImage::ImageDimension );
@@ -144,8 +144,8 @@ protected:
 
   itkSetMacro( TransformMethodEnum, TransformMethodEnumType );
 
-  typedef InterpolateImageFunction<TImage, double> InterpolatorType;
-  typedef ImageToImageMetric<TImage, TImage>       MetricType;
+  using InterpolatorType = InterpolateImageFunction<TImage, double>;
+  using MetricType = ImageToImageMetric<TImage, TImage>;
 
   virtual void Optimize( MetricType * metric, InterpolatorType * interpolator );
 

--- a/src/Registration/itkOptimizedImageToImageRegistrationMethod.hxx
+++ b/src/Registration/itkOptimizedImageToImageRegistrationMethod.hxx
@@ -59,15 +59,15 @@ class ImageRegistrationViewer
   : public Command
 {
 public:
-  typedef ImageRegistrationViewer Self;
-  typedef Command                 Superclass;
-  typedef SmartPointer<Self>      Pointer;
+  using Self = ImageRegistrationViewer;
+  using Superclass = Command;
+  using Pointer = SmartPointer<Self>;
 
   itkTypeMacro( ImageRegistrationViewer, Command );
 
   itkNewMacro( ImageRegistrationViewer );
 
-  typedef SingleValuedNonLinearOptimizer OptimizerType;
+  using OptimizerType = SingleValuedNonLinearOptimizer;
 
   itkSetMacro(DontShowParameters, bool);
   itkSetMacro(UpdateInterval, int);
@@ -217,8 +217,7 @@ OptimizedImageToImageRegistrationMethod<TImage>
     {
     case MATTES_MI_METRIC:
         {
-        typedef MattesMutualInformationImageToImageMetric<TImage, TImage>
-          TypedMetricType;
+        using TypedMetricType = MattesMutualInformationImageToImageMetric<TImage, TImage>;
 
         typename TypedMetricType::Pointer typedMetric = TypedMetricType::New();
 
@@ -441,7 +440,7 @@ OptimizedImageToImageRegistrationMethod<TImage>
   catch( itk::ExceptionObject& exception )
     {
     std::cerr << "Optimization threw an exception." << std::endl;
-    std::cerr << exception << std::endl ;
+    std::cerr << exception << std::endl;
     }
 
   if( this->GetReportProgress() )
@@ -455,7 +454,7 @@ void
 OptimizedImageToImageRegistrationMethod<TImage>
 ::Optimize( MetricType * metric, InterpolatorType * interpolator )
 {
-  typedef ImageRegistrationMethod<TImage, TImage> RegType;
+  using RegType = ImageRegistrationMethod<TImage, TImage>;
 
   if( m_UseEvolutionaryOptimization )
     {
@@ -464,7 +463,7 @@ OptimizedImageToImageRegistrationMethod<TImage>
       std::cout << "EVOLUTIONARY START" << std::endl;
       }
 
-    typedef OnePlusOneEvolutionaryOptimizer EvoOptimizerType;
+    using EvoOptimizerType = OnePlusOneEvolutionaryOptimizer;
     EvoOptimizerType::Pointer evoOpt = EvoOptimizerType::New();
 
     evoOpt->SetNormalVariateGenerator( Statistics::NormalVariateGenerator
@@ -483,7 +482,7 @@ OptimizedImageToImageRegistrationMethod<TImage>
 
     if( this->GetReportProgress() )
       {
-      typedef ImageRegistrationViewer ViewerCommandType;
+      using ViewerCommandType = ImageRegistrationViewer;
       typename ViewerCommandType::Pointer command = ViewerCommandType::New();
       if( this->GetTransform()->GetNumberOfParameters() > 16 )
         {
@@ -551,7 +550,7 @@ OptimizedImageToImageRegistrationMethod<TImage>
     std::cout << "GRADIENT START" << std::endl;
     }
 
-  typedef FRPROptimizer GradOptimizerType;
+  using GradOptimizerType = FRPROptimizer;
   GradOptimizerType::Pointer gradOpt = GradOptimizerType::New();
 
   gradOpt->SetMaximize( false );
@@ -567,7 +566,7 @@ OptimizedImageToImageRegistrationMethod<TImage>
 
   if( this->GetReportProgress() )
     {
-    typedef ImageRegistrationViewer ViewerCommandType;
+    using ViewerCommandType = ImageRegistrationViewer;
     typename ViewerCommandType::Pointer command = ViewerCommandType::New();
     if( this->GetTransform()->GetNumberOfParameters() > 16 )
       {

--- a/src/Registration/itkRigidImageToImageRegistrationMethod.h
+++ b/src/Registration/itkRigidImageToImageRegistrationMethod.h
@@ -35,10 +35,10 @@ class RigidImageToImageRegistrationMethod
 
 public:
 
-  typedef RigidImageToImageRegistrationMethod             Self;
-  typedef OptimizedImageToImageRegistrationMethod<TImage> Superclass;
-  typedef SmartPointer<Self>                              Pointer;
-  typedef SmartPointer<const Self>                        ConstPointer;
+  using Self = RigidImageToImageRegistrationMethod;
+  using Superclass = OptimizedImageToImageRegistrationMethod<TImage>;
+  using Pointer = SmartPointer<Self>;
+  using ConstPointer = SmartPointer<const Self>;
 
   itkTypeMacro( RigidImageToImageRegistrationMethod,
                 OptimizedImageToImageRegistrationMethod );
@@ -55,23 +55,21 @@ public:
   // Overrides the superclass' TransformType typedef
   // We must use MatrixOffsetTransformBase since no itk rigid transform is
   //   templated over ImageDimension.
-  typedef MatrixOffsetTransformBase<double,
+  using RigidTransformType = MatrixOffsetTransformBase<double,
                                     itkGetStaticConstMacro( ImageDimension ),
-                                    itkGetStaticConstMacro( ImageDimension )>
-  RigidTransformType;
-  typedef RigidTransformType TransformType;
+                                    itkGetStaticConstMacro( ImageDimension )>;
+  using TransformType = RigidTransformType;
 
   //
   //  Custom Typedefs
   //
-  typedef Rigid2DTransform<double>       Rigid2DTransformType;
-  typedef VersorRigid3DTransform<double> Rigid3DTransformType;
+  using Rigid2DTransformType = Rigid2DTransform<double>;
+  using Rigid3DTransformType = VersorRigid3DTransform<double>;
 
-  typedef AffineTransform<double,
-                          itkGetStaticConstMacro( ImageDimension )>
-  AffineTransformType;
+  using AffineTransformType = AffineTransform<double,
+                          itkGetStaticConstMacro( ImageDimension )>;
 
-  typedef typename AffineTransformType::Pointer AffineTransformPointer;
+  using AffineTransformPointer = typename AffineTransformType::Pointer;
 
   //
   //  Superclass Methods

--- a/src/Registration/itkRigidImageToImageRegistrationMethod.hxx
+++ b/src/Registration/itkRigidImageToImageRegistrationMethod.hxx
@@ -135,7 +135,7 @@ RigidImageToImageRegistrationMethod<TImage>
   rigidTransform->SetCenter( affine->GetCenter() );
   rigidTransform->SetTranslation( affine->GetTranslation() );
 
-  typedef vnl_matrix<double> VnlMatrixType;
+  using VnlMatrixType = vnl_matrix<double>;
 
   VnlMatrixType M = affine->GetMatrix().GetVnlMatrix();
 

--- a/src/Registration/itkScaleSkewAngle2DImageToImageRegistrationMethod.h
+++ b/src/Registration/itkScaleSkewAngle2DImageToImageRegistrationMethod.h
@@ -39,11 +39,11 @@ class ScaleSkewAngle2DImageToImageRegistrationMethod
 
 public:
 
-  typedef ScaleSkewAngle2DImageToImageRegistrationMethod  Self;
-  typedef OptimizedImageToImageRegistrationMethod< 
-    Image< typename TImage::PixelType, 2 > >              Superclass;
-  typedef SmartPointer<Self>                              Pointer;
-  typedef SmartPointer<const Self>                        ConstPointer;
+  using Self = ScaleSkewAngle2DImageToImageRegistrationMethod;
+  using Superclass = OptimizedImageToImageRegistrationMethod< 
+    Image< typename TImage::PixelType, 2 > >;
+  using Pointer = SmartPointer<Self>;
+  using ConstPointer = SmartPointer<const Self>;
 
   itkTypeMacro( ScaleSkewAngle2DImageToImageRegistrationMethod,
                 OptimizedImageToImageRegistrationMethod );
@@ -57,15 +57,13 @@ public:
   //
 
   // Overrides the superclass' TransformType typedef
-  typedef ::itk::ScaleSkewAngle2DTransform< double >
-            ScaleSkewAngle2DTransformType;
+  using ScaleSkewAngle2DTransformType = ::itk::ScaleSkewAngle2DTransform< double >;
   typedef typename ScaleSkewAngle2DTransformType::Pointer
             ScaleSkewAngle2DTransformPointer;
   typedef ScaleSkewAngle2DTransformType
             TransformType;
 
-  typedef AffineTransform<double, 2>
-            AffineTransformType;
+  using AffineTransformType = AffineTransform<double, 2>;
   typedef typename AffineTransformType::Pointer
             AffineTransformPointer;
 

--- a/src/Registration/itkScaleSkewAngle2DTransform.h
+++ b/src/Registration/itkScaleSkewAngle2DTransform.h
@@ -54,11 +54,11 @@ class ITK_TEMPLATE_EXPORT ScaleSkewAngle2DTransform :
   public Rigid2DTransform<TParametersValueType>
 {
 public:
-  /** Standard class typedefs. */
-  typedef ScaleSkewAngle2DTransform                    Self;
-  typedef Rigid2DTransform<TParametersValueType>       Superclass;
-  typedef SmartPointer<Self>                           Pointer;
-  typedef SmartPointer<const Self>                     ConstPointer;
+  /** Standard class type alias. */
+  using Self = ScaleSkewAngle2DTransform;
+  using Superclass = Rigid2DTransform<TParametersValueType>;
+  using Pointer = SmartPointer<Self>;
+  using ConstPointer = SmartPointer<const Self>;
 
   /** New macro for creation of through a Smart Pointer. */
   itkNewMacro(Self);
@@ -72,34 +72,34 @@ public:
   itkStaticConstMacro(ParametersDimension, unsigned int, 7);
 
   /** Parameters Type   */
-  typedef typename Superclass::ParametersType            ParametersType;
-  typedef typename Superclass::FixedParametersType       FixedParametersType;
-  typedef typename Superclass::JacobianType              JacobianType;
-  typedef typename Superclass::ScalarType                ScalarType;
-  typedef typename Superclass::InputPointType            InputPointType;
-  typedef typename Superclass::OutputPointType           OutputPointType;
-  typedef typename Superclass::InputVectorType           InputVectorType;
-  typedef typename Superclass::OutputVectorType          OutputVectorType;
-  typedef typename Superclass::InputVnlVectorType        InputVnlVectorType;
-  typedef typename Superclass::OutputVnlVectorType       OutputVnlVectorType;
-  typedef typename Superclass::InputCovariantVectorType  InputCovariantVectorType;
-  typedef typename Superclass::OutputCovariantVectorType OutputCovariantVectorType;
-  typedef typename Superclass::MatrixType                MatrixType;
-  typedef typename Superclass::MatrixValueType           MatrixValueType;
-  typedef typename Superclass::InverseMatrixType         InverseMatrixType;
-  typedef typename Superclass::CenterType                CenterType;
-  typedef typename Superclass::OffsetType                OffsetType;
-  typedef typename Superclass::TranslationType           TranslationType;
+  using ParametersType = typename Superclass::ParametersType;
+  using FixedParametersType = typename Superclass::FixedParametersType;
+  using JacobianType = typename Superclass::JacobianType;
+  using ScalarType = typename Superclass::ScalarType;
+  using InputPointType = typename Superclass::InputPointType;
+  using OutputPointType = typename Superclass::OutputPointType;
+  using InputVectorType = typename Superclass::InputVectorType;
+  using OutputVectorType = typename Superclass::OutputVectorType;
+  using InputVnlVectorType = typename Superclass::InputVnlVectorType;
+  using OutputVnlVectorType = typename Superclass::OutputVnlVectorType;
+  using InputCovariantVectorType = typename Superclass::InputCovariantVectorType;
+  using OutputCovariantVectorType = typename Superclass::OutputCovariantVectorType;
+  using MatrixType = typename Superclass::MatrixType;
+  using MatrixValueType = typename Superclass::MatrixValueType;
+  using InverseMatrixType = typename Superclass::InverseMatrixType;
+  using CenterType = typename Superclass::CenterType;
+  using OffsetType = typename Superclass::OffsetType;
+  using TranslationType = typename Superclass::TranslationType;
 
   /** Scale & Skew Vector Type. */
-  typedef Vector<TParametersValueType, 2> ScaleVectorType;
-  typedef Vector<TParametersValueType, 2> SkewVectorType;
+  using ScaleVectorType = Vector<TParametersValueType, 2>;
+  using SkewVectorType = Vector<TParametersValueType, 2>;
 
-  typedef typename ScaleVectorType::ValueType ScaleVectorValueType;
-  typedef typename SkewVectorType::ValueType  SkewVectorValueType;
-  typedef typename TranslationType::ValueType TranslationValueType;
+  using ScaleVectorValueType = typename ScaleVectorType::ValueType;
+  using SkewVectorValueType = typename SkewVectorType::ValueType;
+  using TranslationValueType = typename TranslationType::ValueType;
 
-  typedef typename Superclass::ParametersValueType ParametersValueType;
+  using ParametersValueType = typename Superclass::ParametersValueType;
 
   /** Directly set the matrix of the transform.
    *

--- a/src/Registration/itkScaleSkewVersor3DImageToImageRegistrationMethod.h
+++ b/src/Registration/itkScaleSkewVersor3DImageToImageRegistrationMethod.h
@@ -39,11 +39,11 @@ class ScaleSkewVersor3DImageToImageRegistrationMethod
 
 public:
 
-  typedef ScaleSkewVersor3DImageToImageRegistrationMethod Self;
-  typedef OptimizedImageToImageRegistrationMethod<
-    Image< typename TImage::PixelType, 3 > >              Superclass;
-  typedef SmartPointer<Self>                              Pointer;
-  typedef SmartPointer<const Self>                        ConstPointer;
+  using Self = ScaleSkewVersor3DImageToImageRegistrationMethod;
+  using Superclass = OptimizedImageToImageRegistrationMethod<
+    Image< typename TImage::PixelType, 3 > >;
+  using Pointer = SmartPointer<Self>;
+  using ConstPointer = SmartPointer<const Self>;
 
   itkTypeMacro( ScaleSkewVersor3DImageToImageRegistrationMethod,
                 OptimizedImageToImageRegistrationMethod );
@@ -56,15 +56,13 @@ public:
   // Typedefs from Superclass
   // 
   // Overrides the superclass' TransformType typedef
-  typedef ::itk::ComposeScaleSkewVersor3DTransform< double >
-            ScaleSkewVersor3DTransformType;
+  using ScaleSkewVersor3DTransformType = ::itk::ComposeScaleSkewVersor3DTransform< double >;
   typedef typename ScaleSkewVersor3DTransformType::Pointer
             ScaleSkewVersor3DTransformPointer;
   typedef ScaleSkewVersor3DTransformType
             TransformType;
 
-  typedef AffineTransform<double, 3>
-            AffineTransformType;
+  using AffineTransformType = AffineTransform<double, 3>;
   typedef typename AffineTransformType::Pointer
             AffineTransformPointer;
 

--- a/src/Registration/itkSimilarity2DTransform.h
+++ b/src/Registration/itkSimilarity2DTransform.h
@@ -68,11 +68,11 @@ class ITK_TEMPLATE_EXPORT Similarity2DTransform :
   public Rigid2DTransform<TParametersValueType>
 {
 public:
-  /** Standard class typedefs. */
-  typedef Similarity2DTransform                  Self;
-  typedef Rigid2DTransform<TParametersValueType> Superclass;
-  typedef SmartPointer<Self>                     Pointer;
-  typedef SmartPointer<const Self>               ConstPointer;
+  /** Standard class type alias. */
+  using Self = Similarity2DTransform;
+  using Superclass = Rigid2DTransform<TParametersValueType>;
+  using Pointer = SmartPointer<Self>;
+  using ConstPointer = SmartPointer<const Self>;
 
   /** New macro for creation of through a Smart Pointer. */
   itkNewMacro(Self);
@@ -86,46 +86,46 @@ public:
   itkStaticConstMacro(OutputSpaceDimension,     unsigned int, 2);
   itkStaticConstMacro(ParametersDimension,      unsigned int, 4);
 
-  typedef typename Superclass::ScalarType ScalarType;
-  typedef          TParametersValueType   ScaleType;
+  using ScalarType = typename Superclass::ScalarType;
+  using ScaleType = TParametersValueType;
 
   /** Parameters type. */
-  typedef typename Superclass::ParametersType           ParametersType;
-  typedef typename Superclass::ParametersValueType      ParametersValueType;
-  typedef typename Superclass::FixedParametersType      FixedParametersType;
-  typedef typename Superclass::FixedParametersValueType FixedParametersValueType;
+  using ParametersType = typename Superclass::ParametersType;
+  using ParametersValueType = typename Superclass::ParametersValueType;
+  using FixedParametersType = typename Superclass::FixedParametersType;
+  using FixedParametersValueType = typename Superclass::FixedParametersValueType;
 
   /** Jacobian type. */
-  typedef typename Superclass::JacobianType JacobianType;
+  using JacobianType = typename Superclass::JacobianType;
 
   /** Offset type. */
-  typedef typename Superclass::OffsetType      OffsetType;
-  typedef typename Superclass::OffsetValueType OffsetValueType;
+  using OffsetType = typename Superclass::OffsetType;
+  using OffsetValueType = typename Superclass::OffsetValueType;
 
   /** Matrix type. */
-  typedef typename Superclass::MatrixType      MatrixType;
-  typedef typename Superclass::MatrixValueType MatrixValueType;
+  using MatrixType = typename Superclass::MatrixType;
+  using MatrixValueType = typename Superclass::MatrixValueType;
 
   /** Point type. */
-  typedef typename Superclass::InputPointType  InputPointType;
-  typedef typename Superclass::OutputPointType OutputPointType;
+  using InputPointType = typename Superclass::InputPointType;
+  using OutputPointType = typename Superclass::OutputPointType;
 
   /** Vector type. */
-  typedef typename Superclass::InputVectorType  InputVectorType;
-  typedef typename Superclass::OutputVectorType OutputVectorType;
+  using InputVectorType = typename Superclass::InputVectorType;
+  using OutputVectorType = typename Superclass::OutputVectorType;
 
   /** CovariantVector type. */
-  typedef typename Superclass::InputCovariantVectorType  InputCovariantVectorType;
-  typedef typename Superclass::OutputCovariantVectorType OutputCovariantVectorType;
+  using InputCovariantVectorType = typename Superclass::InputCovariantVectorType;
+  using OutputCovariantVectorType = typename Superclass::OutputCovariantVectorType;
 
   /** VnlVector type. */
-  typedef typename Superclass::InputVnlVectorType  InputVnlVectorType;
-  typedef typename Superclass::OutputVnlVectorType OutputVnlVectorType;
+  using InputVnlVectorType = typename Superclass::InputVnlVectorType;
+  using OutputVnlVectorType = typename Superclass::OutputVnlVectorType;
 
   /** Base inverse transform type. This type should not be changed to the
    * concrete inverse transform type or inheritance would be lost. */
-  typedef typename Superclass::InverseTransformBaseType InverseTransformBaseType;
-  typedef typename InverseTransformBaseType::Pointer    InverseTransformBasePointer;
+  using InverseTransformBaseType = typename Superclass::InverseTransformBaseType;
+  using InverseTransformBasePointer = typename InverseTransformBaseType::Pointer;
 
   /** Set the Scale part of the transform. */
   void SetScale(ScaleType scale);

--- a/src/Registration/itktubeAffineSpatialObjectToImageRegistrationMethod.h
+++ b/src/Registration/itktubeAffineSpatialObjectToImageRegistrationMethod.h
@@ -41,10 +41,10 @@ class AffineSpatialObjectToImageRegistrationMethod
 
 public:
 
-  typedef AffineSpatialObjectToImageRegistrationMethod            Self;
-  typedef OptimizedSpatialObjectToImageRegistrationMethod<ObjectDimension, TImage> Superclass;
-  typedef SmartPointer<Self>                              Pointer;
-  typedef SmartPointer<const Self>                        ConstPointer;
+  using Self = AffineSpatialObjectToImageRegistrationMethod;
+  using Superclass = OptimizedSpatialObjectToImageRegistrationMethod<ObjectDimension, TImage>;
+  using Pointer = SmartPointer<Self>;
+  using ConstPointer = SmartPointer<const Self>;
 
   itkTypeMacro( AffineSpatialObjectToImageRegistrationMethod,
                 OptimizedSpatialObjectToImageRegistrationMethod );
@@ -59,10 +59,9 @@ public:
   //
 
   // Overrides the superclass' TransformType typedef
-  typedef AffineTransform<double, itkGetStaticConstMacro( ImageDimension )>
-                                                AffineTransformType;
-  typedef typename AffineTransformType::Pointer AffineTransformPointer;
-  typedef AffineTransformType                   TransformType;
+  using AffineTransformType = AffineTransform<double, itkGetStaticConstMacro( ImageDimension )>;
+  using AffineTransformPointer = typename AffineTransformType::Pointer;
+  using TransformType = AffineTransformType;
 
   //
   // Superclass Methods

--- a/src/Registration/itktubeAnisotropicDiffusiveRegistrationFunction.h
+++ b/src/Registration/itktubeAnisotropicDiffusiveRegistrationFunction.h
@@ -79,12 +79,12 @@ class AnisotropicDiffusiveRegistrationFunction
   TDeformationField >
 {
 public:
-  /** Standard class typedefs. */
-  typedef AnisotropicDiffusiveRegistrationFunction   Self;
-  typedef PDEDeformableRegistrationFunction<TFixedImage, TMovingImage,
-          TDeformationField>                         Superclass;
-  typedef SmartPointer< Self >                       Pointer;
-  typedef SmartPointer< const Self >                 ConstPointer;
+  /** Standard class type alias. */
+  using Self = AnisotropicDiffusiveRegistrationFunction;
+  using Superclass = PDEDeformableRegistrationFunction<TFixedImage, TMovingImage,
+          TDeformationField>;
+  using Pointer = SmartPointer< Self >;
+  using ConstPointer = SmartPointer< const Self >;
 
   /** Method for creation through the object factory. */
   itkNewMacro( Self );
@@ -97,49 +97,42 @@ public:
   itkStaticConstMacro( ImageDimension, unsigned int,
     Superclass::ImageDimension );
 
-  /** Convenient typedefs from the superclass. */
-  typedef typename Superclass::FixedImageType        FixedImageType;
-  typedef typename Superclass::FixedImagePointer     FixedImagePointer;
-  typedef typename Superclass::MovingImageType       MovingImageType;
-  typedef typename Superclass::MovingImagePointer    MovingImagePointer;
-  typedef typename MovingImageType::PixelType        MovingImagePixelType;
-  typedef typename Superclass::DisplacementFieldType DeformationFieldType;
-  typedef typename DeformationFieldType::Pointer     DeformationFieldPointer;
-  typedef typename Superclass::TimeStepType          TimeStepType;
-  typedef typename Superclass::NeighborhoodType      NeighborhoodType;
-  typedef typename Superclass::PixelType             PixelType;
-  typedef typename Superclass::FloatOffsetType       FloatOffsetType;
+  /** Convenient type alias from the superclass. */
+  using FixedImageType = typename Superclass::FixedImageType;
+  using FixedImagePointer = typename Superclass::FixedImagePointer;
+  using MovingImageType = typename Superclass::MovingImageType;
+  using MovingImagePointer = typename Superclass::MovingImagePointer;
+  using MovingImagePixelType = typename MovingImageType::PixelType;
+  using DeformationFieldType = typename Superclass::DisplacementFieldType;
+  using DeformationFieldPointer = typename DeformationFieldType::Pointer;
+  using TimeStepType = typename Superclass::TimeStepType;
+  using NeighborhoodType = typename Superclass::NeighborhoodType;
+  using PixelType = typename Superclass::PixelType;
+  using FloatOffsetType = typename Superclass::FloatOffsetType;
 
   /** Deformation field types */
   typedef typename DeformationFieldType::PixelType
     DeformationVectorType;
   typedef typename DeformationVectorType::ValueType
     DeformationVectorComponentType;
-  typedef itk::Image< DeformationVectorComponentType, ImageDimension >
-    DeformationVectorComponentImageType;
-  typedef ZeroFluxNeumannBoundaryCondition<
-    DeformationVectorComponentImageType >
-    DeformationVectorComponentImageBoundaryConditionType;
-  typedef ConstNeighborhoodIterator< DeformationVectorComponentImageType,
-    DeformationVectorComponentImageBoundaryConditionType >
-    DeformationVectorComponentNeighborhoodType;
-  typedef itk::FixedArray< DeformationVectorComponentNeighborhoodType,
-    ImageDimension >
-    DeformationVectorComponentNeighborhoodArrayType;
-  typedef std::vector< DeformationVectorComponentNeighborhoodArrayType >
-    DeformationVectorComponentNeighborhoodArrayVectorType;
+  using DeformationVectorComponentImageType = itk::Image< DeformationVectorComponentType, ImageDimension >;
+  using DeformationVectorComponentImageBoundaryConditionType = ZeroFluxNeumannBoundaryCondition<
+    DeformationVectorComponentImageType >;
+  using DeformationVectorComponentNeighborhoodType = ConstNeighborhoodIterator< DeformationVectorComponentImageType,
+    DeformationVectorComponentImageBoundaryConditionType >;
+  using DeformationVectorComponentNeighborhoodArrayType = itk::FixedArray< DeformationVectorComponentNeighborhoodType,
+    ImageDimension >;
+  using DeformationVectorComponentNeighborhoodArrayVectorType = std::vector< DeformationVectorComponentNeighborhoodArrayType >;
 
   /** Typedefs for the intensity-based distance function */
-  typedef MeanSquareRegistrationFunction< FixedImageType, MovingImageType,
-    DeformationFieldType >
-    IntensityDistanceFunctionType;
+  using IntensityDistanceFunctionType = MeanSquareRegistrationFunction< FixedImageType, MovingImageType,
+    DeformationFieldType >;
   typedef typename IntensityDistanceFunctionType::Pointer
     IntensityDistanceFunctionPointer;
 
   /** Typedefs for the regularization function */
-  typedef AnisotropicDiffusionTensorFunction<
-    DeformationVectorComponentImageType >
-    RegularizationFunctionType;
+  using RegularizationFunctionType = AnisotropicDiffusionTensorFunction<
+    DeformationVectorComponentImageType >;
   typedef typename RegularizationFunctionType::Pointer
     RegularizationFunctionPointer;
   typedef typename RegularizationFunctionType::SpacingType
@@ -153,8 +146,7 @@ public:
   typedef typename RegularizationFunctionType::
     DiffusionTensorNeighborhoodType
     DiffusionTensorNeighborhoodType;
-  typedef std::vector< DiffusionTensorNeighborhoodType >
-    DiffusionTensorNeighborhoodVectorType;
+  using DiffusionTensorNeighborhoodVectorType = std::vector< DiffusionTensorNeighborhoodType >;
 
   /** Typedefs for the scalar derivatives */
   typedef typename RegularizationFunctionType::ScalarDerivativeType
@@ -164,10 +156,8 @@ public:
   typedef typename RegularizationFunctionType::
     ScalarDerivativeImageRegionType
       ScalarDerivativeImageRegionType;
-  typedef itk::FixedArray< ScalarDerivativeImageRegionType, ImageDimension >
-      ScalarDerivativeImageRegionArrayType;
-  typedef std::vector < ScalarDerivativeImageRegionArrayType >
-      ScalarDerivativeImageRegionArrayVectorType;
+  using ScalarDerivativeImageRegionArrayType = itk::FixedArray< ScalarDerivativeImageRegionType, ImageDimension >;
+  using ScalarDerivativeImageRegionArrayVectorType = std::vector < ScalarDerivativeImageRegionArrayType >;
 
   /** Typedefs for the tensor derivatives */
   typedef typename RegularizationFunctionType::TensorDerivativeType
@@ -177,22 +167,16 @@ public:
   typedef typename RegularizationFunctionType::
     TensorDerivativeImageRegionType
       TensorDerivativeImageRegionType;
-  typedef std::vector< TensorDerivativeImageRegionType >
-      TensorDerivativeImageRegionVectorType;
-  typedef itk::FixedArray < TensorDerivativeImageRegionType,
-    ImageDimension >
-      TensorDerivativeImageRegionArrayType;
-  typedef std::vector< TensorDerivativeImageRegionArrayType >
-      TensorDerivativeImageRegionArrayVectorType;
+  using TensorDerivativeImageRegionVectorType = std::vector< TensorDerivativeImageRegionType >;
+  using TensorDerivativeImageRegionArrayType = itk::FixedArray < TensorDerivativeImageRegionType,
+    ImageDimension >;
+  using TensorDerivativeImageRegionArrayVectorType = std::vector< TensorDerivativeImageRegionArrayType >;
 
   /** Typedefs for the multiplication vectors */
-  typedef ImageRegionIterator< DeformationFieldType >
-      DeformationVectorImageRegionType;
-  typedef itk::FixedArray < DeformationVectorImageRegionType,
-    ImageDimension >
-      DeformationVectorImageRegionArrayType;
-  typedef std::vector< DeformationVectorImageRegionArrayType >
-      DeformationVectorImageRegionArrayVectorType;
+  using DeformationVectorImageRegionType = ImageRegionIterator< DeformationFieldType >;
+  using DeformationVectorImageRegionArrayType = itk::FixedArray < DeformationVectorImageRegionType,
+    ImageDimension >;
+  using DeformationVectorImageRegionArrayVectorType = std::vector< DeformationVectorImageRegionArrayType >;
 
   /** Computes the time step for an update given a global data structure.
    *  Returns the time step supplied by the user. We don't need

--- a/src/Registration/itktubeDiffusiveRegistrationFilter.h
+++ b/src/Registration/itktubeDiffusiveRegistrationFilter.h
@@ -131,13 +131,13 @@ class DiffusiveRegistrationFilter
                                             TDeformationField >
 {
 public:
-  /** Standard class typedefs. */
-  typedef DiffusiveRegistrationFilter                         Self;
-  typedef PDEDeformableRegistrationFilter< TFixedImage,
+  /** Standard class type alias. */
+  using Self = DiffusiveRegistrationFilter;
+  using Superclass = PDEDeformableRegistrationFilter< TFixedImage,
                                           TMovingImage,
-                                          TDeformationField > Superclass;
-  typedef SmartPointer< Self >                                Pointer;
-  typedef SmartPointer< const Self >                          ConstPointer;
+                                          TDeformationField >;
+  using Pointer = SmartPointer< Self >;
+  using ConstPointer = SmartPointer< const Self >;
 
   /** Method for creation through the object factory.  Usually defined with
     * itkNewMacro(), but the type of the registration function depends on
@@ -156,14 +156,14 @@ public:
   itkStaticConstMacro( ImageDimension, unsigned int,
     Superclass::ImageDimension );
 
-  /** Convenient typedefs from the superclass. */
-  typedef typename Superclass::FixedImageType        FixedImageType;
-  typedef typename Superclass::FixedImagePointer     FixedImagePointer;
-  typedef typename Superclass::MovingImageType       MovingImageType;
-  typedef typename Superclass::MovingImagePointer    MovingImagePointer;
-  typedef typename MovingImageType::PixelType        MovingImagePixelType;
-  typedef typename Superclass::DisplacementFieldType DeformationFieldType;
-  typedef typename Superclass::TimeStepType          TimeStepType;
+  /** Convenient type alias from the superclass. */
+  using FixedImageType = typename Superclass::FixedImageType;
+  using FixedImagePointer = typename Superclass::FixedImagePointer;
+  using MovingImageType = typename Superclass::MovingImageType;
+  using MovingImagePointer = typename Superclass::MovingImagePointer;
+  using MovingImagePixelType = typename MovingImageType::PixelType;
+  using DeformationFieldType = typename Superclass::DisplacementFieldType;
+  using TimeStepType = typename Superclass::TimeStepType;
 
   typedef typename Superclass::DisplacementFieldPointer
       DeformationFieldPointer;
@@ -171,31 +171,28 @@ public:
       FiniteDifferenceFunctionType;
 
   /** Typedefs used in multithreading */
-  typedef typename Superclass::OutputImageType          OutputImageType;
-  typedef typename Superclass::OutputImagePointer       OutputImagePointer;
-  typedef typename Superclass::UpdateBufferType         UpdateBufferType;
-  typedef typename UpdateBufferType::RegionType         ThreadRegionType;
+  using OutputImageType = typename Superclass::OutputImageType;
+  using OutputImagePointer = typename Superclass::OutputImagePointer;
+  using UpdateBufferType = typename Superclass::UpdateBufferType;
+  using ThreadRegionType = typename UpdateBufferType::RegionType;
 
   /** Output image and update buffer types */
-  typedef itk::ImageRegionIterator< OutputImageType >
-      OutputImageRegionType;
+  using OutputImageRegionType = itk::ImageRegionIterator< OutputImageType >;
   typedef typename FiniteDifferenceFunctionType::NeighborhoodType
       NeighborhoodType;
 
   /** The registration function type */
-  typedef AnisotropicDiffusiveRegistrationFunction
-      < FixedImageType, MovingImageType, DeformationFieldType >
-      RegistrationFunctionType;
+  using RegistrationFunctionType = AnisotropicDiffusiveRegistrationFunction
+      < FixedImageType, MovingImageType, DeformationFieldType >;
   typedef typename RegistrationFunctionType::RegularizationFunctionType
       RegularizationFunctionType;
   typedef typename RegistrationFunctionType::RegularizationFunctionPointer
       RegularizationFunctionPointer;
-  typedef typename RegistrationFunctionType::SpacingType SpacingType;
+  using SpacingType = typename RegistrationFunctionType::SpacingType;
 
   /** Deformation component types ( i.e. component of a deformation field,
    *  still a vector */
-  typedef std::vector< DeformationFieldPointer >
-      DeformationFieldArrayType;
+  using DeformationFieldArrayType = std::vector< DeformationFieldPointer >;
   typedef typename RegistrationFunctionType::DeformationVectorType
       DeformationVectorType;
 
@@ -207,9 +204,8 @@ public:
       DeformationVectorComponentImageType;
   typedef typename DeformationVectorComponentImageType::Pointer
       DeformationVectorComponentImagePointer;
-  typedef typename itk::FixedArray< DeformationVectorComponentImagePointer,
-    ImageDimension >
-      DeformationComponentImageArrayType;
+  using DeformationComponentImageArrayType = typename itk::FixedArray< DeformationVectorComponentImagePointer,
+    ImageDimension >;
   typedef typename RegistrationFunctionType
     ::DeformationVectorComponentNeighborhoodType
       DeformationVectorComponentNeighborhoodType;
@@ -223,8 +219,7 @@ public:
       DiffusionTensorImageType;
   typedef typename DiffusionTensorImageType::Pointer
       DiffusionTensorImagePointer;
-  typedef std::vector< DiffusionTensorImagePointer >
-      DiffusionTensorImageArrayType;
+  using DiffusionTensorImageArrayType = std::vector< DiffusionTensorImagePointer >;
   typedef typename RegistrationFunctionType::DiffusionTensorNeighborhoodType
       DiffusionTensorNeighborhoodType;
   typedef typename
@@ -238,10 +233,8 @@ public:
       ScalarDerivativeImageType;
   typedef typename ScalarDerivativeImageType::Pointer
       ScalarDerivativeImagePointer;
-  typedef typename itk::FixedArray< ScalarDerivativeImagePointer >
-      ScalarDerivativeImageArrayType;
-  typedef std::vector< ScalarDerivativeImageArrayType >
-      ScalarDerivativeImageArrayVectorType;
+  using ScalarDerivativeImageArrayType = typename itk::FixedArray< ScalarDerivativeImagePointer >;
+  using ScalarDerivativeImageArrayVectorType = std::vector< ScalarDerivativeImageArrayType >;
   typedef typename RegistrationFunctionType::ScalarDerivativeImageRegionType
       ScalarDerivativeImageRegionType;
   typedef typename
@@ -255,12 +248,9 @@ public:
       TensorDerivativeImageType;
   typedef typename TensorDerivativeImageType::Pointer
       TensorDerivativeImagePointer;
-  typedef std::vector< TensorDerivativeImagePointer >
-      TensorDerivativeImageVectorType;
-  typedef typename itk::FixedArray< TensorDerivativeImagePointer >
-      TensorDerivativeImageArrayType;
-  typedef std::vector< TensorDerivativeImageArrayType >
-      TensorDerivativeImageArrayVectorType;
+  using TensorDerivativeImageVectorType = std::vector< TensorDerivativeImagePointer >;
+  using TensorDerivativeImageArrayType = typename itk::FixedArray< TensorDerivativeImagePointer >;
+  using TensorDerivativeImageArrayVectorType = std::vector< TensorDerivativeImageArrayType >;
   typedef typename RegistrationFunctionType::TensorDerivativeImageRegionType
       TensorDerivativeImageRegionType;
   typedef typename
@@ -273,10 +263,8 @@ public:
       ThreadTensorDerivativeImageRegionType;
 
   /** Typedefs for the multiplication vectors */
-  typedef typename itk::FixedArray< DeformationFieldPointer >
-      DeformationVectorImageArrayType;
-  typedef std::vector< DeformationVectorImageArrayType >
-      DeformationVectorImageArrayVectorType;
+  using DeformationVectorImageArrayType = typename itk::FixedArray< DeformationFieldPointer >;
+  using DeformationVectorImageArrayVectorType = std::vector< DeformationVectorImageArrayType >;
   typedef typename RegistrationFunctionType
     ::DeformationVectorImageRegionType
       DeformationVectorImageRegionType;
@@ -285,12 +273,11 @@ public:
       DeformationVectorImageRegionArrayVectorType;
 
   /** Stopping criterion mask types */
-  typedef FixedImageType    StoppingCriterionMaskImageType;
-  typedef FixedImagePointer StoppingCriterionMaskPointer;
+  using StoppingCriterionMaskImageType = FixedImageType;
+  using StoppingCriterionMaskPointer = FixedImagePointer;
   typedef typename StoppingCriterionMaskImageType::RegionType
     ThreadStoppingCriterionMaskImageRegionType;
-  typedef ImageRegionIterator< StoppingCriterionMaskImageType >
-    StoppingCriterionMaskImageRegionType;
+  using StoppingCriterionMaskImageRegionType = ImageRegionIterator< StoppingCriterionMaskImageType >;
 
   /** Convenience functions to set/get the registration functions
    * timestep. */

--- a/src/Registration/itktubeDiffusiveRegistrationFilter.hxx
+++ b/src/Registration/itktubeDiffusiveRegistrationFilter.hxx
@@ -1752,7 +1752,7 @@ DiffusiveRegistrationFilter
 {
   ImageRegionIterator< UpdateBufferType > updateIt( m_UpdateBuffer,
     regionToProcess );
-  typedef ImageRegionIterator< OutputImageType > OutputImageIteratorType;
+  using OutputImageIteratorType = ImageRegionIterator< OutputImageType >;
   OutputImageIteratorType outputIt1( this->GetOutput(), regionToProcess );
   OutputImageIteratorType outputIt2( outputImage, regionToProcess );
 

--- a/src/Registration/itktubeDiffusiveRegistrationFilterUtils.h
+++ b/src/Registration/itktubeDiffusiveRegistrationFilterUtils.h
@@ -92,10 +92,10 @@ public:
 template< class TImage >
 struct FaceStruct
 {
-  typedef NeighborhoodAlgorithm::ImageBoundaryFacesCalculator<
-    typename TImage::ObjectType >                     FaceCalculatorType;
-    typedef typename FaceCalculatorType::FaceListType FaceListType;
-    typedef typename FaceListType::iterator           FaceListIteratorType;
+  using FaceCalculatorType = NeighborhoodAlgorithm::ImageBoundaryFacesCalculator<
+    typename TImage::ObjectType >;
+    using FaceListType = typename FaceCalculatorType::FaceListType;
+    using FaceListIteratorType = typename FaceListType::iterator;
 
   FaceStruct( void )
     {

--- a/src/Registration/itktubeDiffusiveRegistrationFilterUtils.hxx
+++ b/src/Registration/itktubeDiffusiveRegistrationFilterUtils.hxx
@@ -90,7 +90,7 @@ DiffusiveRegistrationFilterUtils
 {
   // We have to implement nearest neighbors by hand, since we are dealing with
   // pixel types that do not have Numeric Traits
-  typedef typename TResampleImagePointer::ObjectType ResampleImageType;
+  using ResampleImageType = typename TResampleImagePointer::ObjectType;
 
   // Create the resized resampled image
   resampledImage = ResampleImageType::New();
@@ -98,8 +98,7 @@ DiffusiveRegistrationFilterUtils
     templateImage );
 
   // Do NN interpolation
-  typedef itk::ImageRegionIteratorWithIndex< ResampleImageType >
-      ResampleImageRegionType;
+  using ResampleImageRegionType = itk::ImageRegionIteratorWithIndex< ResampleImageType >;
   ResampleImageRegionType resampledImageIt = ResampleImageRegionType(
       resampledImage, resampledImage->GetLargestPossibleRegion() );
 
@@ -133,9 +132,9 @@ DiffusiveRegistrationFilterUtils
                        TResampleImagePointer & resampledImage )
 {
   // Do linear interpolation
-  typedef itk::ResampleImageFilter
+  using ResampleFilterType = itk::ResampleImageFilter
       < typename TResampleImagePointer::ObjectType,
-        typename TResampleImagePointer::ObjectType > ResampleFilterType;
+        typename TResampleImagePointer::ObjectType >;
   typename ResampleFilterType::Pointer resampler = ResampleFilterType::New();
   resampler->SetInput( highResolutionImage );
   resampler->SetOutputParametersFromImage( templateImage );
@@ -156,9 +155,9 @@ DiffusiveRegistrationFilterUtils
     bool normalize )
 {
   // Do linear interpolation
-  typedef itk::ResampleImageFilter
+  using ResampleFilterType = itk::ResampleImageFilter
       < typename TVectorResampleImagePointer::ObjectType,
-        typename TVectorResampleImagePointer::ObjectType > ResampleFilterType;
+        typename TVectorResampleImagePointer::ObjectType >;
   typename ResampleFilterType::Pointer resampler = ResampleFilterType::New();
   resampler->SetInput( highResolutionImage );
   resampler->SetOutputOrigin( templateImage->GetOrigin() );
@@ -184,8 +183,7 @@ void
 DiffusiveRegistrationFilterUtils
 ::NormalizeVectorField( TVectorImagePointer & image )
 {
-  typedef ImageRegionIterator< typename TVectorImagePointer::ObjectType >
-      DeformationVectorImageRegionType;
+  using DeformationVectorImageRegionType = ImageRegionIterator< typename TVectorImagePointer::ObjectType >;
   DeformationVectorImageRegionType vectorIt(
       image, image->GetLargestPossibleRegion() );
   for( vectorIt.GoToBegin(); !vectorIt.IsAtEnd(); ++vectorIt )
@@ -203,7 +201,7 @@ bool
 DiffusiveRegistrationFilterUtils
 ::IsIntensityRangeBetween0And1( TImage * image )
 {
-  typedef itk::MinimumMaximumImageCalculator< TImage > CalculatorType;
+  using CalculatorType = itk::MinimumMaximumImageCalculator< TImage >;
   typename CalculatorType::Pointer calculator = CalculatorType::New();
   calculator->SetImage( image );
   calculator->Compute();
@@ -227,10 +225,9 @@ DiffusiveRegistrationFilterUtils
 {
   assert( deformationField );
 
-  typedef itk::VectorIndexSelectionCastImageFilter
+  using VectorIndexSelectionFilterType = itk::VectorIndexSelectionCastImageFilter
       < TDeformationField,
-      typename TDeformationComponentImageArray::ValueType::ObjectType >
-      VectorIndexSelectionFilterType;
+      typename TDeformationComponentImageArray::ValueType::ObjectType >;
   typename VectorIndexSelectionFilterType::Pointer indexSelector;
   for( unsigned int i = 0; i < TDeformationField::ImageDimension; i++ )
     {

--- a/src/Registration/itktubeInitialSpatialObjectToImageRegistrationMethod.h
+++ b/src/Registration/itktubeInitialSpatialObjectToImageRegistrationMethod.h
@@ -43,10 +43,10 @@ class InitialSpatialObjectToImageRegistrationMethod
 
 public:
 
-  typedef InitialSpatialObjectToImageRegistrationMethod  Self;
-  typedef SpatialObjectToImageRegistrationMethod<ObjectDimension, TImage> Superclass;
-  typedef SmartPointer<Self>                     Pointer;
-  typedef SmartPointer<const Self>               ConstPointer;
+  using Self = InitialSpatialObjectToImageRegistrationMethod;
+  using Superclass = SpatialObjectToImageRegistrationMethod<ObjectDimension, TImage>;
+  using Pointer = SmartPointer<Self>;
+  using ConstPointer = SmartPointer<const Self>;
 
   itkTypeMacro( InitialSpatialObjectToImageRegistrationMethod,
                 SpatialObjectToImageRegistrationMethod );
@@ -56,22 +56,20 @@ public:
   //
   // Typedefs from Superclass
   //
-  typedef typename Superclass::SpatialObjectType SpatialObjectType;
+  using SpatialObjectType = typename Superclass::SpatialObjectType;
 
   itkStaticConstMacro( ImageDimension, unsigned int,
                        TImage::ImageDimension );
 
-  typedef AffineTransform<double, itkGetStaticConstMacro( ImageDimension )>
-  TransformType;
+  using TransformType = AffineTransform<double, itkGetStaticConstMacro( ImageDimension )>;
 
-  typedef typename TransformType::Pointer TransformPointer;
+  using TransformPointer = typename TransformType::Pointer;
 
   //
   // Local Typedefs
   //
-  typedef Point<double, itkGetStaticConstMacro( ImageDimension )>
-  LandmarkPointType;
-  typedef std::vector<LandmarkPointType> LandmarkPointContainer;
+  using LandmarkPointType = Point<double, itkGetStaticConstMacro( ImageDimension )>;
+  using LandmarkPointContainer = std::vector<LandmarkPointType>;
 
   //
   // Custom Methods

--- a/src/Registration/itktubeInitialSpatialObjectToImageRegistrationMethod.hxx
+++ b/src/Registration/itktubeInitialSpatialObjectToImageRegistrationMethod.hxx
@@ -74,10 +74,9 @@ InitialSpatialObjectToImageRegistrationMethod<ObjectDimension, TImage>
 
     if( TImage::ImageDimension == 3 )
       {
-      typedef AnisotropicSimilarity3DTransform<double> LandmarkTransformType;
-      typedef AnisotropicSimilarityLandmarkBasedTransformInitializer<LandmarkTransformType,
-                                                                     TImage, TImage>
-      LandmarkTransformCalculatorType;
+      using LandmarkTransformType = AnisotropicSimilarity3DTransform<double>;
+      using LandmarkTransformCalculatorType = AnisotropicSimilarityLandmarkBasedTransformInitializer<LandmarkTransformType,
+                                                                     TImage, TImage>;
 
       typename LandmarkTransformCalculatorType::Pointer landmarkCalc;
       landmarkCalc = LandmarkTransformCalculatorType::New();
@@ -101,10 +100,9 @@ InitialSpatialObjectToImageRegistrationMethod<ObjectDimension, TImage>
       }
     else if( TImage::ImageDimension == 2 )
       {
-      typedef Rigid2DTransform<double> LandmarkTransformType;
-      typedef AnisotropicSimilarityLandmarkBasedTransformInitializer<LandmarkTransformType,
-                                                                     TImage, TImage>
-      LandmarkTransformCalculatorType;
+      using LandmarkTransformType = Rigid2DTransform<double>;
+      using LandmarkTransformCalculatorType = AnisotropicSimilarityLandmarkBasedTransformInitializer<LandmarkTransformType,
+                                                                     TImage, TImage>;
 
       typename LandmarkTransformCalculatorType::Pointer landmarkCalc;
       landmarkCalc = LandmarkTransformCalculatorType::New();
@@ -161,7 +159,7 @@ InitialSpatialObjectToImageRegistrationMethod<ObjectDimension, TImage>
     return;
     }
 
-  //typedef SpatialObjectRegionMomentsCalculator<TImage> MomentsCalculatorType;
+  //using MomentsCalculatorType = SpatialObjectRegionMomentsCalculator<TImage>;
 
   typename TransformType::Pointer newTransform = TransformType::New();
   newTransform->SetIdentity();
@@ -170,7 +168,7 @@ InitialSpatialObjectToImageRegistrationMethod<ObjectDimension, TImage>
     this->m_NumberOfMoments == 0 )
     {
     //  Moving image info
-    typedef typename SpatialObjectType::BoundingBoxType     BoundingBoxType;
+    using BoundingBoxType = typename SpatialObjectType::BoundingBoxType;
     typename BoundingBoxType::ConstPointer                  bbox;
     typename BoundingBoxType::PointType                     minPnt;
     typename BoundingBoxType::PointType                     maxPnt;

--- a/src/Registration/itktubeMeanSquareRegistrationFunction.h
+++ b/src/Registration/itktubeMeanSquareRegistrationFunction.h
@@ -65,12 +65,12 @@ class MeanSquareRegistrationFunction
                                               TDeformationField >
 {
 public:
-  /** Standard class typedefs. */
-  typedef MeanSquareRegistrationFunction    Self;
-  typedef PDEDeformableRegistrationFunction< TFixedImage,
-    TMovingImage, TDeformationField >       Superclass;
-  typedef SmartPointer< Self >              Pointer;
-  typedef SmartPointer< const Self >        ConstPointer;
+  /** Standard class type alias. */
+  using Self = MeanSquareRegistrationFunction;
+  using Superclass = PDEDeformableRegistrationFunction< TFixedImage,
+    TMovingImage, TDeformationField >;
+  using Pointer = SmartPointer< Self >;
+  using ConstPointer = SmartPointer< const Self >;
 
   /** Method for creation through the object factory. */
   itkNewMacro( Self );
@@ -80,16 +80,16 @@ public:
     PDEDeformableRegistrationFunction );
 
   /** MovingImage image type. */
-  typedef typename Superclass::MovingImageType     MovingImageType;
-  typedef typename Superclass::MovingImagePointer  MovingImagePointer;
-  typedef typename MovingImageType::PixelType      MovingImagePixelType;
+  using MovingImageType = typename Superclass::MovingImageType;
+  using MovingImagePointer = typename Superclass::MovingImagePointer;
+  using MovingImagePixelType = typename MovingImageType::PixelType;
 
   /** FixedImage image type. */
-  typedef typename Superclass::FixedImageType     FixedImageType;
-  typedef typename Superclass::FixedImagePointer  FixedImagePointer;
-  typedef typename FixedImageType::IndexType      IndexType;
-  typedef typename FixedImageType::SizeType       SizeType;
-  typedef typename FixedImageType::SpacingType    SpacingType;
+  using FixedImageType = typename Superclass::FixedImageType;
+  using FixedImagePointer = typename Superclass::FixedImagePointer;
+  using IndexType = typename FixedImageType::IndexType;
+  using SizeType = typename FixedImageType::SizeType;
+  using SpacingType = typename FixedImageType::SpacingType;
 
   /** Deformation field type. */
   typedef typename Superclass::DisplacementFieldType
@@ -104,28 +104,24 @@ public:
     Superclass::ImageDimension );
 
   /** Inherit some enums from the superclass. */
-  typedef typename Superclass::PixelType        PixelType;
-  typedef typename Superclass::RadiusType       RadiusType;
-  typedef typename Superclass::NeighborhoodType NeighborhoodType;
-  typedef typename Superclass::FloatOffsetType  FloatOffsetType;
-  typedef typename Superclass::TimeStepType     TimeStepType;
+  using PixelType = typename Superclass::PixelType;
+  using RadiusType = typename Superclass::RadiusType;
+  using NeighborhoodType = typename Superclass::NeighborhoodType;
+  using FloatOffsetType = typename Superclass::FloatOffsetType;
+  using TimeStepType = typename Superclass::TimeStepType;
 
   /** Interpolator type. */
-  typedef double                                     CoordRepType;
-  typedef InterpolateImageFunction<MovingImageType, CoordRepType>
-                                                     InterpolatorType;
-  typedef typename InterpolatorType::Pointer         InterpolatorPointer;
-  typedef typename InterpolatorType::PointType       PointType;
-  typedef LinearInterpolateImageFunction<MovingImageType, CoordRepType>
-                                                     DefaultInterpolatorType;
+  using CoordRepType = double;
+  using InterpolatorType = InterpolateImageFunction<MovingImageType, CoordRepType>;
+  using InterpolatorPointer = typename InterpolatorType::Pointer;
+  using PointType = typename InterpolatorType::PointType;
+  using DefaultInterpolatorType = LinearInterpolateImageFunction<MovingImageType, CoordRepType>;
 
   /** Covariant vector type. */
-  typedef CovariantVector< double, itkGetStaticConstMacro( ImageDimension ) >
-    CovariantVectorType;
+  using CovariantVectorType = CovariantVector< double, itkGetStaticConstMacro( ImageDimension ) >;
 
   /** Gradient calculator type. */
-  typedef CentralDifferenceImageFunction<FixedImageType>
-    GradientCalculatorType;
+  using GradientCalculatorType = CentralDifferenceImageFunction<FixedImageType>;
   typedef typename GradientCalculatorType::Pointer
     GradientCalculatorPointer;
 
@@ -195,8 +191,7 @@ protected:
   void PrintSelf( std::ostream& os, Indent indent ) const override;
 
   /** FixedImage image neighborhood iterator type. */
-  typedef ConstNeighborhoodIterator<FixedImageType>
-    FixedImageNeighborhoodIteratorType;
+  using FixedImageNeighborhoodIteratorType = ConstNeighborhoodIterator<FixedImageType>;
 
   /** A global data type for this class of equation. Used to store
    * iterators for the fixed image. */

--- a/src/Registration/itktubeMergeAdjacentImagesFilter.h
+++ b/src/Registration/itktubeMergeAdjacentImagesFilter.h
@@ -43,14 +43,14 @@ class MergeAdjacentImagesFilter :
 {
 public:
 
-  typedef MergeAdjacentImagesFilter                          Self;
-  typedef Object                                             Superclass;
-  typedef SmartPointer< Self >                               Pointer;
-  typedef SmartPointer< const Self >                         ConstPointer;
+  using Self = MergeAdjacentImagesFilter;
+  using Superclass = Object;
+  using Pointer = SmartPointer< Self >;
+  using ConstPointer = SmartPointer< const Self >;
 
-  typedef TImage                                             ImageType;
-  typedef typename TImage::PixelType                         PixelType;
-  typedef std::vector< int >                                 PaddingType;
+  using ImageType = TImage;
+  using PixelType = typename TImage::PixelType;
+  using PaddingType = std::vector< int >;
 
 
   /** Method for creation through the object factory. */
@@ -61,7 +61,7 @@ public:
 
   itkStaticConstMacro( ImageDimension, unsigned int, TImage::ImageDimension );
 
-  typedef AffineTransform< double, ImageDimension >          TransformType;
+  using TransformType = AffineTransform< double, ImageDimension >;
 
   /** Set input image 1 */
   virtual void SetInput1( const ImageType * image );

--- a/src/Registration/itktubeMergeAdjacentImagesFilter.hxx
+++ b/src/Registration/itktubeMergeAdjacentImagesFilter.hxx
@@ -111,8 +111,8 @@ void
 MergeAdjacentImagesFilter< TImage >
 ::LoadInitialTransform( const std::string & filename )
 {
-  typedef TransformFileReader                    TransformReaderType;
-  typedef TransformReaderType::TransformListType TransformListType;
+  using TransformReaderType = TransformFileReader;
+  using TransformListType = TransformReaderType::TransformListType;
 
   TransformReaderType::Pointer transformReader = TransformReaderType::New();
   transformReader->SetFileName( filename );
@@ -142,7 +142,7 @@ MergeAdjacentImagesFilter< TImage >
 {
   if( m_OutputTransform.IsNotNull() )
     {
-    typedef TransformFileWriter TransformWriterType;
+    using TransformWriterType = TransformFileWriter;
   
     TransformWriterType::Pointer transformWriter = TransformWriterType::New();
     transformWriter->SetFileName( filename );
@@ -304,8 +304,7 @@ MergeAdjacentImagesFilter< TImage >
   // timeCollector.Stop( "Allocate output image" );
 
   // perform registration
-  typedef typename itk::ImageToImageRegistrationHelper< ImageType >
-    RegFilterType;
+  using RegFilterType = typename itk::ImageToImageRegistrationHelper< ImageType >;
   typename RegFilterType::Pointer regOp = RegFilterType::New();
   regOp->SetFixedImage( m_Input1 );
   regOp->SetMovingImage( m_Input2 );
@@ -351,7 +350,7 @@ MergeAdjacentImagesFilter< TImage >
     m_Input2, NULL, NULL, m_Background );
 
   // timeCollector.Stop( "Resample Image" );
-  typedef typename itk::Image<float, ImageDimension> FloatImageType;
+  using FloatImageType = typename itk::Image<float, ImageDimension>;
 
   if( m_BlendUsingAverage )
     {
@@ -462,12 +461,11 @@ MergeAdjacentImagesFilter< TImage >
     typename FloatImageType::Pointer outputVoronoiMap = nullptr;
     if( m_UseFastBlending )
       {
-      typedef typename itk::GeneralizedDistanceTransformImageFilter<
-        FloatImageType, FloatImageType, FloatImageType >   MapFilterType;
+      using MapFilterType = typename itk::GeneralizedDistanceTransformImageFilter<
+        FloatImageType, FloatImageType, FloatImageType >;
       typename MapFilterType::Pointer mapDistFilter = MapFilterType::New();
 
-      typedef itk::BinaryThresholdImageFilter<FloatImageType, FloatImageType>
-        Indicator;
+      using Indicator = itk::BinaryThresholdImageFilter<FloatImageType, FloatImageType>;
       typename Indicator::Pointer indicator = Indicator::New();
 
       indicator->SetLowerThreshold( 0 );
@@ -488,8 +486,8 @@ MergeAdjacentImagesFilter< TImage >
       }
     else
       {
-      typedef typename itk::DanielssonDistanceMapImageFilter< FloatImageType,
-        FloatImageType, FloatImageType >   MapFilterType;
+      using MapFilterType = typename itk::DanielssonDistanceMapImageFilter< FloatImageType,
+        FloatImageType, FloatImageType >;
       typename MapFilterType::Pointer mapDistFilter = MapFilterType::New();
       mapDistFilter->SetInput( outputMap );
       mapDistFilter->SetInputIsBinary( false );
@@ -527,14 +525,13 @@ MergeAdjacentImagesFilter< TImage >
     typename FloatImageType::Pointer vorImageDistMap = nullptr;
     if( m_UseFastBlending )
       {
-      typedef typename itk::GeneralizedDistanceTransformImageFilter<
-        FloatImageType, FloatImageType >   MapFilterType;
+      using MapFilterType = typename itk::GeneralizedDistanceTransformImageFilter<
+        FloatImageType, FloatImageType >;
       typename MapFilterType::Pointer mapVorFilter = MapFilterType::New();
 
       // timeCollector.Start( "Voronoi Distance Map" );
 
-      typedef itk::BinaryThresholdImageFilter<FloatImageType, FloatImageType>
-        Indicator;
+      using Indicator = itk::BinaryThresholdImageFilter<FloatImageType, FloatImageType>;
       typename Indicator::Pointer indicator2 = Indicator::New();
 
       indicator2->SetLowerThreshold( 0 );
@@ -558,8 +555,8 @@ MergeAdjacentImagesFilter< TImage >
       {
       // timeCollector.Start( "Voronoi Distance Map" );
 
-      typedef typename itk::SignedDanielssonDistanceMapImageFilter<
-        FloatImageType, FloatImageType>  SignedMapFilterType;
+      using SignedMapFilterType = typename itk::SignedDanielssonDistanceMapImageFilter<
+        FloatImageType, FloatImageType>;
       typename SignedMapFilterType::Pointer mapVorFilter =
         SignedMapFilterType::New();
 

--- a/src/Registration/itktubeOptimizedSpatialObjectToImageRegistrationMethod.h
+++ b/src/Registration/itktubeOptimizedSpatialObjectToImageRegistrationMethod.h
@@ -43,10 +43,9 @@ public:
 
   typedef OptimizedSpatialObjectToImageRegistrationMethod
                                                   Self;
-  typedef SpatialObjectToImageRegistrationMethod<ObjectDimension, TImage>
-                                                  Superclass;
-  typedef SmartPointer<Self>                      Pointer;
-  typedef SmartPointer<const Self>                ConstPointer;
+  using Superclass = SpatialObjectToImageRegistrationMethod<ObjectDimension, TImage>;
+  using Pointer = SmartPointer<Self>;
+  using ConstPointer = SmartPointer<const Self>;
 
   itkTypeMacro( OptimizedSpatialObjectToImageRegistrationMethod,
                 SpatialObjectToImageRegistrationMethod );
@@ -56,16 +55,16 @@ public:
   //
   // Typedefs from Superclass
   //
-  typedef TImage                         ImageType;
-  typedef SpatialObject<ObjectDimension> SpatialObjectType;
+  using ImageType = TImage;
+  using SpatialObjectType = SpatialObject<ObjectDimension>;
 
-  typedef typename ImageType::PixelType PixelType;
+  using PixelType = typename ImageType::PixelType;
 
-  typedef typename Superclass::TransformType TransformType;
+  using TransformType = typename Superclass::TransformType;
 
-  typedef typename TransformType::ParametersType TransformParametersType;
+  using TransformParametersType = typename TransformType::ParametersType;
 
-  typedef typename TransformType::ParametersType TransformParametersScalesType;
+  using TransformParametersScalesType = typename TransformType::ParametersType;
 
   itkStaticConstMacro( ImageDimension, unsigned int,
                        TImage::ImageDimension );
@@ -134,7 +133,7 @@ protected:
 
   itkSetMacro( TransformMethodEnum, TransformMethodEnumType );
 
-  typedef SpatialObjectToImageMetric<ObjectDimension, TImage>       MetricType;
+  using MetricType = SpatialObjectToImageMetric<ObjectDimension, TImage>;
 
   virtual void Optimize( MetricType * metric );
 

--- a/src/Registration/itktubeOptimizedSpatialObjectToImageRegistrationMethod.hxx
+++ b/src/Registration/itktubeOptimizedSpatialObjectToImageRegistrationMethod.hxx
@@ -51,15 +51,15 @@ class SpatialObjectToImageRegistrationViewer
   : public Command
 {
 public:
-  typedef SpatialObjectToImageRegistrationViewer Self;
-  typedef Command                 Superclass;
-  typedef SmartPointer<Self>      Pointer;
+  using Self = SpatialObjectToImageRegistrationViewer;
+  using Superclass = Command;
+  using Pointer = SmartPointer<Self>;
 
   itkTypeMacro( SpatialObjectToImageRegistrationViewer, Command );
 
   itkNewMacro( SpatialObjectToImageRegistrationViewer );
 
-  typedef SingleValuedNonLinearOptimizer OptimizerType;
+  using OptimizerType = SingleValuedNonLinearOptimizer;
 
   itkSetMacro(DontShowParameters, bool);
   itkSetMacro(UpdateInterval, int);
@@ -191,8 +191,7 @@ OptimizedSpatialObjectToImageRegistrationMethod<ObjectDimension, TImage>
     default:
     case IMAGE_INTENSITY_METRIC:
         {
-        typedef PointBasedSpatialObjectToImageMetric<ObjectDimension, TImage>
-          TypedMetricType;
+        using TypedMetricType = PointBasedSpatialObjectToImageMetric<ObjectDimension, TImage>;
 
         typename TypedMetricType::Pointer typedMetric = TypedMetricType::New();
         typedMetric->SetSamplingRatio( m_SamplingRatio );
@@ -232,7 +231,7 @@ OptimizedSpatialObjectToImageRegistrationMethod<ObjectDimension, TImage>
   catch( itk::ExceptionObject& exception )
     {
     std::cerr << "Optimization threw an exception." << std::endl;
-    std::cerr << exception << std::endl ;
+    std::cerr << exception << std::endl;
     }
 
   if( this->GetReportProgress() )
@@ -255,7 +254,7 @@ OptimizedSpatialObjectToImageRegistrationMethod<ObjectDimension, TImage>
         std::cout << "EVOLUTIONARY START" << std::endl;
         }
   
-      typedef OnePlusOneEvolutionaryOptimizer EvoOptimizerType;
+      using EvoOptimizerType = OnePlusOneEvolutionaryOptimizer;
       EvoOptimizerType::Pointer evoOpt = EvoOptimizerType::New();
   
       evoOpt->SetNormalVariateGenerator( Statistics::NormalVariateGenerator
@@ -274,7 +273,7 @@ OptimizedSpatialObjectToImageRegistrationMethod<ObjectDimension, TImage>
   
       if( this->GetReportProgress() )
         {
-        typedef SpatialObjectToImageRegistrationViewer ViewerCommandType;
+        using ViewerCommandType = SpatialObjectToImageRegistrationViewer;
         typename ViewerCommandType::Pointer command = ViewerCommandType::New();
         if( this->GetTransform()->GetNumberOfParameters() > 16 )
           {
@@ -342,7 +341,7 @@ OptimizedSpatialObjectToImageRegistrationMethod<ObjectDimension, TImage>
       std::cout << "GRADIENT START" << std::endl;
       }
   
-    typedef FRPROptimizer GradOptimizerType;
+    using GradOptimizerType = FRPROptimizer;
     GradOptimizerType::Pointer gradOpt = GradOptimizerType::New();
   
     gradOpt->SetCatchGetValueException( true );
@@ -357,7 +356,7 @@ OptimizedSpatialObjectToImageRegistrationMethod<ObjectDimension, TImage>
   
     //if( this->GetReportProgress() )
       {
-      typedef SpatialObjectToImageRegistrationViewer ViewerCommandType;
+      using ViewerCommandType = SpatialObjectToImageRegistrationViewer;
       typename ViewerCommandType::Pointer command = ViewerCommandType::New();
       if( this->GetTransform()->GetNumberOfParameters() > 16 )
         {

--- a/src/Registration/itktubePointBasedSpatialObjectToImageMetric.h
+++ b/src/Registration/itktubePointBasedSpatialObjectToImageMetric.h
@@ -53,57 +53,54 @@ class PointBasedSpatialObjectToImageMetric
   : public SpatialObjectToImageMetric< ObjectDimension, TFixedImage >
 {
 public:
-  /** Standard class typedefs. */
-  typedef PointBasedSpatialObjectToImageMetric     Self;
-  typedef SpatialObjectToImageMetric< ObjectDimension, TFixedImage >
-                                                   Superclass;
-  typedef SmartPointer< Self >                     Pointer;
-  typedef SmartPointer< const Self >               ConstPointer;
+  /** Standard class type alias. */
+  using Self = PointBasedSpatialObjectToImageMetric;
+  using Superclass = SpatialObjectToImageMetric< ObjectDimension, TFixedImage >;
+  using Pointer = SmartPointer< Self >;
+  using ConstPointer = SmartPointer< const Self >;
 
   /**  Dimension of the image and tube.  */
   itkStaticConstMacro( ImageDimension, unsigned int,
     TFixedImage::ImageDimension );
 
-  typedef TFixedImage                              FixedImageType;
-  typedef SpatialObject< ObjectDimension >         MovingSpatialObjectType;
+  using FixedImageType = TFixedImage;
+  using MovingSpatialObjectType = SpatialObject< ObjectDimension >;
 
   /**  Type of the Transform Base class */
-  typedef typename Superclass::TransformType       TransformType;
-  typedef typename TransformType::Pointer          TransformPointer;
-  typedef typename TransformType::ParametersType   TransformParametersType;
-  typedef typename TransformType::JacobianType     TransformJacobianType;
+  using TransformType = typename Superclass::TransformType;
+  using TransformPointer = typename TransformType::Pointer;
+  using TransformParametersType = typename TransformType::ParametersType;
+  using TransformJacobianType = typename TransformType::JacobianType;
 
-  typedef typename Superclass::MovingPointType     MovingPointType;
-  typedef typename Superclass::FixedPointType      FixedPointType;
+  using MovingPointType = typename Superclass::MovingPointType;
+  using FixedPointType = typename Superclass::FixedPointType;
 
-  typedef PointBasedSpatialObject< ObjectDimension >
-                                                   PointBasedSpatialObjectType;
+  using PointBasedSpatialObjectType = PointBasedSpatialObject< ObjectDimension >;
   typedef typename PointBasedSpatialObjectType::SpatialObjectPointType
                                                    PointBasedSpatialObjectPointType;
 
-  typedef PointBasedSpatialObject< ObjectDimension >
-                                                   BlobType;
+  using BlobType = PointBasedSpatialObject< ObjectDimension >;
   typedef typename BlobType::SpatialObjectPointType
                                                    BlobPointType;
   typedef typename BlobType::SpatialObjectPointListType
                                                    BlobPointListType;
-  typedef std::vector< double >                    BlobPointWeightListType;
+  using BlobPointWeightListType = std::vector< double >;
 
-  typedef TubeSpatialObject< ObjectDimension >     TubeType;
-  typedef typename TubeType::TubePointType         TubePointType;
-  typedef typename TubeType::TubePointListType     TubePointListType;
-  typedef std::vector< double >                    TubePointWeightListType;
+  using TubeType = TubeSpatialObject< ObjectDimension >;
+  using TubePointType = typename TubeType::TubePointType;
+  using TubePointListType = typename TubeType::TubePointListType;
+  using TubePointWeightListType = std::vector< double >;
 
-  typedef SurfaceSpatialObject< ObjectDimension >    SurfaceType;
-  typedef typename SurfaceType::SurfacePointType     SurfacePointType;
-  typedef typename SurfaceType::SurfacePointListType SurfacePointListType;
-  typedef std::vector< double >                      SurfacePointWeightListType;
+  using SurfaceType = SurfaceSpatialObject< ObjectDimension >;
+  using SurfacePointType = typename SurfaceType::SurfacePointType;
+  using SurfacePointListType = typename SurfaceType::SurfacePointListType;
+  using SurfacePointWeightListType = std::vector< double >;
 
-  typedef typename Superclass::ParametersType      ParametersType;
-  typedef typename Superclass::MeasureType         MeasureType;
-  typedef typename Superclass::FixedVectorType     FixedVectorType;
-  typedef typename Superclass::MovingVectorType    MovingVectorType;
-  typedef typename Superclass::DerivativeType      DerivativeType;
+  using ParametersType = typename Superclass::ParametersType;
+  using MeasureType = typename Superclass::MeasureType;
+  using FixedVectorType = typename Superclass::FixedVectorType;
+  using MovingVectorType = typename Superclass::MovingVectorType;
+  using DerivativeType = typename Superclass::DerivativeType;
 
   /** Run-time type information ( and related methods ). */
   itkTypeMacro( PointBasedSpatialObjectToImageMetric,

--- a/src/Registration/itktubePointBasedSpatialObjectToImageMetric.hxx
+++ b/src/Registration/itktubePointBasedSpatialObjectToImageMetric.hxx
@@ -479,7 +479,7 @@ typename PointBasedSpatialObjectToImageMetric< ObjectDimension, TFixedImage >::M
 PointBasedSpatialObjectToImageMetric< ObjectDimension, TFixedImage >
 ::GetValue( const ParametersType & parameters ) const
 {
-  typedef vnl_vector_fixed<double, ImageDimension> VnlVectorType;
+  using VnlVectorType = vnl_vector_fixed<double, ImageDimension>;
 
   itkDebugMacro( << "**** Get Value ****" );
   itkDebugMacro( << "Parameters = " << parameters );
@@ -573,8 +573,8 @@ void
 PointBasedSpatialObjectToImageMetric< ObjectDimension, TFixedImage >
 ::GetValueAndDerivative( const ParametersType & parameters, MeasureType & value, DerivativeType & derivative ) const
 {
-  typedef vnl_matrix_fixed<double, ImageDimension, ImageDimension> VnlMatrixType;
-  typedef vnl_vector_fixed<double, ImageDimension> VnlVectorType;
+  using VnlMatrixType = vnl_matrix_fixed<double, ImageDimension, ImageDimension>;
+  using VnlVectorType = vnl_vector_fixed<double, ImageDimension>;
 
   itkDebugMacro( << "**** Get Derivative ****" );
   itkDebugMacro( << "Parameters = " << parameters );

--- a/src/Registration/itktubePointBasedSpatialObjectTransformFilter.h
+++ b/src/Registration/itktubePointBasedSpatialObjectTransformFilter.h
@@ -68,25 +68,24 @@ class PointBasedSpatialObjectTransformFilter :
 {
 public:
 
-  typedef TTransformType                                TransformType;
+  using TransformType = TTransformType;
 
-  typedef SpatialObject< TDimension >                   SpatialObjectType;
+  using SpatialObjectType = SpatialObject< TDimension >;
 
-  /** Standard class typedefs. */
-  typedef PointBasedSpatialObjectTransformFilter< TTransformType, TDimension >
-    Self;
+  /** Standard class type alias. */
+  using Self = PointBasedSpatialObjectTransformFilter< TTransformType, TDimension >;
 
-  typedef SpatialObjectFilter< TDimension >                  Superclass;
+  using Superclass = SpatialObjectFilter< TDimension >;
 
-  typedef SmartPointer< Self >                               Pointer;
-  typedef SmartPointer< const Self >                         ConstPointer;
+  using Pointer = SmartPointer< Self >;
+  using ConstPointer = SmartPointer< const Self >;
 
-  typedef PointBasedSpatialObject< TDimension >              PointBasedType;
-  typedef TubeSpatialObject< TDimension >                    TubeType;
-  typedef SurfaceSpatialObject< TDimension >                 SurfaceType;
-  typedef LineSpatialObject< TDimension >                    LineType;
-  typedef DTITubeSpatialObject< TDimension >                 DTITubeType;
-  typedef ContourSpatialObject< TDimension >                 ContourType;
+  using PointBasedType = PointBasedSpatialObject< TDimension >;
+  using TubeType = TubeSpatialObject< TDimension >;
+  using SurfaceType = SurfaceSpatialObject< TDimension >;
+  using LineType = LineSpatialObject< TDimension >;
+  using DTITubeType = DTITubeSpatialObject< TDimension >;
+  using ContourType = ContourSpatialObject< TDimension >;
 
   typedef typename SpatialObject< TDimension >::TransformType
     SpatialObjectTransformType;

--- a/src/Registration/itktubePointBasedSpatialObjectTransformFilter.hxx
+++ b/src/Registration/itktubePointBasedSpatialObjectTransformFilter.hxx
@@ -167,7 +167,7 @@ PointBasedSpatialObjectTransformFilter< TTransformType, TDimension >
     outputSO->SetObjectToParentTransform( tfm );
     }
 
-  typedef typename PointBasedType::SpatialObjectPointListType SpatialObjectPointListType;
+  using SpatialObjectPointListType = typename PointBasedType::SpatialObjectPointListType;
   SpatialObjectPointListType pointBasedPointList = inputSO->GetPoints();
   typename SpatialObjectPointListType::const_iterator pointBasedPointIterator =
     pointBasedPointList.begin();
@@ -213,7 +213,7 @@ PointBasedSpatialObjectTransformFilter< TTransformType, TDimension >
     outputSO->SetObjectToParentTransform( tfm );
     }
 
-  typedef typename TubeType::TubePointListType      TubePointListType;
+  using TubePointListType = typename TubeType::TubePointListType;
   TubePointListType tubePointList = inputSO->GetPoints();
   typename TubePointListType::const_iterator tubePointIterator =
     tubePointList.begin();
@@ -301,7 +301,7 @@ PointBasedSpatialObjectTransformFilter< TTransformType, TDimension >
     outputSO->SetObjectToParentTransform( tfm );
     }
 
-  typedef typename SurfaceType::SurfacePointListType SurfacePointListType;
+  using SurfacePointListType = typename SurfaceType::SurfacePointListType;
   SurfacePointListType surfacePointList = inputSO->GetPoints();
   typename SurfacePointListType::const_iterator surfacePointIterator =
     surfacePointList.begin();

--- a/src/Registration/itktubeRigidSpatialObjectToImageRegistrationMethod.h
+++ b/src/Registration/itktubeRigidSpatialObjectToImageRegistrationMethod.h
@@ -43,10 +43,10 @@ class RigidSpatialObjectToImageRegistrationMethod
 
 public:
 
-  typedef RigidSpatialObjectToImageRegistrationMethod             Self;
-  typedef OptimizedSpatialObjectToImageRegistrationMethod<ObjectDimension, TImage> Superclass;
-  typedef SmartPointer<Self>                              Pointer;
-  typedef SmartPointer<const Self>                        ConstPointer;
+  using Self = RigidSpatialObjectToImageRegistrationMethod;
+  using Superclass = OptimizedSpatialObjectToImageRegistrationMethod<ObjectDimension, TImage>;
+  using Pointer = SmartPointer<Self>;
+  using ConstPointer = SmartPointer<const Self>;
 
   itkTypeMacro( RigidSpatialObjectToImageRegistrationMethod,
                 OptimizedSpatialObjectToImageRegistrationMethod );
@@ -63,23 +63,21 @@ public:
   // Overrides the superclass' TransformType typedef
   // We must use MatrixOffsetTransformBase since no itk rigid transform is
   //   templated over ImageDimension.
-  typedef MatrixOffsetTransformBase<double,
+  using RigidTransformType = MatrixOffsetTransformBase<double,
                                     itkGetStaticConstMacro( ImageDimension ),
-                                    itkGetStaticConstMacro( ImageDimension )>
-  RigidTransformType;
-  typedef RigidTransformType TransformType;
+                                    itkGetStaticConstMacro( ImageDimension )>;
+  using TransformType = RigidTransformType;
 
   //
   //  Custom Typedefs
   //
-  typedef Rigid2DTransform<double>       Rigid2DTransformType;
-  typedef VersorRigid3DTransform<double> Rigid3DTransformType;
+  using Rigid2DTransformType = Rigid2DTransform<double>;
+  using Rigid3DTransformType = VersorRigid3DTransform<double>;
 
-  typedef AffineTransform<double,
-                          itkGetStaticConstMacro( ImageDimension )>
-  AffineTransformType;
+  using AffineTransformType = AffineTransform<double,
+                          itkGetStaticConstMacro( ImageDimension )>;
 
-  typedef typename AffineTransformType::Pointer AffineTransformPointer;
+  using AffineTransformPointer = typename AffineTransformType::Pointer;
 
   //
   //  Superclass Methods

--- a/src/Registration/itktubeRigidSpatialObjectToImageRegistrationMethod.hxx
+++ b/src/Registration/itktubeRigidSpatialObjectToImageRegistrationMethod.hxx
@@ -144,7 +144,7 @@ RigidSpatialObjectToImageRegistrationMethod<ObjectDimension, TImage>
   rigidTransform->SetCenter( affine->GetCenter() );
   rigidTransform->SetTranslation( affine->GetTranslation() );
 
-  typedef vnl_matrix<double> VnlMatrixType;
+  using VnlMatrixType = vnl_matrix<double>;
 
   VnlMatrixType M = affine->GetMatrix().GetVnlMatrix();
 

--- a/src/Registration/itktubeScaleSkewAngle2DSpatialObjectToImageRegistrationMethod.h
+++ b/src/Registration/itktubeScaleSkewAngle2DSpatialObjectToImageRegistrationMethod.h
@@ -42,11 +42,11 @@ class ScaleSkewAngle2DSpatialObjectToImageRegistrationMethod
 
 public:
 
-  typedef ScaleSkewAngle2DSpatialObjectToImageRegistrationMethod  Self;
-  typedef OptimizedSpatialObjectToImageRegistrationMethod< 
-    2, Image< typename TImage::PixelType, 2 > >           Superclass;
-  typedef SmartPointer<Self>                              Pointer;
-  typedef SmartPointer<const Self>                        ConstPointer;
+  using Self = ScaleSkewAngle2DSpatialObjectToImageRegistrationMethod;
+  using Superclass = OptimizedSpatialObjectToImageRegistrationMethod< 
+    2, Image< typename TImage::PixelType, 2 > >;
+  using Pointer = SmartPointer<Self>;
+  using ConstPointer = SmartPointer<const Self>;
 
   itkTypeMacro( ScaleSkewAngle2DSpatialObjectToImageRegistrationMethod,
                 OptimizedSpatialObjectToImageRegistrationMethod );
@@ -61,15 +61,13 @@ public:
   //
 
   // Overrides the superclass' TransformType typedef
-  typedef ::itk::ScaleSkewAngle2DTransform< double >
-            ScaleSkewAngle2DTransformType;
+  using ScaleSkewAngle2DTransformType = ::itk::ScaleSkewAngle2DTransform< double >;
   typedef typename ScaleSkewAngle2DTransformType::Pointer
             ScaleSkewAngle2DTransformPointer;
   typedef ScaleSkewAngle2DTransformType
             TransformType;
 
-  typedef AffineTransform<double, 2>
-            AffineTransformType;
+  using AffineTransformType = AffineTransform<double, 2>;
   typedef typename AffineTransformType::Pointer
             AffineTransformPointer;
 

--- a/src/Registration/itktubeScaleSkewVersor3DSpatialObjectToImageRegistrationMethod.h
+++ b/src/Registration/itktubeScaleSkewVersor3DSpatialObjectToImageRegistrationMethod.h
@@ -42,11 +42,11 @@ class ScaleSkewVersor3DSpatialObjectToImageRegistrationMethod
 
 public:
 
-  typedef ScaleSkewVersor3DSpatialObjectToImageRegistrationMethod Self;
-  typedef OptimizedSpatialObjectToImageRegistrationMethod<
-    3, Image< typename TImage::PixelType, 3 > >           Superclass;
-  typedef SmartPointer<Self>                              Pointer;
-  typedef SmartPointer<const Self>                        ConstPointer;
+  using Self = ScaleSkewVersor3DSpatialObjectToImageRegistrationMethod;
+  using Superclass = OptimizedSpatialObjectToImageRegistrationMethod<
+    3, Image< typename TImage::PixelType, 3 > >;
+  using Pointer = SmartPointer<Self>;
+  using ConstPointer = SmartPointer<const Self>;
 
   itkTypeMacro( ScaleSkewVersor3DSpatialObjectToImageRegistrationMethod,
                 OptimizedSpatialObjectToImageRegistrationMethod );
@@ -60,15 +60,13 @@ public:
   // Typedefs from Superclass
   // 
   // Overrides the superclass' TransformType typedef
-  typedef ::itk::ComposeScaleSkewVersor3DTransform< double >
-            ScaleSkewVersor3DTransformType;
+  using ScaleSkewVersor3DTransformType = ::itk::ComposeScaleSkewVersor3DTransform< double >;
   typedef typename ScaleSkewVersor3DTransformType::Pointer
             ScaleSkewVersor3DTransformPointer;
   typedef ScaleSkewVersor3DTransformType
             TransformType;
 
-  typedef AffineTransform<double, 3>
-            AffineTransformType;
+  using AffineTransformType = AffineTransform<double, 3>;
   typedef typename AffineTransformType::Pointer
             AffineTransformPointer;
 

--- a/src/Registration/itktubeSpatialObjectToImageMetric.h
+++ b/src/Registration/itktubeSpatialObjectToImageMetric.h
@@ -89,10 +89,9 @@ public:
   /** Image dimension enumeration. */
   static constexpr unsigned int ImageDimension = FixedImageType::ImageDimension;
 
-  typedef SpatialObject<itkGetStaticConstMacro( ImageDimension )>
-  ImageMaskObjectType;
+  using ImageMaskObjectType = SpatialObject<itkGetStaticConstMacro( ImageDimension )>;
 
-  typedef SpatialObject< ObjectDimension > SpatialObjectMaskObjectType;
+  using SpatialObjectMaskObjectType = SpatialObject< ObjectDimension >;
 
   /**  Type of the Transform Base class */
   using TransformType = Transform<CoordinateRepresentationType,

--- a/src/Registration/itktubeSpatialObjectToImageRegistrationHelper.h
+++ b/src/Registration/itktubeSpatialObjectToImageRegistrationHelper.h
@@ -46,10 +46,10 @@ class SpatialObjectToImageRegistrationHelper : public Object
 
 public:
 
-  typedef SpatialObjectToImageRegistrationHelper Self;
-  typedef Object                                 Superclass;
-  typedef SmartPointer<Self>                     Pointer;
-  typedef SmartPointer<const Self>               ConstPointer;
+  using Self = SpatialObjectToImageRegistrationHelper;
+  using Superclass = Object;
+  using Pointer = SmartPointer<Self>;
+  using ConstPointer = SmartPointer<const Self>;
 
   itkTypeMacro( SpatialObjectToImageRegistrationHelper, Object );
 
@@ -58,10 +58,10 @@ public:
   //
   // Custom Typedefs
   //
-  typedef TImage ImageType;
-  typedef typename TImage::PixelType PixelType;
+  using ImageType = TImage;
+  using PixelType = typename TImage::PixelType;
 
-  typedef SpatialObject< ObjectDimension > SpatialObjectType;
+  using SpatialObjectType = SpatialObject< ObjectDimension >;
 
   itkStaticConstMacro( ImageDimension, unsigned int,
                        TImage::ImageDimension );
@@ -69,26 +69,20 @@ public:
   //
   // Available Registration Methods
   //
-  typedef SpatialObjectToImageRegistrationMethod<ObjectDimension, TImage>
-    RegistrationMethodType;
+  using RegistrationMethodType = SpatialObjectToImageRegistrationMethod<ObjectDimension, TImage>;
 
-  typedef InitialSpatialObjectToImageRegistrationMethod<ObjectDimension, TImage>
-    InitialRegistrationMethodType;
+  using InitialRegistrationMethodType = InitialSpatialObjectToImageRegistrationMethod<ObjectDimension, TImage>;
 
-  typedef OptimizedSpatialObjectToImageRegistrationMethod<ObjectDimension,
-    TImage> OptimizedRegistrationMethodType;
+  using OptimizedRegistrationMethodType = OptimizedSpatialObjectToImageRegistrationMethod<ObjectDimension,
+    TImage>;
 
-  typedef RigidSpatialObjectToImageRegistrationMethod<ObjectDimension, TImage>
-    RigidRegistrationMethodType;
+  using RigidRegistrationMethodType = RigidSpatialObjectToImageRegistrationMethod<ObjectDimension, TImage>;
 
-  typedef AffineSpatialObjectToImageRegistrationMethod<ObjectDimension, TImage>
-    AffineRegistrationMethodType;
+  using AffineRegistrationMethodType = AffineSpatialObjectToImageRegistrationMethod<ObjectDimension, TImage>;
 
-  typedef ScaleSkewAngle2DSpatialObjectToImageRegistrationMethod<TImage>
-    Affine2DRegistrationMethodType;
+  using Affine2DRegistrationMethodType = ScaleSkewAngle2DSpatialObjectToImageRegistrationMethod<TImage>;
 
-  typedef ScaleSkewVersor3DSpatialObjectToImageRegistrationMethod<TImage>
-    Affine3DRegistrationMethodType;
+  using Affine3DRegistrationMethodType = ScaleSkewVersor3DSpatialObjectToImageRegistrationMethod<TImage>;
 
   //
   // Typedefs for the parameters of the registration methods
@@ -124,9 +118,9 @@ public:
   typedef typename InitialRegistrationMethodType::TransformType
     InitialTransformType;
 
-  typedef std::vector<std::vector<float>  > LandmarkVectorType;
+  using LandmarkVectorType = std::vector<std::vector<float>  >;
 
-  typedef typename TImage::PointType PointType;
+  using PointType = typename TImage::PointType;
 
   typedef typename RigidRegistrationMethodType::TransformType
     RigidTransformType;
@@ -140,7 +134,7 @@ public:
   typedef typename Affine3DRegistrationMethodType::TransformType
     Affine3DTransformType;
 
-  typedef AffineTransformType MatrixTransformType;
+  using MatrixTransformType = AffineTransformType;
 
   //
   // Custom Methods

--- a/src/Registration/itktubeSpatialObjectToImageRegistrationHelper.hxx
+++ b/src/Registration/itktubeSpatialObjectToImageRegistrationHelper.hxx
@@ -84,7 +84,7 @@ SpatialObjectToImageRegistrationHelper<ObjectDimension, TImage>
   m_ReportProgress = false;
 
   // Optimizer
-  m_UseEvolutionaryOptimization = true ;
+  m_UseEvolutionaryOptimization = true;
 
   // Loaded
   m_LoadedMatrixTransform = NULL;
@@ -680,8 +680,8 @@ SpatialObjectToImageRegistrationHelper<ObjectDimension, TImage>
 ::ResampleSpatialObject( const SpatialObjectType * movingSpatialObject,
                  const MatrixTransformType * matrixTransform, double portion)
 {
-  typedef PointBasedSpatialObjectTransformFilter<MatrixTransformType,
-    ObjectDimension> ResampleFilterType;
+  using ResampleFilterType = PointBasedSpatialObjectTransformFilter<MatrixTransformType,
+    ObjectDimension>;
 
   if( movingSpatialObject == NULL
       && matrixTransform == NULL
@@ -799,8 +799,8 @@ void
 SpatialObjectToImageRegistrationHelper<ObjectDimension, TImage>
 ::LoadTransform( const std::string & filename, bool invert )
 {
-  typedef TransformFileReader                    TransformReaderType;
-  typedef TransformReaderType::TransformListType TransformListType;
+  using TransformReaderType = TransformFileReader;
+  using TransformListType = TransformReaderType::TransformListType;
 
   TransformReaderType::Pointer transformReader = TransformReaderType::New();
   transformReader->SetFileName( filename );
@@ -829,7 +829,7 @@ void
 SpatialObjectToImageRegistrationHelper<ObjectDimension, TImage>
 ::SaveTransform( const std::string & filename )
 {
-  typedef TransformFileWriter TransformWriterType;
+  using TransformWriterType = TransformFileWriter;
 
   TransformWriterType::Pointer transformWriter = TransformWriterType::New();
   transformWriter->SetFileName( filename );

--- a/src/Registration/itktubeSpatialObjectToImageRegistrationMethod.h
+++ b/src/Registration/itktubeSpatialObjectToImageRegistrationMethod.h
@@ -51,10 +51,10 @@ class SpatialObjectToImageRegistrationMethod
 
 public:
 
-  typedef SpatialObjectToImageRegistrationMethod Self;
-  typedef ProcessObject                  Superclass;
-  typedef SmartPointer<Self>             Pointer;
-  typedef SmartPointer<const Self>       ConstPointer;
+  using Self = SpatialObjectToImageRegistrationMethod;
+  using Superclass = ProcessObject;
+  using Pointer = SmartPointer<Self>;
+  using ConstPointer = SmartPointer<const Self>;
 
   itkTypeMacro( SpatialObjectToImageRegistrationMethod, ProcessObject );
 
@@ -66,25 +66,23 @@ public:
   itkStaticConstMacro( ImageDimension, unsigned int,
                        TImage::ImageDimension );
 
-  typedef Transform<double, ObjectDimension,
-          itkGetStaticConstMacro( ImageDimension )>  TransformType;
+  using TransformType = Transform<double, ObjectDimension,
+          itkGetStaticConstMacro( ImageDimension )>;
 
-  typedef DataObjectDecorator<TransformType>         TransformOutputType;
+  using TransformOutputType = DataObjectDecorator<TransformType>;
 
-  typedef typename DataObject::Pointer               DataObjectPointer;
-  typedef Superclass::DataObjectPointerArraySizeType DataObjectPointerArraySizeType;
+  using DataObjectPointer = typename DataObject::Pointer;
+  using DataObjectPointerArraySizeType = Superclass::DataObjectPointerArraySizeType;
 
-  typedef SpatialObject<ObjectDimension>             SpatialObjectType;
-  typedef TImage                                     ImageType;
+  using SpatialObjectType = SpatialObject<ObjectDimension>;
+  using ImageType = TImage;
 
-  typedef typename SpatialObjectType::PointType      SpatialObjectPointType;
-  typedef typename ImageType::PointType              PointType;
+  using SpatialObjectPointType = typename SpatialObjectType::PointType;
+  using PointType = typename ImageType::PointType;
 
-  typedef SpatialObject<itkGetStaticConstMacro( ImageDimension )>
-                                                     ImageMaskObjectType;
+  using ImageMaskObjectType = SpatialObject<itkGetStaticConstMacro( ImageDimension )>;
 
-  typedef SpatialObject< ObjectDimension >
-                                                     SpatialObjectMaskObjectType;
+  using SpatialObjectMaskObjectType = SpatialObject< ObjectDimension >;
 
   //
   // Custom Methods

--- a/src/Segmentation/itktubeComputeTrainingMaskFilter.h
+++ b/src/Segmentation/itktubeComputeTrainingMaskFilter.h
@@ -52,12 +52,12 @@ class ComputeTrainingMaskFilter:
     TLabelMap >
 {
 public:
-  typedef ComputeTrainingMaskFilter                       Self;
-  typedef ImageToImageFilter<TInputImage, TLabelMap>      Superclass;
-  typedef SmartPointer<Self>                              Pointer;
-  typedef SmartPointer<const Self>                        ConstPointer;
-  typedef TInputImage                                     ImageType;
-  typedef TLabelMap                                       LabelMapType;
+  using Self = ComputeTrainingMaskFilter;
+  using Superclass = ImageToImageFilter<TInputImage, TLabelMap>;
+  using Pointer = SmartPointer<Self>;
+  using ConstPointer = SmartPointer<const Self>;
+  using ImageType = TInputImage;
+  using LabelMapType = TLabelMap;
 
   itkStaticConstMacro( InputImageDimension, unsigned int,
                       TInputImage::ImageDimension );
@@ -81,22 +81,16 @@ protected:
   void PrintSelf( std::ostream & os, Indent indent ) const override;
 
 private:
-  typedef itk::BinaryBallStructuringElement< short,
-    ImageType::ImageDimension > BallType;
-  typedef itk::DilateObjectMorphologyImageFilter< ImageType, ImageType,
-    BallType >                  DilateFilterType;
-  typedef itk::BinaryThinningImageFilter< ImageType, ImageType >
-                                BinaryThinningFilterType;
-  typedef itk::BinaryThresholdImageFilter< ImageType, ImageType >
-                                ThresholdFilterType;
-  typedef itk::SubtractImageFilter<ImageType, ImageType, ImageType>
-                                SubtractFilterType;
-  typedef itk::MultiplyImageFilter<ImageType, ImageType, ImageType>
-                                MultiplyFilterType;
-  typedef itk::AddImageFilter<ImageType, ImageType, ImageType>
-                                AddFilterType;
-  typedef itk::CastImageFilter< ImageType, LabelMapType >
-                                CastFilterType;
+  using BallType = itk::BinaryBallStructuringElement< short,
+    ImageType::ImageDimension >;
+  using DilateFilterType = itk::DilateObjectMorphologyImageFilter< ImageType, ImageType,
+    BallType >;
+  using BinaryThinningFilterType = itk::BinaryThinningImageFilter< ImageType, ImageType >;
+  using ThresholdFilterType = itk::BinaryThresholdImageFilter< ImageType, ImageType >;
+  using SubtractFilterType = itk::SubtractImageFilter<ImageType, ImageType, ImageType>;
+  using MultiplyFilterType = itk::MultiplyImageFilter<ImageType, ImageType, ImageType>;
+  using AddFilterType = itk::AddImageFilter<ImageType, ImageType, ImageType>;
+  using CastFilterType = itk::CastImageFilter< ImageType, LabelMapType >;
 
   ComputeTrainingMaskFilter( const Self& );
   void operator=( const Self& );

--- a/src/Segmentation/itktubePDFSegmenterBase.h
+++ b/src/Segmentation/itktubePDFSegmenterBase.h
@@ -41,10 +41,10 @@ class PDFSegmenterBase : public ProcessObject
 {
 public:
 
-  typedef PDFSegmenterBase                     Self;
-  typedef ProcessObject                        Superclass;
-  typedef SmartPointer< Self >                 Pointer;
-  typedef SmartPointer< const Self >           ConstPointer;
+  using Self = PDFSegmenterBase;
+  using Superclass = ProcessObject;
+  using Pointer = SmartPointer< Self >;
+  using ConstPointer = SmartPointer< const Self >;
 
   itkTypeMacro( PDFSegmenterBase, ProcessObject );
 
@@ -53,9 +53,9 @@ public:
   //
   // Template Args Typedefs
   //
-  typedef TImage                               InputImageType;
+  using InputImageType = TImage;
 
-  typedef TLabelMap                            LabelMapType;
+  using LabelMapType = TLabelMap;
 
   itkStaticConstMacro( ImageDimension, unsigned int,
     TImage::ImageDimension );
@@ -63,8 +63,7 @@ public:
   //
   // Base Typedefs
   //
-  typedef FeatureVectorGenerator< InputImageType >
-                                               FeatureVectorGeneratorType;
+  using FeatureVectorGeneratorType = FeatureVectorGenerator< InputImageType >;
   typedef typename FeatureVectorGeneratorType::FeatureValueType
                                                FeatureValueType;
   typedef typename FeatureVectorGeneratorType::FeatureVectorType
@@ -72,19 +71,18 @@ public:
   typedef typename FeatureVectorGeneratorType::FeatureImageType
                                                FeatureImageType;
 
-  typedef typename LabelMapType::PixelType     LabelMapPixelType;
+  using LabelMapPixelType = typename LabelMapType::PixelType;
 
-  typedef LabelMapPixelType                    ObjectIdType;
-  typedef std::vector< ObjectIdType >          ObjectIdListType;
+  using ObjectIdType = LabelMapPixelType;
+  using ObjectIdListType = std::vector< ObjectIdType >;
 
-  typedef float                                ProbabilityPixelType;
-  typedef std::vector< ProbabilityPixelType >  ProbabilityVectorType;
-  typedef Image< ProbabilityPixelType, TImage::ImageDimension >
-                                               ProbabilityImageType;
+  using ProbabilityPixelType = float;
+  using ProbabilityVectorType = std::vector< ProbabilityPixelType >;
+  using ProbabilityImageType = Image< ProbabilityPixelType, TImage::ImageDimension >;
 
-  typedef std::vector< double >                VectorDoubleType;
-  typedef std::vector< int >                   VectorIntType;
-  typedef std::vector< unsigned int >          VectorUIntType;
+  using VectorDoubleType = std::vector< double >;
+  using VectorIntType = std::vector< int >;
+  using VectorUIntType = std::vector< unsigned int >;
 
   //
   // Methods
@@ -186,11 +184,10 @@ protected:
 
   void PrintSelf( std::ostream & os, Indent indent ) const override;
 
-  typedef std::vector< typename ProbabilityImageType::Pointer >
-                                              ProbabilityImageVectorType;
-  typedef std::vector< ProbabilityPixelType > ListVectorType;
-  typedef std::vector< ListVectorType >       ListSampleType;
-  typedef std::vector< ListSampleType >       ClassListSampleType;
+  using ProbabilityImageVectorType = std::vector< typename ProbabilityImageType::Pointer >;
+  using ListVectorType = std::vector< ProbabilityPixelType >;
+  using ListSampleType = std::vector< ListVectorType >;
+  using ClassListSampleType = std::vector< ListSampleType >;
 
   ClassListSampleType                           m_InClassList;
   ListSampleType                                m_OutClassList;

--- a/src/Segmentation/itktubePDFSegmenterBase.hxx
+++ b/src/Segmentation/itktubePDFSegmenterBase.hxx
@@ -287,8 +287,7 @@ PDFSegmenterBase< TImage, TLabelMap >
     }
   m_OutClassList.clear();
 
-  typedef itk::ImageRegionConstIteratorWithIndex< LabelMapType >
-    ConstLabelMapIteratorType;
+  using ConstLabelMapIteratorType = itk::ImageRegionConstIteratorWithIndex< LabelMapType >;
   ConstLabelMapIteratorType itInLabelMap( m_InputLabelMap,
     m_InputLabelMap->GetLargestPossibleRegion() );
   itInLabelMap.GoToBegin();
@@ -431,8 +430,7 @@ PDFSegmenterBase< TImage, TLabelMap >
   //
   m_ProbabilityImageVector.resize( numClasses );
 
-  typedef itk::ImageRegionIterator<ProbabilityImageType>
-    ProbabilityImageIteratorType;
+  using ProbabilityImageIteratorType = itk::ImageRegionIterator<ProbabilityImageType>;
   std::vector< ProbabilityImageIteratorType * > probIt( numClasses );
 
   for( unsigned int c = 0; c < numClasses; c++ )
@@ -461,8 +459,7 @@ PDFSegmenterBase< TImage, TLabelMap >
     m_ForceClassification = true;
     }
 
-  typedef itk::ImageRegionConstIteratorWithIndex< LabelMapType >
-    ConstLabelMapIteratorType;
+  using ConstLabelMapIteratorType = itk::ImageRegionConstIteratorWithIndex< LabelMapType >;
   ConstLabelMapIteratorType itInLabelMap( m_InputLabelMap,
     m_InputLabelMap->GetLargestPossibleRegion() );
   itInLabelMap.GoToBegin();
@@ -503,12 +500,11 @@ PDFSegmenterBase< TImage, TLabelMap >
 
   if( m_ProbabilityImageSmoothingStandardDeviation > 0 )
     {
-    typedef itk::SmoothingRecursiveGaussianImageFilter<
-      ProbabilityImageType, ProbabilityImageType > ProbImageFilterType;
+    using ProbImageFilterType = itk::SmoothingRecursiveGaussianImageFilter<
+      ProbabilityImageType, ProbabilityImageType >;
     typename ProbImageFilterType::Pointer probImageFilter;
 
-    typedef itk::ThresholdImageFilter< ProbabilityImageType >
-      ThresholdProbImageFilterType;
+    using ThresholdProbImageFilterType = itk::ThresholdImageFilter< ProbabilityImageType >;
     typename ThresholdProbImageFilterType::Pointer
       thresholdProbImageFilter = ThresholdProbImageFilterType::New();
 
@@ -591,8 +587,8 @@ PDFSegmenterBase< TImage, TLabelMap >
         ++labelIt;
         }
 
-      typedef itk::ConnectedThresholdImageFilter<LabelMapType,
-        LabelMapType> ConnectedFilterType;
+      using ConnectedFilterType = itk::ConnectedThresholdImageFilter<LabelMapType,
+        LabelMapType>;
       typename ConnectedFilterType::Pointer insideConnecter =
         ConnectedFilterType::New();
 
@@ -685,8 +681,8 @@ PDFSegmenterBase< TImage, TLabelMap >
       //
       if( holeFillIterations > 0 )
         {
-        typedef itk::VotingBinaryIterativeHoleFillingImageFilter<
-          LabelMapType > HoleFillingFilterType;
+        using HoleFillingFilterType = itk::VotingBinaryIterativeHoleFillingImageFilter<
+          LabelMapType >;
 
         typename HoleFillingFilterType::Pointer holeFiller =
           HoleFillingFilterType::New();
@@ -705,12 +701,12 @@ PDFSegmenterBase< TImage, TLabelMap >
       //
       // Erode
       //
-      typedef BinaryBallStructuringElement< LabelMapPixelType,
-        InputImageType::ImageDimension >             StructuringElementType;
-      typedef BinaryErodeImageFilter< LabelMapType, LabelMapType,
-        StructuringElementType >                     ErodeFilterType;
-      typedef itk::BinaryDilateImageFilter< LabelMapType,
-        LabelMapType, StructuringElementType >       DilateFilterType;
+      using StructuringElementType = BinaryBallStructuringElement< LabelMapPixelType,
+        InputImageType::ImageDimension >;
+      using ErodeFilterType = BinaryErodeImageFilter< LabelMapType, LabelMapType,
+        StructuringElementType >;
+      using DilateFilterType = itk::BinaryDilateImageFilter< LabelMapType,
+        LabelMapType, StructuringElementType >;
 
       StructuringElementType sphereOp;
       if( erodeRadius > 0 )
@@ -745,8 +741,8 @@ PDFSegmenterBase< TImage, TLabelMap >
       //
       if( true ) // creating a local context to limit memory footprint
         {
-        typedef itk::ConnectedThresholdImageFilter<LabelMapType,
-          LabelMapType> ConnectedLabelMapFilterType;
+        using ConnectedLabelMapFilterType = itk::ConnectedThresholdImageFilter<LabelMapType,
+          LabelMapType>;
 
         typename ConnectedLabelMapFilterType::Pointer
           insideConnectedLabelMapFilter = ConnectedLabelMapFilterType::New();
@@ -803,8 +799,7 @@ PDFSegmenterBase< TImage, TLabelMap >
         }
 
       // Merge with input mask
-      typedef itk::ImageRegionIterator< LabelMapType >
-        LabelMapIteratorType;
+      using LabelMapIteratorType = itk::ImageRegionIterator< LabelMapType >;
       LabelMapIteratorType itOutLM( m_OutputLabelMap,
         m_OutputLabelMap->GetLargestPossibleRegion() );
       itOutLM.GoToBegin();
@@ -865,8 +860,7 @@ PDFSegmenterBase< TImage, TLabelMap >
   else
     {
     // Merge with input mask
-    typedef itk::ImageRegionIteratorWithIndex< LabelMapType >
-      LabelMapIteratorType;
+    using LabelMapIteratorType = itk::ImageRegionIteratorWithIndex< LabelMapType >;
     LabelMapIteratorType itOutLM( m_OutputLabelMap,
       m_OutputLabelMap->GetLargestPossibleRegion() );
     itOutLM.GoToBegin();

--- a/src/Segmentation/itktubePDFSegmenterParzen.h
+++ b/src/Segmentation/itktubePDFSegmenterParzen.h
@@ -43,10 +43,10 @@ class PDFSegmenterParzen : public PDFSegmenterBase< TImage, TLabelMap >
 {
 public:
 
-  typedef PDFSegmenterParzen                         Self;
-  typedef PDFSegmenterBase< TImage, TLabelMap >      Superclass;
-  typedef SmartPointer< Self >                       Pointer;
-  typedef SmartPointer< const Self >                 ConstPointer;
+  using Self = PDFSegmenterParzen;
+  using Superclass = PDFSegmenterBase< TImage, TLabelMap >;
+  using Pointer = SmartPointer< Self >;
+  using ConstPointer = SmartPointer< const Self >;
 
   itkTypeMacro( PDFSegmenterParzen, PDFSegmenterBase );
 
@@ -55,8 +55,8 @@ public:
   //
   // Template Args Typedefs
   //
-  typedef TImage                               InputImageType;
-  typedef TLabelMap                            LabelMapType;
+  using InputImageType = TImage;
+  using LabelMapType = TLabelMap;
 
   itkStaticConstMacro( ImageDimension, unsigned int,
     TImage::ImageDimension );
@@ -66,14 +66,14 @@ public:
   //
   typedef typename Superclass::FeatureVectorGeneratorType
                                                  FeatureVectorGeneratorType;
-  typedef typename Superclass::FeatureValueType  FeatureValueType;
-  typedef typename Superclass::FeatureVectorType FeatureVectorType;
-  typedef typename Superclass::FeatureImageType  FeatureImageType;
+  using FeatureValueType = typename Superclass::FeatureValueType;
+  using FeatureVectorType = typename Superclass::FeatureVectorType;
+  using FeatureImageType = typename Superclass::FeatureImageType;
 
-  typedef typename Superclass::LabelMapPixelType LabelMapPixelType;
+  using LabelMapPixelType = typename Superclass::LabelMapPixelType;
 
-  typedef typename Superclass::ObjectIdType      ObjectIdType;
-  typedef typename Superclass::ObjectIdListType  ObjectIdListType;
+  using ObjectIdType = typename Superclass::ObjectIdType;
+  using ObjectIdListType = typename Superclass::ObjectIdListType;
 
   typedef typename Superclass::ProbabilityPixelType
                                                  ProbabilityPixelType;
@@ -83,23 +83,21 @@ public:
   typedef typename Superclass::ProbabilityImageType
                                                  ProbabilityImageType;
 
-  typedef typename Superclass::VectorDoubleType  VectorDoubleType;
-  typedef typename Superclass::VectorIntType     VectorIntType;
-  typedef typename Superclass::VectorUIntType    VectorUIntType;
+  using VectorDoubleType = typename Superclass::VectorDoubleType;
+  using VectorIntType = typename Superclass::VectorIntType;
+  using VectorUIntType = typename Superclass::VectorUIntType;
 
   //
   // Custom Typedefs
   //
-  typedef float                                HistogramPixelType;
+  using HistogramPixelType = float;
 
-  typedef Image< HistogramPixelType, PARZEN_MAX_NUMBER_OF_FEATURES >
-    HistogramImageType;
+  using HistogramImageType = Image< HistogramPixelType, PARZEN_MAX_NUMBER_OF_FEATURES >;
 
-  typedef HistogramPixelType                   PDFPixelType;
-  typedef HistogramImageType                   PDFImageType;
+  using PDFPixelType = HistogramPixelType;
+  using PDFImageType = HistogramImageType;
 
-  typedef Image< LabelMapPixelType, PARZEN_MAX_NUMBER_OF_FEATURES >
-    LabeledFeatureSpaceType;
+  using LabeledFeatureSpaceType = Image< LabelMapPixelType, PARZEN_MAX_NUMBER_OF_FEATURES >;
 
   //
   // Methods
@@ -152,17 +150,15 @@ private:
   PDFSegmenterParzen( const Self & );          // Purposely not implemented
   void operator = ( const Self & );      // Purposely not implemented
 
-  // Superclass typedefs
-  typedef std::vector< typename ProbabilityImageType::Pointer >
-    ProbabilityImageVectorType;
+  // Superclass type alias
+  using ProbabilityImageVectorType = std::vector< typename ProbabilityImageType::Pointer >;
 
-  typedef std::vector< ProbabilityPixelType > ListVectorType;
-  typedef std::vector< ListVectorType >       ListSampleType;
-  typedef std::vector< ListSampleType >       ClassListSampleType;
+  using ListVectorType = std::vector< ProbabilityPixelType >;
+  using ListSampleType = std::vector< ListVectorType >;
+  using ClassListSampleType = std::vector< ListSampleType >;
 
-  // Custom typedefs
-  typedef std::vector< typename HistogramImageType::Pointer >
-    ClassHistogramImageType;
+  // Custom type alias
+  using ClassHistogramImageType = std::vector< typename HistogramImageType::Pointer >;
 
   ClassHistogramImageType         m_InClassHistogram;
   VectorDoubleType                m_HistogramBinMin;

--- a/src/Segmentation/itktubePDFSegmenterParzen.hxx
+++ b/src/Segmentation/itktubePDFSegmenterParzen.hxx
@@ -472,8 +472,8 @@ PDFSegmenterParzen< TImage, TLabelMap >
   //
   if( true )
     {
-    typedef itk::DiscreteGaussianImageFilter<
-      HistogramImageType, HistogramImageType > HistogramBlurGenType;
+    using HistogramBlurGenType = itk::DiscreteGaussianImageFilter<
+      HistogramImageType, HistogramImageType >;
 
     for( unsigned int c = 0; c < numClasses; c++ )
       {
@@ -487,8 +487,7 @@ PDFSegmenterParzen< TImage, TLabelMap >
         blurFilter->Update();
         m_InClassHistogram[c] = blurFilter->GetOutput();
 
-        typedef itk::ThresholdImageFilter< HistogramImageType >
-          ThresholdFilterType;
+        using ThresholdFilterType = itk::ThresholdImageFilter< HistogramImageType >;
         typename ThresholdFilterType::Pointer thresholdFilter =
           ThresholdFilterType::New();
         thresholdFilter->SetInput( m_InClassHistogram[c] );
@@ -498,8 +497,8 @@ PDFSegmenterParzen< TImage, TLabelMap >
         m_InClassHistogram[c] = thresholdFilter->GetOutput();
         }
 
-      typedef itk::NormalizeToConstantImageFilter< HistogramImageType,
-        HistogramImageType > NormalizeImageFilterType;
+      using NormalizeImageFilterType = itk::NormalizeToConstantImageFilter< HistogramImageType,
+        HistogramImageType >;
       typename NormalizeImageFilterType::Pointer normFilter =
         NormalizeImageFilterType::New();
       normFilter->SetInput( m_InClassHistogram[c] );
@@ -550,8 +549,7 @@ PDFSegmenterParzen< TImage, TLabelMap >
 
   unsigned int numClasses = this->m_ObjectIdList.size();
 
-  typedef itk::ImageRegionIterator< HistogramImageType >
-    PDFIteratorType;
+  using PDFIteratorType = itk::ImageRegionIterator< HistogramImageType >;
   std::vector< PDFIteratorType * > pdfIter( numClasses );
   for( unsigned int i = 0; i < numClasses; i++ )
     {

--- a/src/Segmentation/itktubeRadiusExtractor2.h
+++ b/src/Segmentation/itktubeRadiusExtractor2.h
@@ -54,11 +54,11 @@ class RadiusExtractor2 : public Object
 public:
 
   /**
-   * Standard self typedef */
-  typedef RadiusExtractor2                                   Self;
-  typedef Object                                             Superclass;
-  typedef SmartPointer< Self >                               Pointer;
-  typedef SmartPointer< const Self >                         ConstPointer;
+   * Standard self type alias */
+  using Self = RadiusExtractor2;
+  using Superclass = Object;
+  using Pointer = SmartPointer< Self >;
+  using ConstPointer = SmartPointer< const Self >;
 
   itkTypeMacro( RadiusExtractor2, Object );
   itkNewMacro( RadiusExtractor2 );
@@ -69,27 +69,27 @@ public:
   itkStaticConstMacro( ImageDimension, unsigned int,
     TInputImage::ImageDimension );
 
-  typedef TubeSpatialObject< TInputImage::ImageDimension > TubeType;
+  using TubeType = TubeSpatialObject< TInputImage::ImageDimension >;
 
-  typedef typename TubeType::TubePointType                   TubePointType;
+  using TubePointType = typename TubeType::TubePointType;
 
-  typedef typename TubeType::PointType                       PointType;
-  typedef typename TubeType::VectorType                      VectorType;
+  using PointType = typename TubeType::PointType;
+  using VectorType = typename TubeType::VectorType;
 
   /**
    * Type definition for the input image. */
-  typedef TInputImage                                        InputImageType;
+  using InputImageType = TInputImage;
 
-  typedef typename InputImageType::IndexType                 IndexType;
+  using IndexType = typename InputImageType::IndexType;
 
   /**
    * Type definition for the input image pixel type. */
-  typedef typename TInputImage::PixelType                    PixelType;
+  using PixelType = typename TInputImage::PixelType;
 
   /**
    * Defines the type of matrix used
    */
-  typedef vnl_matrix< double >                               MatrixType;
+  using MatrixType = vnl_matrix< double >;
 
 
   typedef enum { RADIUS_CORRECTION_NONE, RADIUS_CORRECTION_FOR_BINARY_IMAGE,

--- a/src/Segmentation/itktubeRadiusExtractor2.hxx
+++ b/src/Segmentation/itktubeRadiusExtractor2.hxx
@@ -150,7 +150,7 @@ RadiusExtractor2<TInputImage>
 
   if( m_InputImage )
     {
-    typedef MinimumMaximumImageFilter<InputImageType> MinMaxFilterType;
+    using MinMaxFilterType = MinimumMaximumImageFilter<InputImageType>;
     typename MinMaxFilterType::Pointer minMaxFilter =
       MinMaxFilterType::New();
     minMaxFilter->SetInput( m_InputImage );

--- a/src/Segmentation/itktubeRadiusExtractor3.h
+++ b/src/Segmentation/itktubeRadiusExtractor3.h
@@ -54,11 +54,11 @@ class RadiusExtractor3 : public Object
 public:
 
   /**
-   * Standard self typedef */
-  typedef RadiusExtractor3                                   Self;
-  typedef Object                                             Superclass;
-  typedef SmartPointer< Self >                               Pointer;
-  typedef SmartPointer< const Self >                         ConstPointer;
+   * Standard self type alias */
+  using Self = RadiusExtractor3;
+  using Superclass = Object;
+  using Pointer = SmartPointer< Self >;
+  using ConstPointer = SmartPointer< const Self >;
 
   itkTypeMacro( RadiusExtractor3, Object );
   itkNewMacro( RadiusExtractor3 );
@@ -69,27 +69,27 @@ public:
   itkStaticConstMacro( ImageDimension, unsigned int,
     TInputImage::ImageDimension );
 
-  typedef TubeSpatialObject< TInputImage::ImageDimension > TubeType;
+  using TubeType = TubeSpatialObject< TInputImage::ImageDimension >;
 
-  typedef typename TubeType::TubePointType                   TubePointType;
+  using TubePointType = typename TubeType::TubePointType;
 
-  typedef typename TubeType::PointType                       PointType;
-  typedef typename TubeType::VectorType                      VectorType;
+  using PointType = typename TubeType::PointType;
+  using VectorType = typename TubeType::VectorType;
 
   /**
    * Type definition for the input image. */
-  typedef TInputImage                                        InputImageType;
+  using InputImageType = TInputImage;
 
-  typedef typename InputImageType::IndexType                 IndexType;
+  using IndexType = typename InputImageType::IndexType;
 
   /**
    * Type definition for the input image pixel type. */
-  typedef typename TInputImage::PixelType                    PixelType;
+  using PixelType = typename TInputImage::PixelType;
 
   /**
    * Defines the type of matrix used
    */
-  typedef vnl_matrix< double >                               MatrixType;
+  using MatrixType = vnl_matrix< double >;
 
 
   /**

--- a/src/Segmentation/itktubeRadiusExtractor3.hxx
+++ b/src/Segmentation/itktubeRadiusExtractor3.hxx
@@ -60,8 +60,8 @@ public:
 
   itkTypeMacro(ProfileCurve, SingleValuedCostFunction);
 
-  typedef SingleValuedCostFunction::ParametersType ParametersType;
-  typedef SingleValuedCostFunction::DerivativeType DerivativeType;
+  using ParametersType = SingleValuedCostFunction::ParametersType;
+  using DerivativeType = SingleValuedCostFunction::DerivativeType;
 
   void SetData( std::vector<double> * data )
     {
@@ -194,7 +194,7 @@ RadiusExtractor3<TInputImage>
 
   if( m_InputImage )
     {
-    typedef MinimumMaximumImageFilter<InputImageType> MinMaxFilterType;
+    using MinMaxFilterType = MinimumMaximumImageFilter<InputImageType>;
     typename MinMaxFilterType::Pointer minMaxFilter =
       MinMaxFilterType::New();
     minMaxFilter->SetInput( m_InputImage );
@@ -696,7 +696,7 @@ RadiusExtractor3<TInputImage>
 {
   m_KernelOptimalRadius = this->GetRadiusStart();
 
-  typedef FRPROptimizer OptimizerType;
+  using OptimizerType = FRPROptimizer;
   OptimizerType::Pointer opt = OptimizerType::New();
 
   itk::ProfileCurve::Pointer curvFunc = itk::ProfileCurve::New();

--- a/src/Segmentation/itktubeRidgeExtractor.h
+++ b/src/Segmentation/itktubeRidgeExtractor.h
@@ -58,54 +58,53 @@ class RidgeExtractor : public Object
 {
 public:
 
-  typedef RidgeExtractor             Self;
-  typedef Object                     Superclass;
-  typedef SmartPointer< Self >       Pointer;
-  typedef SmartPointer< const Self > ConstPointer;
+  using Self = RidgeExtractor;
+  using Superclass = Object;
+  using Pointer = SmartPointer< Self >;
+  using ConstPointer = SmartPointer< const Self >;
 
   itkTypeMacro( RidgeExtractor, Object );
 
   itkNewMacro( RidgeExtractor );
 
   /** Type definition for the input image. */
-  typedef TInputImage                                      InputImageType;
+  using InputImageType = TInputImage;
 
   /** Standard for the number of dimension */
   itkStaticConstMacro( ImageDimension, unsigned int,
     TInputImage::ImageDimension );
 
   /** Type definition for the input image. */
-  typedef Image< float, TInputImage::ImageDimension >     TubeMaskImageType;
+  using TubeMaskImageType = Image< float, TInputImage::ImageDimension >;
 
   /** Type definition for the input image pixel type. */
-  typedef typename TInputImage::PixelType                 PixelType;
+  using PixelType = typename TInputImage::PixelType;
 
   /** Type definition for the input image index type. */
-  typedef typename TInputImage::IndexType                 IndexType;
+  using IndexType = typename TInputImage::IndexType;
 
   /** Type definition for the input image point type. */
-  typedef typename TInputImage::PointType                 PointType;
+  using PointType = typename TInputImage::PointType;
 
   /** Type definition for the input image index type. */
-  typedef ContinuousIndex< double, TInputImage::ImageDimension >
-                                                ContinuousIndexType;
+  using ContinuousIndexType = ContinuousIndex< double, TInputImage::ImageDimension >;
 
   /** Defines the type of vectors used */
-  typedef vnl_vector< unsigned int >            IntVectorType;
+  using IntVectorType = vnl_vector< unsigned int >;
 
   /** Defines the type of vectors used */
-  typedef vnl_vector< double >                  VectorType;
+  using VectorType = vnl_vector< double >;
 
   /** Defines the type of matrix used */
-  typedef vnl_matrix< double >                  MatrixType;
+  using MatrixType = vnl_matrix< double >;
 
-  /** Tube SpatialObject typedefs */
-  typedef TubeSpatialObject< TInputImage::ImageDimension > TubeType;
+  /** Tube SpatialObject type alias */
+  using TubeType = TubeSpatialObject< TInputImage::ImageDimension >;
 
-  typedef typename TubeType::TubePointType      TubePointType;
+  using TubePointType = typename TubeType::TubePointType;
 
   /** Defines the type of vectors used */
-  typedef typename TubeType::CovariantVectorType CovariantVectorType;
+  using CovariantVectorType = typename TubeType::CovariantVectorType;
 
   typedef enum { SUCCESS, EXITED_IMAGE, REVISITED_VOXEL, RIDGE_FAIL,
     ROUND_FAIL, CURVE_FAIL, LEVEL_FAIL, TANGENT_FAIL, DISTANCE_FAIL,

--- a/src/Segmentation/itktubeRidgeExtractor.hxx
+++ b/src/Segmentation/itktubeRidgeExtractor.hxx
@@ -209,7 +209,7 @@ RidgeExtractor<TInputImage>
     m_DataFunc->SetUseRelativeSpacing( true );
     m_DataFunc->SetInputImage( inputImage );
 
-    typedef MinimumMaximumImageFilter<InputImageType> MinMaxFilterType;
+    using MinMaxFilterType = MinimumMaximumImageFilter<InputImageType>;
     typename MinMaxFilterType::Pointer minMaxFilter =
       MinMaxFilterType::New();
     minMaxFilter->SetInput( m_InputImage );
@@ -2042,8 +2042,8 @@ bool
 RidgeExtractor<TInputImage>
 ::DeleteTube( const TubeType * tube, TDrawMask * drawMask )
 {
-  typedef typename TDrawMask::PixelType      DrawPixelType;
-  typedef NeighborhoodIterator< TDrawMask >  NeighborhoodIteratorType;
+  using DrawPixelType = typename TDrawMask::PixelType;
+  using NeighborhoodIteratorType = NeighborhoodIterator< TDrawMask >;
 
   if( tube->GetPoints().size() == 0 )
     {
@@ -2172,7 +2172,7 @@ RidgeExtractor<TInputImage>
     std::cout << "*** START: AddTube" << std::endl;
     }
 
-  typedef NeighborhoodIterator< TDrawMask > NeighborhoodIteratorType;
+  using NeighborhoodIteratorType = NeighborhoodIterator< TDrawMask >;
 
   int tubeId = tube->GetId();
   int tubePointCount = 0;

--- a/src/Segmentation/itktubeRidgeSeedFilter.h
+++ b/src/Segmentation/itktubeRidgeSeedFilter.h
@@ -47,26 +47,25 @@ class RidgeSeedFilter : public ImageToImageFilter< TImage, TLabelMap >
 {
 public:
 
-  typedef RidgeSeedFilter                            Self;
-  typedef ImageToImageFilter< TImage, TLabelMap >    Superclass;
-  typedef SmartPointer< Self >                       Pointer;
-  typedef SmartPointer< const Self >                 ConstPointer;
+  using Self = RidgeSeedFilter;
+  using Superclass = ImageToImageFilter< TImage, TLabelMap >;
+  using Pointer = SmartPointer< Self >;
+  using ConstPointer = SmartPointer< const Self >;
 
   itkTypeMacro( RidgeSeedFilter, ImageToImageFilter );
 
   itkNewMacro( Self );
 
-  typedef TImage                                  InputImageType;
-  typedef Image< float, TImage::ImageDimension >  OutputImageType;
+  using InputImageType = TImage;
+  using OutputImageType = Image< float, TImage::ImageDimension >;
 
-  typedef TLabelMap                               LabelMapType;
-  typedef typename LabelMapType::PixelType        LabelMapPixelType;
+  using LabelMapType = TLabelMap;
+  using LabelMapPixelType = typename LabelMapType::PixelType;
 
   itkStaticConstMacro( ImageDimension, unsigned int,
     TImage::ImageDimension );
 
-  typedef RidgeFFTFeatureVectorGenerator< InputImageType >
-    RidgeFeatureGeneratorType;
+  using RidgeFeatureGeneratorType = RidgeFFTFeatureVectorGenerator< InputImageType >;
 
   typedef typename RidgeFeatureGeneratorType::FeatureValueType
     FeatureValueType;
@@ -84,17 +83,14 @@ public:
   typedef typename RidgeFeatureGeneratorType::ValueListType
     WhitenStdDevsType;
 
-  typedef BasisFeatureVectorGenerator< InputImageType, LabelMapType >
-    SeedFeatureGeneratorType;
+  using SeedFeatureGeneratorType = BasisFeatureVectorGenerator< InputImageType, LabelMapType >;
 
-  typedef typename SeedFeatureGeneratorType::ObjectIdType ObjectIdType;
-  typedef typename SeedFeatureGeneratorType::VectorType   VectorType;
-  typedef typename SeedFeatureGeneratorType::MatrixType   MatrixType;
+  using ObjectIdType = typename SeedFeatureGeneratorType::ObjectIdType;
+  using VectorType = typename SeedFeatureGeneratorType::VectorType;
+  using MatrixType = typename SeedFeatureGeneratorType::MatrixType;
 
-  typedef PDFSegmenterBase< InputImageType, LabelMapType >
-    PDFSegmenterType;
-  typedef PDFSegmenterParzen< InputImageType, LabelMapType >
-    PDFSegmenterParzenType;
+  using PDFSegmenterType = PDFSegmenterBase< InputImageType, LabelMapType >;
+  using PDFSegmenterParzenType = PDFSegmenterParzen< InputImageType, LabelMapType >;
   typedef typename  PDFSegmenterType::ProbabilityPixelType
     ProbabilityPixelType;
   typedef typename  PDFSegmenterType::ProbabilityImageType

--- a/src/Segmentation/itktubeRidgeSeedFilter.hxx
+++ b/src/Segmentation/itktubeRidgeSeedFilter.hxx
@@ -497,8 +497,7 @@ RidgeSeedFilter< TImage, TLabelMap >
   if( false ) // m_Skeletonize )
     {
     std::cout << "Skeletonize" << std::endl;
-    typedef itk::BinaryThinningImageFilter< LabelMapType, LabelMapType >
-      FilterType;
+    using FilterType = itk::BinaryThinningImageFilter< LabelMapType, LabelMapType >;
 
     typename FilterType::Pointer filter;
 

--- a/src/Segmentation/itktubeSegmentTubeUsingMinimalPathFilter.h
+++ b/src/Segmentation/itktubeSegmentTubeUsingMinimalPathFilter.h
@@ -49,20 +49,20 @@ template< unsigned int Dimension, class TInputPixel >
 class SegmentTubeUsingMinimalPathFilter: public Object
 {
 public:
-  /** Standard class typedefs. */
-  typedef SegmentTubeUsingMinimalPathFilter Self;
-  typedef Object                             Superclass;
-  typedef SmartPointer< Self >               Pointer;
-  typedef SmartPointer< const Self >         ConstPointer;
+  /** Standard class type alias. */
+  using Self = SegmentTubeUsingMinimalPathFilter;
+  using Superclass = Object;
+  using Pointer = SmartPointer< Self >;
+  using ConstPointer = SmartPointer< const Self >;
 
-  typedef itk::Image< TInputPixel, Dimension > InputImageType;
-  typedef itk::GroupSpatialObject< Dimension > InputSpatialObjectType;
+  using InputImageType = itk::Image< TInputPixel, Dimension >;
+  using InputSpatialObjectType = itk::GroupSpatialObject< Dimension >;
 
-  typedef typename InputSpatialObjectType::Pointer TubeGroupPointer;
+  using TubeGroupPointer = typename InputSpatialObjectType::Pointer;
 
-  typedef itk::Point< double, Dimension >           PointType;
-  typedef itk::TubeSpatialObjectPoint< Dimension >  TubePointType;
-  typedef itk::TubeSpatialObject< Dimension >       TubeType;
+  using PointType = itk::Point< double, Dimension >;
+  using TubePointType = itk::TubeSpatialObjectPoint< Dimension >;
+  using TubeType = itk::TubeSpatialObject< Dimension >;
 
   /** Method for creation through the object factory. */
   itkNewMacro( Self );

--- a/src/Segmentation/itktubeSegmentTubeUsingMinimalPathFilter.hxx
+++ b/src/Segmentation/itktubeSegmentTubeUsingMinimalPathFilter.hxx
@@ -60,19 +60,18 @@ void
 SegmentTubeUsingMinimalPathFilter< Dimension, TInputPixel >
 ::Update( void )
 {
-  typedef itk::PolyLineParametricPath< Dimension > PathType;
-  typedef itk::SpeedFunctionToPathFilter
-    < InputImageType, PathType > PathFilterType;
-  typedef itk::LinearInterpolateImageFunction< InputImageType, double >
-    InterpolatorType;
+  using PathType = itk::PolyLineParametricPath< Dimension >;
+  using PathFilterType = itk::SpeedFunctionToPathFilter
+    < InputImageType, PathType >;
+  using InterpolatorType = itk::LinearInterpolateImageFunction< InputImageType, double >;
   typename InterpolatorType::Pointer interpolator = InterpolatorType::New();
 
-  typedef itk::SingleImageCostFunction< InputImageType > CostFunctionType;
+  using CostFunctionType = itk::SingleImageCostFunction< InputImageType >;
   typename CostFunctionType::Pointer costFunction = CostFunctionType::New();
   costFunction->SetInterpolator( interpolator );
 
   //Get Input image information
-  typedef typename TubeType::TransformType TransformType;
+  using TransformType = typename TubeType::TransformType;
   typename TransformType::InputVectorType scaleVector;
   typename TransformType::OffsetType offsetVector;
   typename InputImageType::SpacingType spacing = m_SpeedImage->GetSpacing();
@@ -84,7 +83,7 @@ SegmentTubeUsingMinimalPathFilter< Dimension, TInputPixel >
     offsetVector[k] = origin[k];
     }
   // Create path information
-  typedef itk::SpeedFunctionPathInformation< PointType > PathInformationType;
+  using PathInformationType = itk::SpeedFunctionPathInformation< PointType >;
   typename PathInformationType::Pointer pathInfo = PathInformationType::New();
   pathInfo->SetStartPoint( m_StartPoint );
   for( unsigned int i = 0; i < m_IntermediatePoints.size(); i++ )
@@ -113,7 +112,7 @@ SegmentTubeUsingMinimalPathFilter< Dimension, TInputPixel >
   if( m_OptimizationMethod == "Iterate_Neighborhood" )
     {
     // Create IterateNeighborhoodOptimizer
-    typedef itk::IterateNeighborhoodOptimizer OptimizerType;
+    using OptimizerType = itk::IterateNeighborhoodOptimizer;
     typename OptimizerType::Pointer optimizer = OptimizerType::New();
     optimizer->MinimizeOn();
     optimizer->FullyConnectedOn();
@@ -128,7 +127,7 @@ SegmentTubeUsingMinimalPathFilter< Dimension, TInputPixel >
   else if( m_OptimizationMethod == "Gradient_Descent" )
     {
     // Create GradientDescentOptimizer
-    typedef itk::GradientDescentOptimizer OptimizerType;
+    using OptimizerType = itk::GradientDescentOptimizer;
     typename OptimizerType::Pointer optimizer = OptimizerType::New();
     optimizer->SetNumberOfIterations( m_OptimizerNumberOfIterations );
     pathFilter->SetOptimizer( optimizer );
@@ -145,7 +144,7 @@ SegmentTubeUsingMinimalPathFilter< Dimension, TInputPixel >
         }
       }
     // Create RegularStepGradientDescentOptimizer
-    typedef itk::RegularStepGradientDescentOptimizer OptimizerType;
+    using OptimizerType = itk::RegularStepGradientDescentOptimizer;
     typename OptimizerType::Pointer optimizer = OptimizerType::New();
     optimizer->SetNumberOfIterations( m_OptimizerNumberOfIterations );
     optimizer->SetMaximumStepLength
@@ -234,8 +233,7 @@ SegmentTubeUsingMinimalPathFilter< Dimension, TInputPixel >
     // Extract Radius
     if( m_RadiusImage )
       {
-      typedef itk::tube::RadiusExtractor3< InputImageType >
-        RadiusExtractorType;
+      using RadiusExtractorType = itk::tube::RadiusExtractor3< InputImageType >;
       typename RadiusExtractorType::Pointer radiusExtractor
         = RadiusExtractorType::New();
       radiusExtractor->SetInputImage( m_RadiusImage );

--- a/src/Segmentation/itktubeTubeExtractor.h
+++ b/src/Segmentation/itktubeTubeExtractor.h
@@ -54,11 +54,11 @@ class TubeExtractor : public Object
 public:
 
   /**
-   * Standard self typedef */
-  typedef TubeExtractor               Self;
-  typedef Object                      Superclass;
-  typedef SmartPointer< Self >        Pointer;
-  typedef SmartPointer< const Self >  ConstPointer;
+   * Standard self type alias */
+  using Self = TubeExtractor;
+  using Superclass = Object;
+  using Pointer = SmartPointer< Self >;
+  using ConstPointer = SmartPointer< const Self >;
 
   /**
    * Run-time type information ( and related methods ). */
@@ -68,10 +68,10 @@ public:
 
   /**
    * Type definition for the input image. */
-  typedef TInputImage                               ImageType;
+  using ImageType = TInputImage;
 
-  typedef RidgeExtractor<ImageType>                 RidgeExtractorType;
-  typedef RadiusExtractor3<ImageType>               RadiusExtractorType;
+  using RidgeExtractorType = RidgeExtractor<ImageType>;
+  using RadiusExtractorType = RadiusExtractor3<ImageType>;
 
   typedef typename RidgeExtractorType::TubeMaskImageType
                                                     TubeMaskImageType;
@@ -84,28 +84,28 @@ public:
 
   /**
    * Type definition for the input image pixel type. */
-  typedef typename ImageType::PixelType                 PixelType;
+  using PixelType = typename ImageType::PixelType;
 
   /**  Type definition for VesselTubeSpatialObject */
-  typedef TubeSpatialObject< ImageDimension >           TubeType;
-  typedef typename TubeType::TubePointType              TubePointType;
+  using TubeType = TubeSpatialObject< ImageDimension >;
+  using TubePointType = typename TubeType::TubePointType;
 
-  typedef itk::GroupSpatialObject< ImageDimension >     TubeGroupType;
+  using TubeGroupType = itk::GroupSpatialObject< ImageDimension >;
 
   /**
    * Type definition for the input image pixel type. */
-  typedef ContinuousIndex<double, ImageDimension >      ContinuousIndexType;
-  typedef std::vector< ContinuousIndexType >            ContinuousIndexListType;
-  typedef Point<double, ImageDimension >                PointType;
-  typedef std::vector< PointType >                      PointListType;
-  typedef double                                        RadiusType;
-  typedef std::vector< RadiusType >                     RadiusListType;
+  using ContinuousIndexType = ContinuousIndex<double, ImageDimension >;
+  using ContinuousIndexListType = std::vector< ContinuousIndexType >;
+  using PointType = Point<double, ImageDimension >;
+  using PointListType = std::vector< PointType >;
+  using RadiusType = double;
+  using RadiusListType = std::vector< RadiusType >;
 
-  typedef typename ImageType::IndexType                 IndexType;
+  using IndexType = typename ImageType::IndexType;
 
   /**
    * Defines the type of vectors used */
-  typedef itk::Vector< double, ImageDimension >         VectorType;
+  using VectorType = itk::Vector< double, ImageDimension >;
 
 
   /***********/

--- a/src/Segmentation/itktubeTubeExtractor.hxx
+++ b/src/Segmentation/itktubeTubeExtractor.hxx
@@ -191,7 +191,7 @@ void
 TubeExtractor<TInputImage>
 ::SetDataMinMaxLimits( double limitMin, double limitMax )
 {
-  typedef LimitedMinimumMaximumImageFilter<ImageType> MinMaxFilterType;
+  using MinMaxFilterType = LimitedMinimumMaximumImageFilter<ImageType>;
   typename MinMaxFilterType::Pointer minMaxFilter = MinMaxFilterType::New();
   minMaxFilter->SetInput( this->GetInputImage() );
   minMaxFilter->SetMinimumLimit( limitMin );
@@ -578,13 +578,13 @@ TubeExtractor<TInputImage>
     {
     if( m_UseSeedMaskAsProbabilities )
       {
-      typedef itk::ImageDuplicator<TubeMaskImageType> DuplicatorType;
+      using DuplicatorType = itk::ImageDuplicator<TubeMaskImageType>;
       typename DuplicatorType::Pointer duplicator = DuplicatorType::New();
       duplicator->SetInputImage(m_SeedMask);
       duplicator->Update();
       typename TubeMaskImageType::Pointer tmpSeedMask = duplicator->GetOutput();
       
-      typedef itk::MinimumMaximumImageCalculator<TubeMaskImageType> MinMaxCalcType;
+      using MinMaxCalcType = itk::MinimumMaximumImageCalculator<TubeMaskImageType>;
       typename MinMaxCalcType::Pointer maxCalc = MinMaxCalcType::New();
       unsigned int count = 1;
       double successRatio = 1;
@@ -623,8 +623,7 @@ TubeExtractor<TInputImage>
             }
           else
             {
-            typedef itk::NeighborhoodIterator< TubeMaskImageType >
-              NeighborIterType;
+            using NeighborIterType = itk::NeighborhoodIterator< TubeMaskImageType >;
             typename NeighborIterType::RadiusType radius;
             radius.Fill(5);
             NeighborIterType iter( radius, tmpSeedMask,

--- a/test/Common/tubeObjectTest.cxx
+++ b/test/Common/tubeObjectTest.cxx
@@ -33,7 +33,7 @@ int tubeObjectTest( int argc, char * argv[] )
     return EXIT_FAILURE;
     }
 
-  typedef tube::Object ObjectType;
+  using ObjectType = tube::Object;
 
   ObjectType::Pointer object = new ObjectType();
   std::ostringstream oss;

--- a/test/CompareTools/CompareImages.cxx
+++ b/test/CompareTools/CompareImages.cxx
@@ -151,7 +151,7 @@ int CompareImages( int argc, char * argv[] )
 
   try
     {
-    typedef std::vector< std::string >::const_iterator  NameIteratorType;
+    using NameIteratorType = std::vector< std::string >::const_iterator;
     NameIteratorType baselineImageItr = baselineImageFilenames.begin();
     while( baselineImageItr != baselineImageFilenames.end() )
       {
@@ -219,10 +219,10 @@ int RegressionTestImage ( const char *testImageFilename,
 {
   // Use the factory mechanism to read the test and baseline files and
   //   convert them to double
-  typedef itk::Image<double, ITK_TEST_DIMENSION_MAX>         ImageType;
-  typedef itk::Image<unsigned char, ITK_TEST_DIMENSION_MAX>  OutputType;
-  typedef itk::Image<unsigned char, 2>                       DiffOutputType;
-  typedef itk::ImageFileReader<ImageType>                    ReaderType;
+  using ImageType = itk::Image<double, ITK_TEST_DIMENSION_MAX>;
+  using OutputType = itk::Image<unsigned char, ITK_TEST_DIMENSION_MAX>;
+  using DiffOutputType = itk::Image<unsigned char, 2>;
+  using ReaderType = itk::ImageFileReader<ImageType>;
 
   // Read the baseline file
   ReaderType::Pointer baselineReader = ReaderType::New();
@@ -271,7 +271,7 @@ int RegressionTestImage ( const char *testImageFilename,
     }
 
   // Now compare the two images
-  typedef itk::tube::DifferenceImageFilter<ImageType, ImageType> DiffType;
+  using DiffType = itk::tube::DifferenceImageFilter<ImageType, ImageType>;
   DiffType::Pointer diff = DiffType::New();
     diff->SetValidInput( baselineReader->GetOutput() );
     diff->SetTestInput( testReader->GetOutput() );
@@ -308,14 +308,10 @@ int RegressionTestImage ( const char *testImageFilename,
 
   if ( reportErrors )
     {
-    typedef itk::RescaleIntensityImageFilter<ImageType, OutputType>
-      RescaleType;
-    typedef itk::ExtractImageFilter<OutputType, DiffOutputType>
-      ExtractType;
-    typedef itk::ImageFileWriter<DiffOutputType>
-      WriterType;
-    typedef itk::ImageRegion<ITK_TEST_DIMENSION_MAX>
-      RegionType;
+    using RescaleType = itk::RescaleIntensityImageFilter<ImageType, OutputType>;
+    using ExtractType = itk::ExtractImageFilter<OutputType, DiffOutputType>;
+    using WriterType = itk::ImageFileWriter<DiffOutputType>;
+    using RegionType = itk::ImageRegion<ITK_TEST_DIMENSION_MAX>;
 
     OutputType::IndexType index; index.Fill( 0 );
     OutputType::SizeType size; size.Fill( 0 );

--- a/test/CompareTools/CompareTextFiles.cxx
+++ b/test/CompareTools/CompareTextFiles.cxx
@@ -136,7 +136,7 @@ int CompareTextFiles( int argc, char * argv[] )
       }
     else
       {
-      typedef std::list< std::string >::const_iterator  nameIterator;
+      using nameIterator = std::list< std::string >::const_iterator;
       nameIterator baselineFileItr = baselineFilenames.begin();
       while( baselineFileItr != baselineFilenames.end() )
         {

--- a/test/Filtering/itktubeAnisotropicCoherenceEnhancingDiffusionImageFilterTest.cxx
+++ b/test/Filtering/itktubeAnisotropicCoherenceEnhancingDiffusionImageFilterTest.cxx
@@ -39,13 +39,13 @@ int itktubeAnisotropicCoherenceEnhancingDiffusionImageFilterTest( int argc,
     }
   // Define the dimension of the images
   enum { Dimension = 3 };
-  typedef double      InputPixelType;
+  using InputPixelType = double;
 
   // Declare the types of the images
-  typedef itk::Image< InputPixelType, Dimension>           InputImageType;
-  typedef itk::Image< InputPixelType, Dimension>           OutputImageType;
+  using InputImageType = itk::Image< InputPixelType, Dimension>;
+  using OutputImageType = itk::Image< InputPixelType, Dimension>;
 
-  typedef itk::ImageFileReader< InputImageType  >      ImageReaderType;
+  using ImageReaderType = itk::ImageFileReader< InputImageType  >;
 
   ImageReaderType::Pointer   reader = ImageReaderType::New();
   reader->SetFileName ( argv[1] );
@@ -63,8 +63,8 @@ int itktubeAnisotropicCoherenceEnhancingDiffusionImageFilterTest( int argc,
 
 
   // Declare the anisotropic diffusion edge enhancement filter
-  typedef itk::tube::AnisotropicCoherenceEnhancingDiffusionImageFilter<
-    InputImageType, OutputImageType>  CoherenceEnhancingFilterType;
+  using CoherenceEnhancingFilterType = itk::tube::AnisotropicCoherenceEnhancingDiffusionImageFilter<
+    InputImageType, OutputImageType>;
 
   // Create a edge enhancement Filter
   CoherenceEnhancingFilterType::Pointer CoherenceEnhancingFilter =
@@ -136,7 +136,7 @@ int itktubeAnisotropicCoherenceEnhancingDiffusionImageFilterTest( int argc,
 
   std::cout << "Writing out the enhanced image to " <<  argv[2] << std::endl;
 
-  typedef itk::ImageFileWriter< OutputImageType  >      ImageWriterType;
+  using ImageWriterType = itk::ImageFileWriter< OutputImageType  >;
   ImageWriterType::Pointer writer = ImageWriterType::New();
 
   writer->SetFileName( argv[2] );

--- a/test/Filtering/itktubeAnisotropicEdgeEnhancementDiffusionImageFilterTest.cxx
+++ b/test/Filtering/itktubeAnisotropicEdgeEnhancementDiffusionImageFilterTest.cxx
@@ -37,13 +37,13 @@ int itktubeAnisotropicEdgeEnhancementDiffusionImageFilterTest( int argc, char * 
     }
   // Define the dimension of the images
   enum { Dimension = 3 };
-  typedef double      InputPixelType;
+  using InputPixelType = double;
 
   // Declare the types of the images
-  typedef itk::Image< InputPixelType, Dimension>           InputImageType;
-  typedef itk::Image< InputPixelType, Dimension>           OutputImageType;
+  using InputImageType = itk::Image< InputPixelType, Dimension>;
+  using OutputImageType = itk::Image< InputPixelType, Dimension>;
 
-  typedef itk::ImageFileReader< InputImageType  >      ImageReaderType;
+  using ImageReaderType = itk::ImageFileReader< InputImageType  >;
 
   ImageReaderType::Pointer   reader = ImageReaderType::New();
   reader->SetFileName ( argv[1] );
@@ -61,8 +61,8 @@ int itktubeAnisotropicEdgeEnhancementDiffusionImageFilterTest( int argc, char * 
 
 
   // Declare the anisotropic diffusion edge enhancement filter
-  typedef itk::tube::AnisotropicEdgeEnhancementDiffusionImageFilter<
-    InputImageType, OutputImageType>  EdgeEnhancementFilterType;
+  using EdgeEnhancementFilterType = itk::tube::AnisotropicEdgeEnhancementDiffusionImageFilter<
+    InputImageType, OutputImageType>;
 
   // Create a edge enhancement Filter
   EdgeEnhancementFilterType::Pointer EdgeEnhancementFilter =
@@ -112,7 +112,7 @@ int itktubeAnisotropicEdgeEnhancementDiffusionImageFilterTest( int argc, char * 
 
   std::cout << "Writing out the enhanced image to " <<  argv[2] << std::endl;
 
-  typedef itk::ImageFileWriter< OutputImageType  >      ImageWriterType;
+  using ImageWriterType = itk::ImageFileWriter< OutputImageType  >;
   ImageWriterType::Pointer writer = ImageWriterType::New();
 
   writer->SetFileName( argv[2] );

--- a/test/Filtering/itktubeAnisotropicHybridDiffusionImageFilterTest.cxx
+++ b/test/Filtering/itktubeAnisotropicHybridDiffusionImageFilterTest.cxx
@@ -42,13 +42,13 @@ int itktubeAnisotropicHybridDiffusionImageFilterTest( int argc,
 
   // Define the dimension of the images
   enum { Dimension = 3 };
-  typedef double      InputPixelType;
+  using InputPixelType = double;
 
   // Declare the types of the images
-  typedef itk::Image< InputPixelType, Dimension>           InputImageType;
-  typedef itk::Image< InputPixelType, Dimension>           OutputImageType;
+  using InputImageType = itk::Image< InputPixelType, Dimension>;
+  using OutputImageType = itk::Image< InputPixelType, Dimension>;
 
-  typedef itk::ImageFileReader< InputImageType  >      ImageReaderType;
+  using ImageReaderType = itk::ImageFileReader< InputImageType  >;
 
   ImageReaderType::Pointer   reader = ImageReaderType::New();
   reader->SetFileName ( argv[1] );
@@ -66,8 +66,8 @@ int itktubeAnisotropicHybridDiffusionImageFilterTest( int argc,
 
 
   // Declare the anisotropic diffusion hybrid enhancement filter
-  typedef itk::tube::AnisotropicHybridDiffusionImageFilter< InputImageType,
-                                            OutputImageType>  HybridFilterType;
+  using HybridFilterType = itk::tube::AnisotropicHybridDiffusionImageFilter< InputImageType,
+                                            OutputImageType>;
 
   // Create a hybrid diffusion Filter
   HybridFilterType::Pointer HybridFilter =
@@ -141,7 +141,7 @@ int itktubeAnisotropicHybridDiffusionImageFilterTest( int argc,
 
   std::cout << "Writing out the enhanced image to " <<  argv[2] << std::endl;
 
-  typedef itk::ImageFileWriter< OutputImageType  >      ImageWriterType;
+  using ImageWriterType = itk::ImageFileWriter< OutputImageType  >;
   ImageWriterType::Pointer writer = ImageWriterType::New();
 
   writer->SetFileName( argv[2] );

--- a/test/Filtering/itktubeCVTImageFilterTest.cxx
+++ b/test/Filtering/itktubeCVTImageFilterTest.cxx
@@ -44,18 +44,18 @@ int itktubeCVTImageFilterTest( int argc, char * argv[] )
   enum { Dimension = 2 };
 
   // Define the pixel type
-  typedef float PixelType;
+  using PixelType = float;
 
   // Declare the types of the images
-  typedef itk::Image<PixelType, Dimension>  ImageType;
+  using ImageType = itk::Image<PixelType, Dimension>;
 
   // Declare the reader and writer
-  typedef itk::ImageFileReader< ImageType > ReaderType;
-  typedef itk::ImageFileWriter< ImageType > WriterType;
+  using ReaderType = itk::ImageFileReader< ImageType >;
+  using WriterType = itk::ImageFileWriter< ImageType >;
 
 
   // Declare the type for the Filter
-  typedef itk::tube::CVTImageFilter< ImageType > FilterType;
+  using FilterType = itk::tube::CVTImageFilter< ImageType >;
 
   // Create the reader and writer
   ReaderType::Pointer reader = ReaderType::New();

--- a/test/Filtering/itktubeExtractTubePointsSpatialObjectFilterTest.cxx
+++ b/test/Filtering/itktubeExtractTubePointsSpatialObjectFilterTest.cxx
@@ -37,11 +37,11 @@ int itktubeExtractTubePointsSpatialObjectFilterTest( int argc, char* argv[] )
   const char * inputTubeTree = argv[1];
 
   static const unsigned int Dimension = 3;
-  typedef itk::TubeSpatialObject< Dimension >   TubeSpatialObjectType;
-  typedef itk::GroupSpatialObject< Dimension >  GroupSpatialObjectType;
+  using TubeSpatialObjectType = itk::TubeSpatialObject< Dimension >;
+  using GroupSpatialObjectType = itk::GroupSpatialObject< Dimension >;
 
   // Read input tube tree.
-  typedef itk::SpatialObjectReader< Dimension >  ReaderType;
+  using ReaderType = itk::SpatialObjectReader< Dimension >;
   ReaderType::Pointer reader = ReaderType::New();
   reader->SetFileName( inputTubeTree );
   try
@@ -63,8 +63,8 @@ int itktubeExtractTubePointsSpatialObjectFilterTest( int argc, char* argv[] )
   std::cout << "Number of children = "
     << groupSpatialObject->GetNumberOfChildren() << std::endl;
 
-  typedef itk::tube::ExtractTubePointsSpatialObjectFilter<
-    TubeSpatialObjectType > ExtractTubePointsSpatialObjectFilterType;
+  using ExtractTubePointsSpatialObjectFilterType = itk::tube::ExtractTubePointsSpatialObjectFilter<
+    TubeSpatialObjectType >;
   ExtractTubePointsSpatialObjectFilterType::Pointer extractTubePointsFilter =
     ExtractTubePointsSpatialObjectFilterType::New();
   extractTubePointsFilter->SetInput( reader->GetGroup() );

--- a/test/Filtering/itktubeFFTGaussianDerivativeIFFTFilterTest.cxx
+++ b/test/Filtering/itktubeFFTGaussianDerivativeIFFTFilterTest.cxx
@@ -40,18 +40,17 @@ int itktubeFFTGaussianDerivativeIFFTFilterTest( int argc, char * argv[] )
   enum { Dimension = 2 };
 
   // Define the pixel type
-  typedef float PixelType;
+  using PixelType = float;
 
   // Declare the types of the images
-  typedef itk::Image<PixelType, Dimension>  ImageType;
+  using ImageType = itk::Image<PixelType, Dimension>;
 
   // Declare the reader and writer
-  typedef itk::ImageFileReader< ImageType > ReaderType;
-  typedef itk::ImageFileWriter< ImageType > WriterType;
+  using ReaderType = itk::ImageFileReader< ImageType >;
+  using WriterType = itk::ImageFileWriter< ImageType >;
 
   // Declare the type for the Filter
-  typedef itk::tube::FFTGaussianDerivativeIFFTFilter< ImageType, ImageType >
-    FunctionType;
+  using FunctionType = itk::tube::FFTGaussianDerivativeIFFTFilter< ImageType, ImageType >;
 
   // Create the reader and writer
   ReaderType::Pointer reader = ReaderType::New();

--- a/test/Filtering/itktubeRidgeFFTFilterTest.cxx
+++ b/test/Filtering/itktubeRidgeFFTFilterTest.cxx
@@ -40,17 +40,17 @@ int itktubeRidgeFFTFilterTest( int argc, char * argv[] )
   enum { Dimension = 3 };
 
   // Define the pixel type
-  typedef float PixelType;
+  using PixelType = float;
 
   // Declare the types of the images
-  typedef itk::Image<PixelType, Dimension>  ImageType;
+  using ImageType = itk::Image<PixelType, Dimension>;
 
   // Declare the reader and writer
-  typedef itk::ImageFileReader< ImageType > ReaderType;
-  typedef itk::ImageFileWriter< ImageType > WriterType;
+  using ReaderType = itk::ImageFileReader< ImageType >;
+  using WriterType = itk::ImageFileWriter< ImageType >;
 
   // Declare the type for the Filter
-  typedef itk::tube::RidgeFFTFilter< ImageType > FunctionType;
+  using FunctionType = itk::tube::RidgeFFTFilter< ImageType >;
 
   // Create the reader and writer
   ReaderType::Pointer reader = ReaderType::New();

--- a/test/Filtering/itktubeSheetnessMeasureImageFilterTest.cxx
+++ b/test/Filtering/itktubeSheetnessMeasureImageFilterTest.cxx
@@ -33,16 +33,16 @@ int itktubeSheetnessMeasureImageFilterTest( int ,char *[] )
   const unsigned int myDimension = 3;
 
   // Declare the types of the images
-  typedef itk::Image<float, myDimension>           myImageType;
+  using myImageType = itk::Image<float, myDimension>;
 
   // Declare the type of the index to access images
-  typedef itk::Index<myDimension>             myIndexType;
+  using myIndexType = itk::Index<myDimension>;
 
   // Declare the type of the size
-  typedef itk::Size<myDimension>              mySizeType;
+  using mySizeType = itk::Size<myDimension>;
 
   // Declare the type of the Region
-  typedef itk::ImageRegion<myDimension>        myRegionType;
+  using myRegionType = itk::ImageRegion<myDimension>;
 
   // Create the image
   myImageType::Pointer inputImage  = myImageType::New();
@@ -69,7 +69,7 @@ int itktubeSheetnessMeasureImageFilterTest( int ,char *[] )
   inputImage->Allocate();
 
   // Declare Iterator type for the input image
-  typedef itk::ImageRegionIteratorWithIndex<myImageType>  myIteratorType;
+  using myIteratorType = itk::ImageRegionIteratorWithIndex<myImageType>;
 
   // Create one iterator for the Input Image A ( this is a light object )
   myIteratorType it( inputImage, inputImage->GetRequestedRegion() );
@@ -104,20 +104,20 @@ int itktubeSheetnessMeasureImageFilterTest( int ,char *[] )
   std::cout << "Finished creating a synthetic image" << std::endl;
 
   std::cout << "Writing out the synthetic image" << std::endl;
-  typedef itk::ImageFileWriter<myImageType>     InputImageWriterType;
+  using InputImageWriterType = itk::ImageFileWriter<myImageType>;
   InputImageWriterType::Pointer inputImageWriter= InputImageWriterType::New();
   inputImageWriter->SetFileName( "SyntheticImageForSheetnessTest.mha" );
   inputImageWriter->SetInput( inputImage );
   inputImageWriter->Update();
 
   // Declare the type for the Hessian filter
-  typedef itk::HessianRecursiveGaussianImageFilter<
-                                            myImageType >  myHessianFilterType;
+  using myHessianFilterType = itk::HessianRecursiveGaussianImageFilter<
+                                            myImageType >;
 
   // Declare the type for the sheetness measure filter
-  typedef itk::tube::SheetnessMeasureImageFilter< float >  mySheetnessFilterType;
+  using mySheetnessFilterType = itk::tube::SheetnessMeasureImageFilter< float >;
 
-  typedef mySheetnessFilterType::OutputImageType mySheetnessImageType;
+  using mySheetnessImageType = mySheetnessFilterType::OutputImageType;
 
 
   // Create a Hessian Filter
@@ -147,10 +147,10 @@ int itktubeSheetnessMeasureImageFilterTest( int ,char *[] )
 
   //Write out the sheetness image
   //Define output type
-  typedef mySheetnessFilterType::OutputImageType SheetnessImageType;
+  using SheetnessImageType = mySheetnessFilterType::OutputImageType;
 
   std::cout << "Write out the sheetness image" << std::endl;
-  typedef itk::ImageFileWriter<SheetnessImageType>     SheetnessImageWriterType;
+  using SheetnessImageWriterType = itk::ImageFileWriter<SheetnessImageType>;
   SheetnessImageWriterType::Pointer writer= SheetnessImageWriterType::New();
   writer->SetFileName( "SheetnessImage.mha" );
   writer->SetInput( outputImage );

--- a/test/Filtering/itktubeSheetnessMeasureImageFilterTest2.cxx
+++ b/test/Filtering/itktubeSheetnessMeasureImageFilterTest2.cxx
@@ -45,13 +45,13 @@ int itktubeSheetnessMeasureImageFilterTest2( int argc, char * argv[] )
   enum { Dimension = 3 };
 
   // Define the pixel type
-  typedef short PixelType;
+  using PixelType = short;
 
   // Declare the types of the images
-  typedef itk::Image<PixelType, Dimension>           InputImageType;
+  using InputImageType = itk::Image<PixelType, Dimension>;
 
   // Declare the reader
-  typedef itk::ImageFileReader< InputImageType > ReaderType;
+  using ReaderType = itk::ImageFileReader< InputImageType >;
 
   // Create the reader and writer
   ReaderType::Pointer reader = ReaderType::New();
@@ -59,11 +59,11 @@ int itktubeSheetnessMeasureImageFilterTest2( int argc, char * argv[] )
   reader->Update();
 
   // Declare the type for the Hessian filter
-  typedef itk::HessianRecursiveGaussianImageFilter<
-                                            InputImageType >  HessianFilterType;
+  using HessianFilterType = itk::HessianRecursiveGaussianImageFilter<
+                                            InputImageType >;
 
   // Declare the type for the sheetness measure filter
-  typedef itk::tube::SheetnessMeasureImageFilter< float >  SheetnessFilterType;
+  using SheetnessFilterType = itk::tube::SheetnessMeasureImageFilter< float >;
 
   // Create a Hessian Filter
   HessianFilterType::Pointer filterHessian = HessianFilterType::New();
@@ -90,10 +90,10 @@ int itktubeSheetnessMeasureImageFilterTest2( int argc, char * argv[] )
 
   //Write out the sheetness image
   //Define output type
-  typedef SheetnessFilterType::OutputImageType SheetnessImageType;
+  using SheetnessImageType = SheetnessFilterType::OutputImageType;
 
   std::cout << "Write out the sheetness image" << std::endl;
-  typedef itk::ImageFileWriter<SheetnessImageType>     SheetnessImageWriterType;
+  using SheetnessImageWriterType = itk::ImageFileWriter<SheetnessImageType>;
   SheetnessImageWriterType::Pointer writer= SheetnessImageWriterType::New();
   writer->SetFileName( argv[2] );
   writer->SetInput( filterSheetness->GetOutput() );
@@ -111,14 +111,11 @@ int itktubeSheetnessMeasureImageFilterTest2( int argc, char * argv[] )
   //Compute the eigenvalues
   typedef  SheetnessFilterType::InputImageType
     SymmetricSecondRankTensorImageType;
-  typedef  itk::FixedArray< double, Dimension>
-    EigenValueArrayType;
-  typedef  itk::Image< EigenValueArrayType, Dimension>
-    EigenValueImageType;
+  using EigenValueArrayType = itk::FixedArray< double, Dimension>;
+  using EigenValueImageType = itk::Image< EigenValueArrayType, Dimension>;
 
-  typedef itk::SymmetricEigenAnalysisImageFilter<
-    SymmetricSecondRankTensorImageType, EigenValueImageType>
-    EigenAnalysisFilterType;
+  using EigenAnalysisFilterType = itk::SymmetricEigenAnalysisImageFilter<
+    SymmetricSecondRankTensorImageType, EigenValueImageType>;
 
   EigenAnalysisFilterType::Pointer eigenAnalysisFilter =
     EigenAnalysisFilterType::New();
@@ -131,14 +128,12 @@ int itktubeSheetnessMeasureImageFilterTest2( int argc, char * argv[] )
 
 
   //Generate and write out the primary eigenvector image
-  typedef  itk::Matrix< double, 3, 3>
-    EigenVectorMatrixType;
-  typedef  itk::Image< EigenVectorMatrixType, Dimension>
-    EigenVectorImageType;
+  using EigenVectorMatrixType = itk::Matrix< double, 3, 3>;
+  using EigenVectorImageType = itk::Image< EigenVectorMatrixType, Dimension>;
 
-  typedef  itk::tube::SymmetricEigenVectorAnalysisImageFilter<
+  using EigenVectorAnalysisFilterType = itk::tube::SymmetricEigenVectorAnalysisImageFilter<
     SymmetricSecondRankTensorImageType, EigenValueImageType,
-    EigenVectorImageType> EigenVectorAnalysisFilterType;
+    EigenVectorImageType>;
 
   EigenVectorAnalysisFilterType::Pointer eigenVectorAnalysisFilter =
     EigenVectorAnalysisFilterType::New();
@@ -154,7 +149,7 @@ int itktubeSheetnessMeasureImageFilterTest2( int argc, char * argv[] )
   EigenVectorImageType::ConstPointer eigenVectorImage =
     eigenVectorAnalysisFilter->GetOutput();
 
-  typedef itk::VectorImage< double, 3 >    VectorImageType;
+  using VectorImageType = itk::VectorImage< double, 3 >;
   VectorImageType::Pointer primaryEigenVectorImage = VectorImageType::New();
 
   unsigned int vectorLength = 3; // Eigenvector length
@@ -265,7 +260,7 @@ int itktubeSheetnessMeasureImageFilterTest2( int argc, char * argv[] )
     ++primaryEigenVectorImageIterator;
     }
 
-  typedef itk::ImageFileWriter< VectorImageType > EigenVectorWriterType;
+  using EigenVectorWriterType = itk::ImageFileWriter< VectorImageType >;
   EigenVectorWriterType::Pointer eigenVectorWriter =
     EigenVectorWriterType::New();
   eigenVectorWriter->SetFileName( argv[3] );

--- a/test/Filtering/itktubeShrinkWithBlendingImageFilterTest.cxx
+++ b/test/Filtering/itktubeShrinkWithBlendingImageFilterTest.cxx
@@ -42,22 +42,21 @@ int itktubeShrinkWithBlendingImageFilterTest( int argc, char * argv[] )
   enum { Dimension = 2 };
 
   // Define the pixel type
-  typedef float PixelType;
+  using PixelType = float;
 
   // Declare the types of the images
-  typedef itk::Image< PixelType, Dimension >  ImageType;
+  using ImageType = itk::Image< PixelType, Dimension >;
 
   // Declare the reader and writer
-  typedef itk::ImageFileReader< ImageType > ReaderType;
-  typedef itk::ImageFileWriter< ImageType > WriterType;
+  using ReaderType = itk::ImageFileReader< ImageType >;
+  using WriterType = itk::ImageFileWriter< ImageType >;
 
-  typedef itk::Vector< float, Dimension >          PointPixelType;
-  typedef itk::Image< PointPixelType, Dimension >  PointImageType;
-  typedef itk::ImageFileWriter< PointImageType >   PointImageWriterType;
+  using PointPixelType = itk::Vector< float, Dimension >;
+  using PointImageType = itk::Image< PointPixelType, Dimension >;
+  using PointImageWriterType = itk::ImageFileWriter< PointImageType >;
 
   // Declare the type for the Filter
-  typedef itk::tube::ShrinkWithBlendingImageFilter< ImageType, ImageType >
-    FilterType;
+  using FilterType = itk::tube::ShrinkWithBlendingImageFilter< ImageType, ImageType >;
 
   // Create the reader and writer
   ReaderType::Pointer reader = ReaderType::New();

--- a/test/Filtering/itktubeStructureTensorRecursiveGaussianImageFilterTest.cxx
+++ b/test/Filtering/itktubeStructureTensorRecursiveGaussianImageFilterTest.cxx
@@ -45,21 +45,21 @@ int itktubeStructureTensorRecursiveGaussianImageFilterTest( int argc,
   enum { Dimension = 3 };
 
   // Define the pixel type
-  typedef short PixelType;
+  using PixelType = short;
 
   // Declare the types of the images
-  typedef itk::Image<PixelType, Dimension>  InputImageType;
+  using InputImageType = itk::Image<PixelType, Dimension>;
 
   // Declare the reader
-  typedef itk::ImageFileReader< InputImageType > ReaderType;
+  using ReaderType = itk::ImageFileReader< InputImageType >;
 
   // Create the reader and writer
   ReaderType::Pointer reader = ReaderType::New();
   reader->SetFileName( argv[1] );
 
   // Declare the type for the
-  typedef itk::tube::StructureTensorRecursiveGaussianImageFilter <
-    InputImageType >  StructureTensorFilterType;
+  using StructureTensorFilterType = itk::tube::StructureTensorRecursiveGaussianImageFilter <
+    InputImageType >;
 
   // Create a  Filter
   StructureTensorFilterType::Pointer filter =
@@ -79,15 +79,14 @@ int itktubeStructureTensorRecursiveGaussianImageFilterTest( int argc,
   filter->Update();
 
   // Compute the eigenvectors and eigenvalues of the structure tensor matrix
-  typedef  itk::FixedArray< double, Dimension>         EigenValueArrayType;
-  typedef  itk::Image< EigenValueArrayType, Dimension> EigenValueImageType;
+  using EigenValueArrayType = itk::FixedArray< double, Dimension>;
+  using EigenValueImageType = itk::Image< EigenValueArrayType, Dimension>;
 
   typedef  StructureTensorFilterType::OutputImageType
     SymmetricSecondRankTensorImageType;
 
-  typedef itk::SymmetricEigenAnalysisImageFilter<
-    SymmetricSecondRankTensorImageType, EigenValueImageType>
-    EigenAnalysisFilterType;
+  using EigenAnalysisFilterType = itk::SymmetricEigenAnalysisImageFilter<
+    SymmetricSecondRankTensorImageType, EigenValueImageType>;
 
   EigenAnalysisFilterType::Pointer eigenAnalysisFilter =
     EigenAnalysisFilterType::New();
@@ -99,14 +98,12 @@ int itktubeStructureTensorRecursiveGaussianImageFilterTest( int argc,
   eigenAnalysisFilter->Update();
 
   // Generate eigenvector image
-  typedef  itk::Matrix< double, 3, 3>
-    EigenVectorMatrixType;
-  typedef  itk::Image< EigenVectorMatrixType, Dimension>
-    EigenVectorImageType;
+  using EigenVectorMatrixType = itk::Matrix< double, 3, 3>;
+  using EigenVectorImageType = itk::Image< EigenVectorMatrixType, Dimension>;
 
-  typedef itk::tube::SymmetricEigenVectorAnalysisImageFilter<
+  using EigenVectorAnalysisFilterType = itk::tube::SymmetricEigenVectorAnalysisImageFilter<
     SymmetricSecondRankTensorImageType, EigenValueImageType,
-    EigenVectorImageType> EigenVectorAnalysisFilterType;
+    EigenVectorImageType>;
 
   EigenVectorAnalysisFilterType::Pointer eigenVectorAnalysisFilter =
     EigenVectorAnalysisFilterType::New();
@@ -122,7 +119,7 @@ int itktubeStructureTensorRecursiveGaussianImageFilterTest( int argc,
   EigenVectorImageType::ConstPointer eigenVectorImage =
     eigenVectorAnalysisFilter->GetOutput();
 
-  typedef itk::VectorImage< double, 3 >    VectorImageType;
+  using VectorImageType = itk::VectorImage< double, 3 >;
   VectorImageType::Pointer primaryEigenVectorImage = VectorImageType::New();
 
   unsigned int vectorLength = 3; // Eigenvector length
@@ -145,7 +142,7 @@ int itktubeStructureTensorRecursiveGaussianImageFilterTest( int argc,
   primaryEigenVectorImage->FillBuffer( nullVector );
 
   //Generate an image containing the largest eigenvalues
-  typedef itk::Image< double, 3 >    PrimaryEigenValueImageType;
+  using PrimaryEigenValueImageType = itk::Image< double, 3 >;
   PrimaryEigenValueImageType::Pointer primaryEigenValueImage =
     PrimaryEigenValueImageType::New();
 
@@ -195,7 +192,7 @@ int itktubeStructureTensorRecursiveGaussianImageFilterTest( int argc,
   eigenValueImageIterator.GoToBegin();
 
   //Iterator for the structure tensor
-  typedef StructureTensorFilterType::OutputImageType TensorImageType;
+  using TensorImageType = StructureTensorFilterType::OutputImageType;
   TensorImageType::ConstPointer tensorImage = filter->GetOutput();
   itk::ImageRegionConstIterator<TensorImageType> tensorImageIterator;
   tensorImageIterator = itk::ImageRegionConstIterator<TensorImageType>(
@@ -280,14 +277,13 @@ int itktubeStructureTensorRecursiveGaussianImageFilterTest( int argc,
 
     }
 
-  typedef itk::ImageFileWriter< VectorImageType > WriterType;
+  using WriterType = itk::ImageFileWriter< VectorImageType >;
   WriterType::Pointer writer = WriterType::New();
   writer->SetFileName( argv[2] );
   writer->SetInput( primaryEigenVectorImage );
   writer->Update();
 
-  typedef itk::ImageFileWriter< PrimaryEigenValueImageType >
-    EigenValueImageWriterType;
+  using EigenValueImageWriterType = itk::ImageFileWriter< PrimaryEigenValueImageType >;
   EigenValueImageWriterType::Pointer eigenValueWriter =
     EigenValueImageWriterType::New();
   eigenValueWriter->SetFileName( argv[3] );

--- a/test/Filtering/itktubeStructureTensorRecursiveGaussianImageFilterTestNew.cxx
+++ b/test/Filtering/itktubeStructureTensorRecursiveGaussianImageFilterTestNew.cxx
@@ -30,8 +30,8 @@ int itktubeStructureTensorRecursiveGaussianImageFilterTestNew( int argc, char * 
 {
   // Define image
   enum { Dimension = 3 };
-  typedef double PixelType;
-  typedef itk::Image<PixelType, Dimension>  ImageType;
+  using PixelType = double;
+  using ImageType = itk::Image<PixelType, Dimension>;
 
   // Set the value of sigma if specified in command line
   double sigma = 0.1;
@@ -88,14 +88,14 @@ int itktubeStructureTensorRecursiveGaussianImageFilterTestNew( int argc, char * 
     it.Set( static_cast<ImageType::PixelType>( std::sin( point[0] ) ) ); //sinx
     }
 
-  typedef itk::ImageFileWriter<ImageType>        WriterType;
+  using WriterType = itk::ImageFileWriter<ImageType>;
   WriterType::Pointer writer = WriterType::New();
   writer->SetFileName( "sin.mha" );
   writer->SetInput( inImage );
   writer->Update();
 
   // Create a copy of the image
-  typedef itk::ImageDuplicator<ImageType>        ImageDuplicatorType;
+  using ImageDuplicatorType = itk::ImageDuplicator<ImageType>;
 
   ImageDuplicatorType::Pointer duplicator = ImageDuplicatorType::New();
   duplicator->SetInputImage( inImage );
@@ -116,8 +116,7 @@ int itktubeStructureTensorRecursiveGaussianImageFilterTestNew( int argc, char * 
     }
 
   // Compute reference image as convolution of Gaussian and product of gradient
-  typedef itk::RecursiveGaussianImageFilter<ImageType, ImageType>
-                                                 GaussianFilterType;
+  using GaussianFilterType = itk::RecursiveGaussianImageFilter<ImageType, ImageType>;
 
   ImageType::Pointer refImage = prodImage;
   for( unsigned int i = 0; i < Dimension; i++ )
@@ -136,8 +135,7 @@ int itktubeStructureTensorRecursiveGaussianImageFilterTestNew( int argc, char * 
   writer1->Update();
 
   // Declare the type for the filter
-  typedef itk::tube::StructureTensorRecursiveGaussianImageFilter<ImageType>
-                                                     StructureTensorFilterType;
+  using StructureTensorFilterType = itk::tube::StructureTensorRecursiveGaussianImageFilter<ImageType>;
 
   // Create a  Filter
   StructureTensorFilterType::Pointer filter = StructureTensorFilterType::New();
@@ -152,12 +150,12 @@ int itktubeStructureTensorRecursiveGaussianImageFilterTestNew( int argc, char * 
   filter->Update();
 
   // Define output type
-  typedef StructureTensorFilterType::OutputImageType TensorImageType;
-  typedef StructureTensorFilterType::OutputPixelType TensorImagePixelType;
+  using TensorImageType = StructureTensorFilterType::OutputImageType;
+  using TensorImagePixelType = StructureTensorFilterType::OutputPixelType;
 
   TensorImageType::Pointer outImage = filter->GetOutput();
 
-  typedef itk::ImageFileWriter<TensorImageType>     TensorWriterType;
+  using TensorWriterType = itk::ImageFileWriter<TensorImageType>;
   TensorWriterType::Pointer writer2 = TensorWriterType::New();
   writer2->SetFileName( "tensor.nrrd" );
   writer2->SetInput( outImage );

--- a/test/Filtering/itktubeSubSampleSpatialObjectFilterTest.cxx
+++ b/test/Filtering/itktubeSubSampleSpatialObjectFilterTest.cxx
@@ -39,10 +39,10 @@ int itktubeSubSampleSpatialObjectFilterTest( int argc, char * argv[] )
   const char * outputTubeNetwork = argv[2];
 
   enum { Dimension = 3 };
-  typedef itk::GroupSpatialObject< Dimension >  GroupSpatialObjectType;
+  using GroupSpatialObjectType = itk::GroupSpatialObject< Dimension >;
 
   // Read input tube tree.
-  typedef itk::SpatialObjectReader< Dimension >  ReaderType;
+  using ReaderType = itk::SpatialObjectReader< Dimension >;
   ReaderType::Pointer reader = ReaderType::New();
   reader->SetFileName( inputTubeNetwork );
   try
@@ -60,8 +60,8 @@ int itktubeSubSampleSpatialObjectFilterTest( int argc, char * argv[] )
     << std::endl;
 
   // Sub-sample the tube tree.
-  typedef itk::tube::SubSampleSpatialObjectFilter<>
-      SubSampleFilterType;
+  using SubSampleFilterType =
+      itk::tube::SubSampleSpatialObjectFilter<>;
   SubSampleFilterType::Pointer subSampleFilter =
     SubSampleFilterType::New();
   subSampleFilter->SetInput( reader->GetGroup() );
@@ -75,7 +75,7 @@ int itktubeSubSampleSpatialObjectFilterTest( int argc, char * argv[] )
     }
 
   // Write output tube tree.
-  typedef itk::SpatialObjectWriter< Dimension > WriterType;
+  using WriterType = itk::SpatialObjectWriter< Dimension >;
   WriterType::Pointer writer = WriterType::New();
   writer->SetFileName( outputTubeNetwork );
   writer->SetInput( subSampleFilter->GetOutput() );

--- a/test/Filtering/itktubeSubSampleTubeSpatialObjectFilterTest.cxx
+++ b/test/Filtering/itktubeSubSampleTubeSpatialObjectFilterTest.cxx
@@ -39,10 +39,10 @@ int itktubeSubSampleTubeSpatialObjectFilterTest( int argc, char * argv[] )
   const char * outputTubeNetwork = argv[2];
 
   enum { ObjectDimension = 3 };
-  typedef itk::TubeSpatialObject< ObjectDimension >   TubeSpatialObjectType;
-  typedef itk::GroupSpatialObject< ObjectDimension >  GroupSpatialObjectType;
+  using TubeSpatialObjectType = itk::TubeSpatialObject< ObjectDimension >;
+  using GroupSpatialObjectType = itk::GroupSpatialObject< ObjectDimension >;
 
-  typedef itk::SpatialObjectReader< ObjectDimension >  ReaderType;
+  using ReaderType = itk::SpatialObjectReader< ObjectDimension >;
   ReaderType::Pointer reader = ReaderType::New();
   reader->SetFileName( inputTubeNetwork );
   try
@@ -73,8 +73,7 @@ int itktubeSubSampleTubeSpatialObjectFilterTest( int argc, char * argv[] )
       dynamic_cast< TubeSpatialObjectType * >( ( *it ).GetPointer() );
     if( pointBasedSpatialObject )
       {
-      typedef itk::tube::SubSampleTubeSpatialObjectFilter< ObjectDimension >
-        SubSampleFilterType;
+      using SubSampleFilterType = itk::tube::SubSampleTubeSpatialObjectFilter< ObjectDimension >;
       SubSampleFilterType::Pointer subSampleFilter = SubSampleFilterType::New();
       const unsigned int samplingFactor = 5;
       subSampleFilter->SetSampling( samplingFactor );
@@ -94,7 +93,7 @@ int itktubeSubSampleTubeSpatialObjectFilterTest( int argc, char * argv[] )
     }
 
 
-  typedef itk::SpatialObjectWriter< ObjectDimension > WriterType;
+  using WriterType = itk::SpatialObjectWriter< ObjectDimension >;
   WriterType::Pointer writer = WriterType::New();
   writer->SetFileName( outputTubeNetwork );
   writer->SetInput( output );

--- a/test/Filtering/itktubeTortuositySpatialObjectFilterTest.cxx
+++ b/test/Filtering/itktubeTortuositySpatialObjectFilterTest.cxx
@@ -37,8 +37,8 @@ GenerateStraightTube( itk::TubeSpatialObject<3>::PointType
   start, itk::TubeSpatialObject<3>::VectorType increment,
   int numberOfPoints, itk::TubeSpatialObject<3>::Pointer & vessel )
 {
-  typedef itk::TubeSpatialObject<3>        VesselTubeType;
-  typedef VesselTubeType::PointType        PointType;
+  using VesselTubeType = itk::TubeSpatialObject<3>;
+  using PointType = VesselTubeType::PointType;
 
   vessel = VesselTubeType::New();
   VesselTubeType::TubePointListType tubePointList;
@@ -72,8 +72,8 @@ void
 GenerateCosTube( double length, double amplitude, double frequency,
   itk::TubeSpatialObject<3>::Pointer & vessel )
 {
-  typedef itk::TubeSpatialObject<3>   VesselTubeType;
-  typedef VesselTubeType::PointType   PointType;
+  using VesselTubeType = itk::TubeSpatialObject<3>;
+  using PointType = VesselTubeType::PointType;
 
   vessel = VesselTubeType::New();
   VesselTubeType::TubePointListType tubePointList;
@@ -103,10 +103,9 @@ GenerateCosTube( double length, double amplitude, double frequency,
 bool TestVesselMetrics( itk::TubeSpatialObject<3>::Pointer &
   vessel, double results[] )
 {
-  typedef itk::TubeSpatialObject<3>   VesselTubeType;
+  using VesselTubeType = itk::TubeSpatialObject<3>;
 
-  typedef itk::tube::TortuositySpatialObjectFilter<VesselTubeType>
-    FilterType;
+  using FilterType = itk::tube::TortuositySpatialObjectFilter<VesselTubeType>;
 
   // Run the metrics
   FilterType::Pointer filter = FilterType::New();
@@ -213,7 +212,7 @@ bool TestVesselMetrics( itk::TubeSpatialObject<3>::Pointer &
 //--------------------------------------------------------------------------
 int itktubeTortuositySpatialObjectFilterTest( int, char*[] )
 {
-  typedef itk::TubeSpatialObject<3> VesselTubeType;
+  using VesselTubeType = itk::TubeSpatialObject<3>;
 
   //
   // Test straight spatial objects

--- a/test/Filtering/itktubeTubeEnhancingDiffusion2DImageFilterTest.cxx
+++ b/test/Filtering/itktubeTubeEnhancingDiffusion2DImageFilterTest.cxx
@@ -41,19 +41,19 @@ int itktubeTubeEnhancingDiffusion2DImageFilterTest( int argc, char * argv[] )
   enum { Dimension = 2 };
 
   // Define the pixel type
-  typedef float PixelType;
+  using PixelType = float;
 
   // Declare the types of the images
-  typedef itk::Image<PixelType, Dimension>  ImageType;
+  using ImageType = itk::Image<PixelType, Dimension>;
 
   // Declare the reader and writer
-  typedef itk::ImageFileReader< ImageType > ReaderType;
-  typedef itk::ImageFileWriter< ImageType > WriterType;
+  using ReaderType = itk::ImageFileReader< ImageType >;
+  using WriterType = itk::ImageFileWriter< ImageType >;
 
 
   // Declare the type for the Filter
-  typedef itk::tube::TubeEnhancingDiffusion2DImageFilter<
-    PixelType, Dimension > FilterType;
+  using FilterType = itk::tube::TubeEnhancingDiffusion2DImageFilter<
+    PixelType, Dimension >;
 
   // Create the reader and writer
   ReaderType::Pointer reader = ReaderType::New();

--- a/test/Filtering/tubeFilteringPrintTest.cxx
+++ b/test/Filtering/tubeFilteringPrintTest.cxx
@@ -46,8 +46,8 @@ int tubeFilteringPrintTest( int itkNotUsed( argc ), char * itkNotUsed(
   argv )[] )
 {
   const unsigned int Dimension = 3;
-  typedef itk::Image< float, Dimension >      ImageType;
-  typedef itk::TubeSpatialObject< Dimension > TubeSpatialObjectType;
+  using ImageType = itk::Image< float, Dimension >;
+  using TubeSpatialObjectType = itk::TubeSpatialObject< Dimension >;
 
   itk::tube::AnisotropicCoherenceEnhancingDiffusionImageFilter< ImageType,
     ImageType > ::Pointer acedif =
@@ -72,38 +72,37 @@ int tubeFilteringPrintTest( int itkNotUsed( argc ), char * itkNotUsed(
     ::New();
   std::cout << "-------------ahdif" << ahdif << std::endl;
 
-  typedef itk::tube::CropImageFilter< ImageType,
-    ImageType > CropImageFilter;
+  using CropImageFilter = itk::tube::CropImageFilter< ImageType,
+    ImageType >;
   CropImageFilter::Pointer cropImage = CropImageFilter::New();
   std::cout << "-------------cropImage" << cropImage << std::endl;
 
-  typedef itk::tube::CVTImageFilter< ImageType > CVTImageFilter;
+  using CVTImageFilter = itk::tube::CVTImageFilter< ImageType >;
   CVTImageFilter::Pointer cvtImage = CVTImageFilter::New();
   std::cout << "-------------cvtImage" << cvtImage << std::endl;
 
-  typedef itk::tube::ExtractTubePointsSpatialObjectFilter<
-    TubeSpatialObjectType > ExtractTubePointsSpatialObjectFilterType;
+  using ExtractTubePointsSpatialObjectFilterType = itk::tube::ExtractTubePointsSpatialObjectFilter<
+    TubeSpatialObjectType >;
   ExtractTubePointsSpatialObjectFilterType::Pointer etpsof =
     ExtractTubePointsSpatialObjectFilterType::New();
   std::cout << "-------------etpsof" << etpsof << std::endl;
 
-  typedef itk::tube::FFTGaussianDerivativeIFFTFilter< ImageType >
-    FFTGaussianDerivativeIFFTFilter;
+  using FFTGaussianDerivativeIFFTFilter = itk::tube::FFTGaussianDerivativeIFFTFilter< ImageType >;
   FFTGaussianDerivativeIFFTFilter::Pointer fgdif =
     FFTGaussianDerivativeIFFTFilter::New();
   std::cout << "-------------fgdif " << fgdif << std::endl;
 
-  typedef itk::tube::MinimumSpanningTreeVesselConnectivityFilter<
-    Dimension > VesselConnectivityFilterType;
+  using VesselConnectivityFilterType = itk::tube::MinimumSpanningTreeVesselConnectivityFilter<
+    Dimension >;
   VesselConnectivityFilterType::Pointer mstvcf =
     VesselConnectivityFilterType::New();
   std::cout << "-------------mstvcf " << mstvcf << std::endl;
 
-  typedef itk::tube::RidgeFFTFilter< ImageType > RidgeFFTFilterType;
+  using RidgeFFTFilterType = itk::tube::RidgeFFTFilter< ImageType >;
   RidgeFFTFilterType::Pointer rfif = RidgeFFTFilterType::New();
   std::cout << "-------------rfif " << rfif << std::endl;
 
-  typedef itk::tube::ReResampleImageFilter< float, 3 > ReResampleImageFilterType;
+  using ReResampleImageFilterType = itk::tube::ReResampleImageFilter< float, 3 >;
   ReResampleImageFilterType::Pointer rrif = ReResampleImageFilterType::New();
   std::cout << "-------------rrif " << rrif << std::endl;
 
@@ -113,10 +112,10 @@ int tubeFilteringPrintTest( int itkNotUsed( argc ), char * itkNotUsed(
     ::New();
   std::cout << "-------------strgif" << strgif << std::endl;
 
-  typedef itk::FixedArray< float, 3 >            EigenValueArrayType;
-  typedef itk::Matrix< float, 3, 3 >             EigenVectorMatrixType;
-  typedef itk::Image< EigenValueArrayType, 3>    EigenValueImageType;
-  typedef itk::Image< EigenVectorMatrixType, 3>  EigenVectorImageType;
+  using EigenValueArrayType = itk::FixedArray< float, 3 >;
+  using EigenVectorMatrixType = itk::Matrix< float, 3, 3 >;
+  using EigenValueImageType = itk::Image< EigenValueArrayType, 3>;
+  using EigenVectorImageType = itk::Image< EigenVectorMatrixType, 3>;
 
   typedef itk::tube::StructureTensorRecursiveGaussianImageFilter<
     ImageType >::OutputImageType SymmetricSecondRankTensorImageType;

--- a/test/Filtering/tubeTubeMathFiltersTest.cxx
+++ b/test/Filtering/tubeTubeMathFiltersTest.cxx
@@ -28,7 +28,7 @@ limitations under the License.
 
 double tubeLength( itk::TubeSpatialObject<3> * tube )
 {
-  typedef itk::TubeSpatialObject<3>   TubeType;
+  using TubeType = itk::TubeSpatialObject<3>;
 
   TubeType::TubePointListType tubePointList = tube->GetPoints();
   TubeType::TubePointListType::iterator tubePointItr;
@@ -62,7 +62,7 @@ int tubeTubeMathFiltersTest( int tubeNotUsed( argc ),
 {
   bool returnStatus = EXIT_SUCCESS;
 
-  typedef itk::TubeSpatialObject<3>   TubeType;
+  using TubeType = itk::TubeSpatialObject<3>;
 
   TubeType::Pointer tube = TubeType::New();
   TubeType::Pointer tube0 = TubeType::New();
@@ -70,7 +70,7 @@ int tubeTubeMathFiltersTest( int tubeNotUsed( argc ),
   TubeType::TubePointListType tubePointList;
   TubeType::TubePointType tubePoint;
 
-  typedef itk::Statistics::MersenneTwisterRandomVariateGenerator RandomType;
+  using RandomType = itk::Statistics::MersenneTwisterRandomVariateGenerator;
   RandomType::Pointer rndGen = RandomType::New();
   rndGen->Initialize( 1 );
 

--- a/test/IO/itktubePDFSegmenterParzenIOTest.cxx
+++ b/test/IO/itktubePDFSegmenterParzenIOTest.cxx
@@ -40,18 +40,17 @@ int itktubePDFSegmenterParzenIOTest( int argc, char * argv[] )
   enum { Dimension = 2 };
 
   // Define the pixel type
-  typedef float PixelType;
+  using PixelType = float;
 
   // Declare the types of the images
-  typedef itk::Image<PixelType, Dimension>  ImageType;
+  using ImageType = itk::Image<PixelType, Dimension>;
 
   // Declare the reader and writer
-  typedef itk::ImageFileReader< ImageType > ReaderType;
-  typedef itk::ImageFileWriter< ImageType > WriterType;
+  using ReaderType = itk::ImageFileReader< ImageType >;
+  using WriterType = itk::ImageFileWriter< ImageType >;
 
   // Declare the type for the Filter
-  typedef itk::tube::PDFSegmenterParzen< ImageType, ImageType >
-    FilterType;
+  using FilterType = itk::tube::PDFSegmenterParzen< ImageType, ImageType >;
 
   // Create the reader and writer
   ReaderType::Pointer reader = ReaderType::New();

--- a/test/IO/itktubeRidgeSeedFilterIOTest.cxx
+++ b/test/IO/itktubeRidgeSeedFilterIOTest.cxx
@@ -41,21 +41,20 @@ int itktubeRidgeSeedFilterIOTest( int argc, char * argv[] )
   enum { Dimension = 2 };
 
   // Define the pixel type
-  typedef float PixelType;
+  using PixelType = float;
 
   // Declare the types of the images
-  typedef itk::Image<PixelType, Dimension>  ImageType;
+  using ImageType = itk::Image<PixelType, Dimension>;
 
   // Declare the reader and writer
-  typedef itk::ImageFileReader< ImageType > ReaderType;
+  using ReaderType = itk::ImageFileReader< ImageType >;
 
-  typedef itk::Image< unsigned char, Dimension >    LabelMapType;
-  typedef itk::ImageFileReader< LabelMapType >      LabelMapReaderType;
-  typedef itk::ImageFileWriter< LabelMapType >      LabelMapWriterType;
+  using LabelMapType = itk::Image< unsigned char, Dimension >;
+  using LabelMapReaderType = itk::ImageFileReader< LabelMapType >;
+  using LabelMapWriterType = itk::ImageFileWriter< LabelMapType >;
 
   // Declare the type for the Filter
-  typedef itk::tube::RidgeSeedFilter< ImageType, LabelMapType >
-    FilterType;
+  using FilterType = itk::tube::RidgeSeedFilter< ImageType, LabelMapType >;
 
   timeCollector.Start( "Reader" );
   // Create the reader

--- a/test/IO/itktubeTubeExtractorIOTest.cxx
+++ b/test/IO/itktubeTubeExtractorIOTest.cxx
@@ -34,10 +34,10 @@ int itktubeTubeExtractorIOTest( int argc, char * argv[] )
     }
 
   // Prep
-  typedef itk::Image< float, 3 >                     ImageType;
+  using ImageType = itk::Image< float, 3 >;
 
   // Declare the type for the Filter
-  typedef itk::tube::TubeExtractorIO< ImageType >    IOMethodType;
+  using IOMethodType = itk::tube::TubeExtractorIO< ImageType >;
 
   // TubeExtractor must have been assigned an input image prior to
   //   reading parameters into it.

--- a/test/IO/itktubeTubeXIOTest.cxx
+++ b/test/IO/itktubeTubeXIOTest.cxx
@@ -35,7 +35,7 @@ int itktubeTubeXIOTest( int argc, char * argv[] )
     }
 
   // Declare the type for the Filter
-  typedef itk::tube::TubeXIO< 3 >    IOMethodType;
+  using IOMethodType = itk::tube::TubeXIO< 3 >;
   IOMethodType::Pointer ioMethod = IOMethodType::New();
 
   if( !ioMethod->Read( argv[1] ) )

--- a/test/IO/tubeIOPrintTest.cxx
+++ b/test/IO/tubeIOPrintTest.cxx
@@ -27,7 +27,7 @@ limitations under the License.
 
 int tubeIOPrintTest( int tubeNotUsed( argc ), char * tubeNotUsed( argv )[] )
 {
-  typedef itk::Image< float, 3 > ImageType;
+  using ImageType = itk::Image< float, 3 >;
   itk::tube::PDFSegmenterParzenIO< ImageType,
     ImageType > pdfSegmenterParzenIO;
   std::cout << "-------------pdfSegmenterParzenIO" << std::endl;

--- a/test/Numerics/itktubeBlurImageFunctionTest.cxx
+++ b/test/Numerics/itktubeBlurImageFunctionTest.cxx
@@ -35,9 +35,9 @@ int itktubeBlurImageFunctionTest( int argc, char * argv[] )
     return EXIT_FAILURE;
     }
 
-  typedef itk::Image<float, 3>   ImageType;
-  typedef ImageType::SizeType    ImageSizeType;
-  typedef ImageType::SpacingType ImageSpacingType;
+  using ImageType = itk::Image<float, 3>;
+  using ImageSizeType = ImageType::SizeType;
+  using ImageSpacingType = ImageType::SpacingType;
 
   ImageType::Pointer im = ImageType::New();
 
@@ -72,7 +72,7 @@ int itktubeBlurImageFunctionTest( int argc, char * argv[] )
   index[2] = 15;
   im->SetPixel( index, 100 );
 
-  typedef itk::tube::BlurImageFunction<ImageType> ImageOpType;
+  using ImageOpType = itk::tube::BlurImageFunction<ImageType>;
   ImageOpType::Pointer imOp = ImageOpType::New();
 
   imOp->SetInputImage( im );
@@ -102,7 +102,7 @@ int itktubeBlurImageFunctionTest( int argc, char * argv[] )
     ++itOut;
     }
 
-  typedef itk::ImageFileWriter<ImageType> ImageWriterType;
+  using ImageWriterType = itk::ImageFileWriter<ImageType>;
   ImageWriterType::Pointer imWriter = ImageWriterType::New();
   imWriter->SetFileName( argv[1] );
   imWriter->SetInput( imOut );

--- a/test/Numerics/itktubeImageRegionMomentsCalculatorTest.cxx
+++ b/test/Numerics/itktubeImageRegionMomentsCalculatorTest.cxx
@@ -42,17 +42,17 @@ int itktubeImageRegionMomentsCalculatorTest( int argc, char * argv[] )
   enum { Dimension = 2 };
 
   // Define the pixel type
-  typedef float PixelType;
+  using PixelType = float;
 
   // Declare the types of the images
-  typedef itk::Image<PixelType, Dimension>  ImageType;
+  using ImageType = itk::Image<PixelType, Dimension>;
 
   // Declare the reader and writer
-  typedef itk::ImageFileReader< ImageType > ReaderType;
+  using ReaderType = itk::ImageFileReader< ImageType >;
 
 
   // Declare the type for the Filter
-  typedef itk::tube::ImageRegionMomentsCalculator< ImageType > FilterType;
+  using FilterType = itk::tube::ImageRegionMomentsCalculator< ImageType >;
 
   // Create the reader and writer
   ReaderType::Pointer reader = ReaderType::New();

--- a/test/Numerics/itktubeJointHistogramImageFunctionTest.cxx
+++ b/test/Numerics/itktubeJointHistogramImageFunctionTest.cxx
@@ -42,20 +42,19 @@ int itktubeJointHistogramImageFunctionTest( int argc, char * argv[] )
   enum { Dimension = 2 };
 
   // Define the pixel type
-  typedef float PixelType;
+  using PixelType = float;
 
   // Declare the types of the images
-  typedef itk::Image<PixelType, Dimension>  ImageType;
+  using ImageType = itk::Image<PixelType, Dimension>;
 
   // Declare the reader and writer
-  typedef itk::ImageFileReader< ImageType > ReaderType;
-  typedef itk::ImageFileWriter< ImageType > WriterType;
+  using ReaderType = itk::ImageFileReader< ImageType >;
+  using WriterType = itk::ImageFileWriter< ImageType >;
 
   // Declare the type for the Filter
-  typedef itk::tube::JointHistogramImageFunction< ImageType > FunctionType;
+  using FunctionType = itk::tube::JointHistogramImageFunction< ImageType >;
 
-  typedef itk::ImageFileWriter< FunctionType::HistogramType >
-                                                        HistoWriterType;
+  using HistoWriterType = itk::ImageFileWriter< FunctionType::HistogramType >;
 
   // Create the reader and writer
   ReaderType::Pointer reader = ReaderType::New();

--- a/test/Numerics/itktubeNJetBasisFeatureVectorGeneratorTest.cxx
+++ b/test/Numerics/itktubeNJetBasisFeatureVectorGeneratorTest.cxx
@@ -44,24 +44,22 @@ int itktubeNJetBasisFeatureVectorGeneratorTest( int argc, char * argv[] )
   enum { Dimension = 2 };
 
   // Define the pixel type
-  typedef float PixelType;
+  using PixelType = float;
 
   // Declare the types of the images
-  typedef itk::Image<PixelType, Dimension>  ImageType;
+  using ImageType = itk::Image<PixelType, Dimension>;
 
   // Declare the reader and writer
-  typedef itk::ImageFileReader< ImageType > ReaderType;
-  typedef itk::ImageFileWriter< ImageType > WriterType;
+  using ReaderType = itk::ImageFileReader< ImageType >;
+  using WriterType = itk::ImageFileWriter< ImageType >;
 
-  typedef itk::Image< unsigned char, Dimension >    LabelMapType;
-  typedef itk::ImageFileReader< LabelMapType >      LabelMapReaderType;
+  using LabelMapType = itk::Image< unsigned char, Dimension >;
+  using LabelMapReaderType = itk::ImageFileReader< LabelMapType >;
 
 
   // Declare the type for the filter
-  typedef itk::tube::NJetFeatureVectorGenerator< ImageType >
-    FilterType;
-  typedef itk::tube::BasisFeatureVectorGenerator< ImageType, LabelMapType >
-    BasisFilterType;
+  using FilterType = itk::tube::NJetFeatureVectorGenerator< ImageType >;
+  using BasisFilterType = itk::tube::BasisFeatureVectorGenerator< ImageType, LabelMapType >;
 
   // Create the reader
   ReaderType::Pointer reader = ReaderType::New();

--- a/test/Numerics/itktubeNJetFeatureVectorGeneratorTest.cxx
+++ b/test/Numerics/itktubeNJetFeatureVectorGeneratorTest.cxx
@@ -39,18 +39,18 @@ int itktubeNJetFeatureVectorGeneratorTest( int argc, char * argv[] )
   enum { Dimension = 2 };
 
   // Define the pixel type
-  typedef float PixelType;
+  using PixelType = float;
 
   // Declare the types of the images
-  typedef itk::Image<PixelType, Dimension>  ImageType;
+  using ImageType = itk::Image<PixelType, Dimension>;
 
   // Declare the reader and writer
-  typedef itk::ImageFileReader< ImageType > ReaderType;
-  typedef itk::ImageFileWriter< ImageType > WriterType;
+  using ReaderType = itk::ImageFileReader< ImageType >;
+  using WriterType = itk::ImageFileWriter< ImageType >;
 
 
   // Declare the type for the Filter
-  typedef itk::tube::NJetFeatureVectorGenerator< ImageType > FilterType;
+  using FilterType = itk::tube::NJetFeatureVectorGenerator< ImageType >;
 
   // Create the reader and writer
   ReaderType::Pointer reader = ReaderType::New();

--- a/test/Numerics/itktubeNJetImageFunctionTest.cxx
+++ b/test/Numerics/itktubeNJetImageFunctionTest.cxx
@@ -40,18 +40,18 @@ int itktubeNJetImageFunctionTest( int argc, char * argv[] )
   enum { Dimension = 2 };
 
   // Define the pixel type
-  typedef float PixelType;
+  using PixelType = float;
 
   // Declare the types of the images
-  typedef itk::Image<PixelType, Dimension>  ImageType;
+  using ImageType = itk::Image<PixelType, Dimension>;
 
   // Declare the reader and writer
-  typedef itk::ImageFileReader< ImageType > ReaderType;
-  typedef itk::ImageFileWriter< ImageType > WriterType;
+  using ReaderType = itk::ImageFileReader< ImageType >;
+  using WriterType = itk::ImageFileWriter< ImageType >;
 
 
   // Declare the type for the Filter
-  typedef itk::tube::NJetImageFunction< ImageType > FunctionType;
+  using FunctionType = itk::tube::NJetImageFunction< ImageType >;
 
   // Create the reader and writer
   ReaderType::Pointer reader = ReaderType::New();
@@ -68,7 +68,7 @@ int itktubeNJetImageFunctionTest( int argc, char * argv[] )
 
   ImageType::Pointer inputImage = reader->GetOutput();
 
-  typedef itk::tube::NJetImageFunction< ImageType >   FunctionType;
+  using FunctionType = itk::tube::NJetImageFunction< ImageType >;
   FunctionType::Pointer func = FunctionType::New();
   func->SetInputImage( inputImage );
 

--- a/test/Numerics/itktubeRidgeBasisFeatureVectorGeneratorTest.cxx
+++ b/test/Numerics/itktubeRidgeBasisFeatureVectorGeneratorTest.cxx
@@ -40,24 +40,22 @@ int itktubeRidgeBasisFeatureVectorGeneratorTest( int argc, char * argv[] )
   enum { Dimension = 2 };
 
   // Define the pixel type
-  typedef float PixelType;
+  using PixelType = float;
 
   // Declare the types of the images
-  typedef itk::Image<PixelType, Dimension>  ImageType;
+  using ImageType = itk::Image<PixelType, Dimension>;
 
   // Declare the reader and writer
-  typedef itk::ImageFileReader< ImageType > ReaderType;
-  typedef itk::ImageFileWriter< ImageType > WriterType;
+  using ReaderType = itk::ImageFileReader< ImageType >;
+  using WriterType = itk::ImageFileWriter< ImageType >;
 
-  typedef itk::Image<unsigned char, Dimension>      LabelMapType;
-  typedef itk::ImageFileReader< LabelMapType >      LabelMapReaderType;
+  using LabelMapType = itk::Image<unsigned char, Dimension>;
+  using LabelMapReaderType = itk::ImageFileReader< LabelMapType >;
 
 
   // Declare the type for the Filter
-  typedef itk::tube::RidgeFFTFeatureVectorGenerator< ImageType >
-    FilterType;
-  typedef itk::tube::BasisFeatureVectorGenerator< ImageType, LabelMapType >
-    BasisFilterType;
+  using FilterType = itk::tube::RidgeFFTFeatureVectorGenerator< ImageType >;
+  using BasisFilterType = itk::tube::BasisFeatureVectorGenerator< ImageType, LabelMapType >;
 
   // Create the reader
   ReaderType::Pointer reader = ReaderType::New();

--- a/test/Numerics/itktubeRidgeFFTFeatureVectorGeneratorTest.cxx
+++ b/test/Numerics/itktubeRidgeFFTFeatureVectorGeneratorTest.cxx
@@ -39,18 +39,18 @@ int itktubeRidgeFFTFeatureVectorGeneratorTest( int argc, char * argv[] )
   enum { Dimension = 2 };
 
   // Define the pixel type
-  typedef float PixelType;
+  using PixelType = float;
 
   // Declare the types of the images
-  typedef itk::Image<PixelType, Dimension>  ImageType;
+  using ImageType = itk::Image<PixelType, Dimension>;
 
   // Declare the reader and writer
-  typedef itk::ImageFileReader< ImageType > ReaderType;
-  typedef itk::ImageFileWriter< ImageType > WriterType;
+  using ReaderType = itk::ImageFileReader< ImageType >;
+  using WriterType = itk::ImageFileWriter< ImageType >;
 
 
   // Declare the type for the Filter
-  typedef itk::tube::RidgeFFTFeatureVectorGenerator< ImageType > FilterType;
+  using FilterType = itk::tube::RidgeFFTFeatureVectorGenerator< ImageType >;
 
   // Create the reader and writer
   ReaderType::Pointer reader = ReaderType::New();

--- a/test/Numerics/itktubeSingleValuedCostFunctionImageSourceTest.cxx
+++ b/test/Numerics/itktubeSingleValuedCostFunctionImageSourceTest.cxx
@@ -35,20 +35,20 @@ class ArthurDentCostFunction:
   public SingleValuedCostFunction
 {
 public:
-  /** Standard class typedefs. */
-  typedef ArthurDentCostFunction        Self;
-  typedef SingleValuedCostFunction      Superclass;
-  typedef SmartPointer< Self >          Pointer;
-  typedef SmartPointer< const Self >    ConstPointer;
+  /** Standard class type alias. */
+  using Self = ArthurDentCostFunction;
+  using Superclass = SingleValuedCostFunction;
+  using Pointer = SmartPointer< Self >;
+  using ConstPointer = SmartPointer< const Self >;
 
   /** Run-time type information ( and related methods ). */
   itkTypeMacro( ArthurDentCostFunction, SingleValuedCostFunction );
 
   itkNewMacro( Self );
 
-  typedef Superclass::MeasureType         MeasureType;
-  typedef Superclass::ParametersType      ParametersType;
-  typedef Superclass::ParametersValueType ParametersValueType;
+  using MeasureType = Superclass::MeasureType;
+  using ParametersType = Superclass::ParametersType;
+  using ParametersValueType = Superclass::ParametersValueType;
 
   virtual MeasureType GetValue( const ParametersType & parameters ) const
     override
@@ -92,19 +92,18 @@ int itktubeSingleValuedCostFunctionImageSourceTest( int argc, char * argv[] )
     }
   const char * outputCostFunctionImage = argv[1];
 
-  typedef float      FloatType;
+  using FloatType = float;
   const unsigned int Dimension = 3;
 
-  typedef itk::ArthurDentCostFunction CostFunctionType;
+  using CostFunctionType = itk::ArthurDentCostFunction;
   CostFunctionType::Pointer costFunction = CostFunctionType::New();
 
-  typedef itk::tube::SingleValuedCostFunctionImageSource< CostFunctionType, Dimension >
-    CostFunctionImageSourceType;
+  using CostFunctionImageSourceType = itk::tube::SingleValuedCostFunctionImageSource< CostFunctionType, Dimension >;
   CostFunctionImageSourceType::Pointer costFunctionImageSource =
     CostFunctionImageSourceType::New();
   costFunctionImageSource->SetCostFunction( costFunction );
 
-  typedef CostFunctionImageSourceType::ParametersType ParametersType;
+  using ParametersType = CostFunctionImageSourceType::ParametersType;
 
   ParametersType parametersLowerBound( Dimension );
   parametersLowerBound[0] = -5.0;
@@ -124,14 +123,14 @@ int itktubeSingleValuedCostFunctionImageSourceTest( int argc, char * argv[] )
   parametersStep[2] = 0.5;
   costFunctionImageSource->SetParametersStep( parametersStep );
 
-  typedef itk::Image< FloatType, Dimension > OutputImageType;
+  using OutputImageType = itk::Image< FloatType, Dimension >;
 
-  typedef itk::CastImageFilter< CostFunctionImageSourceType::OutputImageType,
-    OutputImageType > CastImageFilterType;
+  using CastImageFilterType = itk::CastImageFilter< CostFunctionImageSourceType::OutputImageType,
+    OutputImageType >;
   CastImageFilterType::Pointer castImageFilter = CastImageFilterType::New();
   castImageFilter->SetInput( costFunctionImageSource->GetOutput() );
 
-  typedef itk::ImageFileWriter< OutputImageType > WriterType;
+  using WriterType = itk::ImageFileWriter< OutputImageType >;
   WriterType::Pointer writer = WriterType::New();
   writer->SetFileName( outputCostFunctionImage );
   writer->SetInput( castImageFilter->GetOutput() );

--- a/test/Numerics/itktubeVotingResampleImageFunctionTest.cxx
+++ b/test/Numerics/itktubeVotingResampleImageFunctionTest.cxx
@@ -41,19 +41,17 @@ int itktubeVotingResampleImageFunctionTest( int argc, char * argv[] )
     }
 
   const unsigned int Dimension = 2;
-  typedef unsigned char                       PixelType;
-  typedef itk::Image<PixelType, Dimension>    ImageType;
+  using PixelType = unsigned char;
+  using ImageType = itk::Image<PixelType, Dimension>;
 
-  typedef ImageType::IndexType                ImageIndexType;
-  typedef ImageType::SizeType                 ImageSizeType;
-  typedef double                              CoordRepType;
-  typedef itk::AffineTransform<CoordRepType,Dimension>
-                                              AffineTransformType;
-  typedef itk::tube::VotingResampleImageFunction<ImageType,CoordRepType>
-                                              InterpolatorType;
+  using ImageIndexType = ImageType::IndexType;
+  using ImageSizeType = ImageType::SizeType;
+  using CoordRepType = double;
+  using AffineTransformType = itk::AffineTransform<CoordRepType,Dimension>;
+  using InterpolatorType = itk::tube::VotingResampleImageFunction<ImageType,CoordRepType>;
 
-  typedef itk::ImageFileReader< ImageType >   ImageReaderType;
-  typedef itk::ImageFileWriter< ImageType >   ImageWriterType;
+  using ImageReaderType = itk::ImageFileReader< ImageType >;
+  using ImageWriterType = itk::ImageFileWriter< ImageType >;
 
 
   // Create and configure an image

--- a/test/Numerics/tubeBrentOptimizerNDTest.cxx
+++ b/test/Numerics/tubeBrentOptimizerNDTest.cxx
@@ -72,7 +72,7 @@ int tubeBrentOptimizerNDTest( int tubeNotUsed( argc ), char * tubeNotUsed( argv 
 
   tube::OptimizerND opt( 2, &myFunc, &myFuncD, &opt1D );
 
-  typedef vnl_vector< double > VectorType;
+  using VectorType = vnl_vector< double >;
 
   int returnStatus = EXIT_SUCCESS;
 

--- a/test/Numerics/tubeNumericsPrintTest.cxx
+++ b/test/Numerics/tubeNumericsPrintTest.cxx
@@ -35,8 +35,8 @@ limitations under the License.
 
 int tubeNumericsPrintTest( int itkNotUsed( argc ), char * itkNotUsed( argv )[] )
 {
-  typedef itk::Image< float, 2 >                 ImageType;
-  typedef itk::Image< itk::Vector<float, 2>, 2 > VectorImageType;
+  using ImageType = itk::Image< float, 2 >;
+  using VectorImageType = itk::Image< itk::Vector<float, 2>, 2 >;
 
   itk::tube::ImageRegionMomentsCalculator< ImageType >::Pointer
     regionMomentsObject =

--- a/test/Numerics/tubeSplineApproximation1DTest.cxx
+++ b/test/Numerics/tubeSplineApproximation1DTest.cxx
@@ -135,7 +135,7 @@ int tubeSplineApproximation1DTest( int argc, char * argv[] )
     returnStatus = EXIT_FAILURE;
     }
 
-  typedef itk::Image< float, 3 >  ImageType;
+  using ImageType = itk::Image< float, 3 >;
 
   ImageType::Pointer im = ImageType::New();
   ImageType::RegionType imRegion;
@@ -214,7 +214,7 @@ int tubeSplineApproximation1DTest( int argc, char * argv[] )
     ++itIm;
     }
 
-  typedef itk::ImageFileWriter<ImageType> ImageWriterType;
+  using ImageWriterType = itk::ImageFileWriter<ImageType>;
   ImageWriterType::Pointer imWriter = ImageWriterType::New();
   imWriter->SetFileName( argv[1] );
   imWriter->SetInput( im );

--- a/test/Numerics/tubeSplineNDTest.cxx
+++ b/test/Numerics/tubeSplineNDTest.cxx
@@ -128,7 +128,7 @@ int tubeSplineNDTest( int argc, char * argv[] )
     returnStatus = EXIT_FAILURE;
     }
 
-  typedef itk::Image< float, 3 >  ImageType;
+  using ImageType = itk::Image< float, 3 >;
 
   ImageType::Pointer im = ImageType::New();
   ImageType::RegionType imRegion;
@@ -221,7 +221,7 @@ int tubeSplineNDTest( int argc, char * argv[] )
     ++itIm;
     }
 
-  typedef itk::ImageFileWriter<ImageType> ImageWriterType;
+  using ImageWriterType = itk::ImageFileWriter<ImageType>;
   ImageWriterType::Pointer imWriter = ImageWriterType::New();
   imWriter->SetFileName( argv[1] );
   imWriter->SetInput( im );

--- a/test/ObjectDocuments/tubeObjectDocumentsPrintTest.cxx
+++ b/test/ObjectDocuments/tubeObjectDocumentsPrintTest.cxx
@@ -34,32 +34,32 @@ limitations under the License.
 int tubeObjectDocumentsPrintTest( int tubeNotUsed( argc ),
                                       char * tubeNotUsed( argv )[] )
 {
-  typedef itk::tube::BlobSpatialObjectDocument BlobSpatialObjectDocumentType;
+  using BlobSpatialObjectDocumentType = itk::tube::BlobSpatialObjectDocument;
 
   BlobSpatialObjectDocumentType::Pointer blobSpatialObjectDocument
     = BlobSpatialObjectDocumentType::New();
   tubeStandardOutputMacro( << "-------------itk::tube::BlobSpatialObjectDocument"
                            << blobSpatialObjectDocument );
 
-  typedef itk::tube::Document DocumentType;
+  using DocumentType = itk::tube::Document;
 
   DocumentType::Pointer document = DocumentType::New();
   tubeStandardOutputMacro( << "-------------itk::tube::Document" << document );
 
-  typedef itk::tube::ImageDocument ImageDocumentType;
+  using ImageDocumentType = itk::tube::ImageDocument;
 
   ImageDocumentType::Pointer imageDocument = ImageDocumentType::New();
   tubeStandardOutputMacro( << "-------------itk::tube::ImageDocument"
                            << imageDocument );
 
-  typedef tube::MetaDocument MetaDocumentType;
+  using MetaDocumentType = tube::MetaDocument;
 
   MetaDocumentType::Pointer metaDocument = new MetaDocumentType();
   tubeStandardOutputMacro( << "-------------tube::MetaDocument"
                            << metaDocument );
   delete metaDocument;
 
-  typedef tube::MetaObjectDocument MetaObjectDocumentType;
+  using MetaObjectDocumentType = tube::MetaObjectDocument;
 
   MetaObjectDocumentType::Pointer metaObjectDocument
     = new MetaObjectDocumentType();
@@ -67,36 +67,34 @@ int tubeObjectDocumentsPrintTest( int tubeNotUsed( argc ),
                            << metaObjectDocument );
   delete metaObjectDocument;
 
-  typedef itk::tube::ObjectDocument ObjectDocumentType;
+  using ObjectDocumentType = itk::tube::ObjectDocument;
 
   ObjectDocumentType::Pointer objectDocument = ObjectDocumentType::New();
   tubeStandardOutputMacro( << "-------------itk::tube::ObjectDocument"
                            << objectDocument );
 
-  typedef itk::Image< float, 3 > ImageType;
-  typedef itk::tube::ObjectDocumentToImageFilter< ObjectDocumentType, ImageType >
-    ObjectDocumentToImageFilterType;
+  using ImageType = itk::Image< float, 3 >;
+  using ObjectDocumentToImageFilterType = itk::tube::ObjectDocumentToImageFilter< ObjectDocumentType, ImageType >;
 
   ObjectDocumentToImageFilterType::Pointer objectDocumentToImageFilter
     = ObjectDocumentToImageFilterType::New();
   tubeStandardOutputMacro( << "-------------itk::tube::ObjectDocumentToImageFilter"
                            << objectDocumentToImageFilter );
 
-  typedef itk::tube::ObjectDocumentToObjectSource< ObjectDocumentType, 3 >
-    ObjectDocumentToObjectSourceType;
+  using ObjectDocumentToObjectSourceType = itk::tube::ObjectDocumentToObjectSource< ObjectDocumentType, 3 >;
 
   ObjectDocumentToObjectSourceType::Pointer objectDocumentToObjectSource
     = ObjectDocumentToObjectSourceType::New();
   tubeStandardOutputMacro( << "-------------itk::tube::ObjectDocumentToObjectSource"
                            << objectDocumentToObjectSource );
 
-  typedef tube::OptionList OptionListType;
+  using OptionListType = tube::OptionList;
 
   OptionListType::Pointer optionList = new OptionListType();
   tubeStandardOutputMacro( << "-------------tube::OptionList" << optionList );
   delete optionList;
 
-  typedef itk::tube::SpatialObjectDocument SpatialObjectDocumentType;
+  using SpatialObjectDocumentType = itk::tube::SpatialObjectDocument;
 
   SpatialObjectDocumentType::Pointer spatialObjectDocument
     = SpatialObjectDocumentType::New();

--- a/test/Registration/itktubePointBasedSpatialObjectTransformFilterTest.cxx
+++ b/test/Registration/itktubePointBasedSpatialObjectTransformFilterTest.cxx
@@ -44,13 +44,12 @@ int itktubePointBasedSpatialObjectTransformFilterTest( int argc, char * argv[] )
     return EXIT_FAILURE;
     }
 
-  typedef itk::GroupSpatialObject<3>                      GroupType;
-  typedef itk::SpatialObjectReader<3>                     SOReaderType;
-  typedef itk::SpatialObjectWriter<3>                     SOWriterType;
-  typedef itk::Euler3DTransform<double>                   TransformType;
+  using GroupType = itk::GroupSpatialObject<3>;
+  using SOReaderType = itk::SpatialObjectReader<3>;
+  using SOWriterType = itk::SpatialObjectWriter<3>;
+  using TransformType = itk::Euler3DTransform<double>;
 
-  typedef itk::tube::PointBasedSpatialObjectTransformFilter<TransformType,3>
-    TransformFilterType;
+  using TransformFilterType = itk::tube::PointBasedSpatialObjectTransformFilter<TransformType,3>;
 
   // read in vessel
   SOReaderType::Pointer reader = SOReaderType::New();
@@ -152,16 +151,15 @@ int itktubePointBasedSpatialObjectTransformFilterTest( int argc, char * argv[] )
   if( std::atoi( argv[11] ) )
     {
     // Write vessel as an image
-    typedef itk::Image<double, 3>                           ImageType;
-    typedef itk::ImageFileReader<ImageType>                 ImageReaderType;
-    typedef itk::ImageFileWriter<ImageType>                 ImageWriterType;
+    using ImageType = itk::Image<double, 3>;
+    using ImageReaderType = itk::ImageFileReader<ImageType>;
+    using ImageWriterType = itk::ImageFileWriter<ImageType>;
 
     ImageReaderType::Pointer imageReader = ImageReaderType::New();
     imageReader->SetFileName( argv[3] );
     imageReader->Update();
 
-    typedef itk::SpatialObjectToImageFilter<GroupType, ImageType>
-      SpatialObjectToImageFilterType;
+    using SpatialObjectToImageFilterType = itk::SpatialObjectToImageFilter<GroupType, ImageType>;
     SpatialObjectToImageFilterType::Pointer vesselToImageFilter =
       SpatialObjectToImageFilterType::New();
 

--- a/test/Registration/itktubePointsToImageTest.cxx
+++ b/test/Registration/itktubePointsToImageTest.cxx
@@ -38,15 +38,15 @@ int itktubePointsToImageTest( int argc, char * argv[] )
 
   enum { Dimension = 3 };
 
-  typedef itk::SpatialObjectReader< Dimension >      ReaderType;
+  using ReaderType = itk::SpatialObjectReader< Dimension >;
   typedef itk::SpatialObject< Dimension >::ChildrenListType
       ObjectListType;
-  typedef itk::SpatialObject< Dimension >            SpatialObjectType;
-  typedef itk::GroupSpatialObject< Dimension >       GroupType;
-  typedef itk::TubeSpatialObject< Dimension >        TubeType;
-  typedef TubeType::TubePointListType                TubePointListType;
-  typedef TubeType::TubePointType                    TubePointType;
-  typedef itk::Image< float, Dimension >             ImageType;
+  using SpatialObjectType = itk::SpatialObject< Dimension >;
+  using GroupType = itk::GroupSpatialObject< Dimension >;
+  using TubeType = itk::TubeSpatialObject< Dimension >;
+  using TubePointListType = TubeType::TubePointListType;
+  using TubePointType = TubeType::TubePointType;
+  using ImageType = itk::Image< float, Dimension >;
 
   // Read the tube
   ReaderType::Pointer tubeReader = ReaderType::New();
@@ -129,8 +129,7 @@ int itktubePointsToImageTest( int argc, char * argv[] )
     }
   delete tubeList;
 
-  typedef itk::SpatialObjectToImageFilter<GroupType, ImageType>
-                                              SpatialObjectToImageFilterType;
+  using SpatialObjectToImageFilterType = itk::SpatialObjectToImageFilter<GroupType, ImageType>;
   SpatialObjectToImageFilterType::Pointer tubeToImageFilter =
     SpatialObjectToImageFilterType::New();
 
@@ -145,7 +144,7 @@ int itktubePointsToImageTest( int argc, char * argv[] )
   tubeToImageFilter->SetInsideValue( 1.0 );
   tubeToImageFilter->SetOutsideValue( 0.0 );
   tubeToImageFilter->Update();
-  typedef itk::ImageFileWriter< ImageType > ImageWriterType;
+  using ImageWriterType = itk::ImageFileWriter< ImageType >;
 
   ImageWriterType::Pointer imageWriter = ImageWriterType::New();
   imageWriter->SetFileName( argv[2] );

--- a/test/Registration/itktubeSpatialObjectToImageMetricPerformanceTest.cxx
+++ b/test/Registration/itktubeSpatialObjectToImageMetricPerformanceTest.cxx
@@ -49,14 +49,13 @@ int itktubeSpatialObjectToImageMetricPerformanceTest( int argc, char * argv[] )
     return EXIT_FAILURE;
     }
 
-  typedef itk::Image<double, 3>                             Image3DType;
+  using Image3DType = itk::Image<double, 3>;
 
-  typedef itk::ImageFileReader<Image3DType>                 ImageReaderType;
-  typedef itk::SpatialObjectReader<3>                       SOReaderType;
+  using ImageReaderType = itk::ImageFileReader<Image3DType>;
+  using SOReaderType = itk::SpatialObjectReader<3>;
 
-  typedef itk::tube::PointBasedSpatialObjectToImageMetric<3, Image3DType >
-                                                            MetricType;
-  typedef itk::ComposeScaleSkewVersor3DTransform<double>    TransformType;
+  using MetricType = itk::tube::PointBasedSpatialObjectToImageMetric<3, Image3DType >;
+  using TransformType = itk::ComposeScaleSkewVersor3DTransform<double>;
 
   // read image ( fixedImage )
   ImageReaderType::Pointer imageReader = ImageReaderType::New();
@@ -85,8 +84,8 @@ int itktubeSpatialObjectToImageMetricPerformanceTest( int argc, char * argv[] )
     }
 
   // subsample points in vessel
-  typedef itk::tube::SubSampleSpatialObjectFilter<>
-    SubSampleFilterType;
+  using SubSampleFilterType =
+      itk::tube::SubSampleSpatialObjectFilter<>;
   SubSampleFilterType::Pointer subSampleFilter =
     SubSampleFilterType::New();
   subSampleFilter->SetInput( tubeReader->GetGroup() );

--- a/test/Registration/itktubeSpatialObjectToImageMetricTest.cxx
+++ b/test/Registration/itktubeSpatialObjectToImageMetricTest.cxx
@@ -47,18 +47,17 @@ int itktubeSpatialObjectToImageMetricTest( int argc, char * argv[] )
     return EXIT_FAILURE;
     }
 
-  typedef double            FloatType;
+  using FloatType = double;
   static const unsigned int ImageDimension = 3;
   static const unsigned int ObjectDimension = 3;
 
-  typedef itk::Image< FloatType, ImageDimension >         ImageType;
+  using ImageType = itk::Image< FloatType, ImageDimension >;
 
-  typedef itk::ImageFileReader< ImageType >               ImageReaderType;
-  typedef itk::SpatialObjectReader< ObjectDimension >     GroupReaderType;
+  using ImageReaderType = itk::ImageFileReader< ImageType >;
+  using GroupReaderType = itk::SpatialObjectReader< ObjectDimension >;
 
-  typedef itk::tube::PointBasedSpatialObjectToImageMetric< 3, ImageType >
-                                                          MetricType;
-  typedef itk::ComposeScaleSkewVersor3DTransform< double >       TransformType;
+  using MetricType = itk::tube::PointBasedSpatialObjectToImageMetric< 3, ImageType >;
+  using TransformType = itk::ComposeScaleSkewVersor3DTransform< double >;
 
   // read image ( fixedImage )
   ImageReaderType::Pointer imageReader = ImageReaderType::New();
@@ -87,8 +86,8 @@ int itktubeSpatialObjectToImageMetricTest( int argc, char * argv[] )
     }
 
   // subsample points in vessel
-  typedef itk::tube::SubSampleSpatialObjectFilter<>
-    SubSampleFilterType;
+  using SubSampleFilterType =
+      itk::tube::SubSampleSpatialObjectFilter<>;
   SubSampleFilterType::Pointer subSampleFilter =
     SubSampleFilterType::New();
   subSampleFilter->SetInput( groupReader->GetGroup() );

--- a/test/Registration/itktubeSpatialObjectToImageRegistrationPerformanceTest.cxx
+++ b/test/Registration/itktubeSpatialObjectToImageRegistrationPerformanceTest.cxx
@@ -40,9 +40,9 @@ limitations under the License.
 class CommandIterationUpdate : public itk::Command
 {
 public:
-  typedef  CommandIterationUpdate   Self;
-  typedef  itk::Command             Superclass;
-  typedef itk::SmartPointer<Self>   Pointer;
+  using Self = CommandIterationUpdate;
+  using Superclass = itk::Command;
+  using Pointer = itk::SmartPointer<Self>;
   itkNewMacro( Self );
 
 protected:
@@ -58,8 +58,8 @@ protected:
   std::ofstream measuresFileStream;
 
 public:
-  typedef itk::OnePlusOneEvolutionaryOptimizer EvoOptimizerType;
-  typedef itk::GradientDescentOptimizer GradOptimizerType;
+  using EvoOptimizerType = itk::OnePlusOneEvolutionaryOptimizer;
+  using GradOptimizerType = itk::GradientDescentOptimizer;
 
   void Execute( itk::Object *caller, const itk::EventObject & event ) override
     {
@@ -111,11 +111,10 @@ int itktubeSpatialObjectToImageRegistrationPerformanceTest( int argc, char * arg
     return EXIT_FAILURE;
     }
 
-  typedef itk::SpatialObjectReader<3>                    GroupReaderType;
-  typedef itk::Image<double, 3>                          ImageType;
-  typedef itk::ImageFileReader<ImageType>                ImageReaderType;
-  typedef itk::tube::SpatialObjectToImageRegistrationHelper<3, ImageType>
-                                                         RegistrationHelperType;
+  using GroupReaderType = itk::SpatialObjectReader<3>;
+  using ImageType = itk::Image<double, 3>;
+  using ImageReaderType = itk::ImageFileReader<ImageType>;
+  using RegistrationHelperType = itk::tube::SpatialObjectToImageRegistrationHelper<3, ImageType>;
 
   // read image
   ImageReaderType::Pointer imageReader = ImageReaderType::New();
@@ -133,8 +132,8 @@ int itktubeSpatialObjectToImageRegistrationPerformanceTest( int argc, char * arg
   // Gaussian blur the original input image to increase the likelihood of vessel
   // spatial object overlapping with the vessel image at their initial alignment.
   // this enlarges the convergence zone.
-  typedef itk::RecursiveGaussianImageFilter
-    <ImageType, ImageType> GaussianBlurFilterType;
+  using GaussianBlurFilterType = itk::RecursiveGaussianImageFilter
+    <ImageType, ImageType>;
 
   GaussianBlurFilterType::Pointer blurFilters[3];
   for( int i = 0; i < 3; i++ )
@@ -173,8 +172,8 @@ int itktubeSpatialObjectToImageRegistrationPerformanceTest( int argc, char * arg
     }
 
   // subsample points in group
-  typedef itk::tube::SubSampleSpatialObjectFilter<>
-    SubSampleFilterType;
+  using SubSampleFilterType =
+      itk::tube::SubSampleSpatialObjectFilter<>;
   SubSampleFilterType::Pointer subSampleFilter =
     SubSampleFilterType::New();
   subSampleFilter->SetInput( groupReader->GetGroup() );

--- a/test/Registration/itktubeSpatialObjectToImageRegistrationTest.cxx
+++ b/test/Registration/itktubeSpatialObjectToImageRegistrationTest.cxx
@@ -53,18 +53,16 @@ int itktubeSpatialObjectToImageRegistrationTest( int argc, char * argv[] )
   const char * outputImage = argv[4];
 
   enum { ObjectDimension = 3 };
-  typedef double            FloatType;
+  using FloatType = double;
 
-  typedef itk::GroupSpatialObject< ObjectDimension >           GroupType;
-  typedef itk::SpatialObjectReader< ObjectDimension >          SOReaderType;
-  typedef itk::Image< FloatType, ObjectDimension >             ImageType;
-  typedef itk::ImageFileReader< ImageType >              ImageReaderType;
-  typedef itk::ImageFileWriter< ImageType >              ImageWriterType;
-  typedef itk::tube::SpatialObjectToImageRegistrationHelper< 3, ImageType >
-                                                         RegistrationHelperType;
-  typedef RegistrationHelperType::MatrixTransformType    TransformType;
-  typedef itk::tube::PointBasedSpatialObjectTransformFilter< TransformType, ObjectDimension >
-                                                         TubeTransformFilterType;
+  using GroupType = itk::GroupSpatialObject< ObjectDimension >;
+  using SOReaderType = itk::SpatialObjectReader< ObjectDimension >;
+  using ImageType = itk::Image< FloatType, ObjectDimension >;
+  using ImageReaderType = itk::ImageFileReader< ImageType >;
+  using ImageWriterType = itk::ImageFileWriter< ImageType >;
+  using RegistrationHelperType = itk::tube::SpatialObjectToImageRegistrationHelper< 3, ImageType >;
+  using TransformType = RegistrationHelperType::MatrixTransformType;
+  using TubeTransformFilterType = itk::tube::PointBasedSpatialObjectTransformFilter< TransformType, ObjectDimension >;
 
   // read image
   ImageReaderType::Pointer imageReader = ImageReaderType::New();
@@ -73,8 +71,7 @@ int itktubeSpatialObjectToImageRegistrationTest( int argc, char * argv[] )
   // Gaussian blur the original input image to increase the likelihood of vessel
   // spatial object overlapping with the vessel image at their initial alignment.
   // this enlarges the convergence zone.
-  typedef itk::SmoothingRecursiveGaussianImageFilter<ImageType, ImageType>
-                                                           GaussianBlurFilterType;
+  using GaussianBlurFilterType = itk::SmoothingRecursiveGaussianImageFilter<ImageType, ImageType>;
   GaussianBlurFilterType::Pointer blurFilter;
   blurFilter = GaussianBlurFilterType::New();
   blurFilter->SetInput(imageReader->GetOutput());
@@ -103,7 +100,7 @@ int itktubeSpatialObjectToImageRegistrationTest( int argc, char * argv[] )
     }
 
   // subsample points in vessel
-  typedef itk::tube::SubSampleSpatialObjectFilter< ObjectDimension > SubSampleFilterType;
+  using SubSampleFilterType = itk::tube::SubSampleSpatialObjectFilter< ObjectDimension >;
   SubSampleFilterType::Pointer subSampleFilter =
     SubSampleFilterType::New();
   subSampleFilter->SetInput( groupReader->GetGroup() );
@@ -198,7 +195,7 @@ int itktubeSpatialObjectToImageRegistrationTest( int argc, char * argv[] )
   std::cout << " done.\n";
 
   // Write the transformed tube to file.
-  typedef itk::SpatialObjectWriter< ObjectDimension > SOWriterType;
+  using SOWriterType = itk::SpatialObjectWriter< ObjectDimension >;
   SOWriterType::Pointer tubesWriter = SOWriterType::New();
   tubesWriter->SetInput( transformFilter->GetOutput() );
   tubesWriter->SetFileName( outputTubes );
@@ -212,8 +209,7 @@ int itktubeSpatialObjectToImageRegistrationTest( int argc, char * argv[] )
     result = EXIT_FAILURE;
     }
 
-  typedef itk::SpatialObjectToImageFilter< GroupType, ImageType>
-                                              SpatialObjectToImageFilterType;
+  using SpatialObjectToImageFilterType = itk::SpatialObjectToImageFilter< GroupType, ImageType>;
   SpatialObjectToImageFilterType::Pointer vesselToImageFilter =
     SpatialObjectToImageFilterType::New();
 

--- a/test/Registration/itktubeSyntheticTubeImageGenerationTest.cxx
+++ b/test/Registration/itktubeSyntheticTubeImageGenerationTest.cxx
@@ -50,21 +50,18 @@ int itktubeSyntheticTubeImageGenerationTest( int argc, char * argv[] )
     return EXIT_FAILURE;
     }
 
-  typedef itk::Image<double, 3>                             Image3DType;
-  typedef itk::ImageRegionIteratorWithIndex< Image3DType >  Image3DIteratorType;
-  typedef itk::TubeSpatialObject<3>                         TubeType;
-  typedef itk::TubeSpatialObjectPoint<3>                    TubePointType;
-  typedef itk::GroupSpatialObject<3>                        GroupType;
+  using Image3DType = itk::Image<double, 3>;
+  using Image3DIteratorType = itk::ImageRegionIteratorWithIndex< Image3DType >;
+  using TubeType = itk::TubeSpatialObject<3>;
+  using TubePointType = itk::TubeSpatialObjectPoint<3>;
+  using GroupType = itk::GroupSpatialObject<3>;
 
-  typedef itk::SpatialObjectToImageFilter< GroupType, Image3DType >
-    SpatialObjectToImageFilterType;
-  typedef itk::Euler3DTransform<double>
-    TransformType;
-  typedef itk::tube::PointBasedSpatialObjectTransformFilter<TransformType, 3>
-    TubeTransformFilterType;
+  using SpatialObjectToImageFilterType = itk::SpatialObjectToImageFilter< GroupType, Image3DType >;
+  using TransformType = itk::Euler3DTransform<double>;
+  using TubeTransformFilterType = itk::tube::PointBasedSpatialObjectTransformFilter<TransformType, 3>;
 
-  typedef itk::ImageFileWriter<Image3DType>                 ImageWriterType;
-  typedef itk::SpatialObjectWriter<3>                       TubeWriterType;
+  using ImageWriterType = itk::ImageFileWriter<Image3DType>;
+  using TubeWriterType = itk::SpatialObjectWriter<3>;
 
   Image3DType::SizeType imageSize;
   imageSize[0] = 32;
@@ -96,8 +93,7 @@ int itktubeSyntheticTubeImageGenerationTest( int argc, char * argv[] )
   // Gaussian blur the images to increase the likelihood of vessel
   // spatial object overlapping.
   std::cout << "Apply Gaussian blur..." << std::endl;
-  typedef itk::RecursiveGaussianImageFilter<Image3DType, Image3DType>
-    GaussianBlurFilterType;
+  using GaussianBlurFilterType = itk::RecursiveGaussianImageFilter<Image3DType, Image3DType>;
   GaussianBlurFilterType::Pointer blurFilters[3];
   for( int i = 0; i < 3; i++ )
     {
@@ -220,7 +216,7 @@ int itktubeSyntheticTubeImageGenerationTest( int argc, char * argv[] )
   std::cout << "Transform and Convert the tube into an Image..." << std::endl;
 
   // read tube ( spatialObject )
-  typedef itk::SpatialObjectReader<3> SOReaderType;
+  using SOReaderType = itk::SpatialObjectReader<3>;
   SOReaderType::Pointer tubeReader = SOReaderType::New();
   std::cout << "Read VesselTube: " << argv[4] << std::endl;
   tubeReader->SetFileName( argv[4] );

--- a/test/Registration/tubeRegistrationPrintTest.cxx
+++ b/test/Registration/tubeRegistrationPrintTest.cxx
@@ -54,8 +54,8 @@ int tubeRegistrationPrintTest( int itkNotUsed( argc ), char * itkNotUsed(
   argv )[] )
 {
   //const unsigned int Dimension = 3;
-  //typedef itk::Image< float, Dimension >      ImageType;
-  //typedef itk::TubeSpatialObject< Dimension > TubeSpatialObjectType;
+  //using ImageType = itk::Image< float, Dimension >;
+  //using TubeSpatialObjectType = itk::TubeSpatialObject< Dimension >;
 
   /*
   itk::tube::AnisotropicCoherenceEnhancingDiffusionImageFilter< ImageType,
@@ -81,38 +81,37 @@ int tubeRegistrationPrintTest( int itkNotUsed( argc ), char * itkNotUsed(
     ::New();
   std::cout << "-------------ahdif" << ahdif << std::endl;
 
-  typedef itk::tube::CropImageFilter< ImageType,
-    ImageType > CropImageFilter;
+  using CropImageFilter = itk::tube::CropImageFilter< ImageType,
+    ImageType >;
   CropImageFilter::Pointer cropImage = CropImageFilter::New();
   std::cout << "-------------cropImage" << cropImage << std::endl;
 
-  typedef itk::tube::CVTImageFilter< ImageType > CVTImageFilter;
+  using CVTImageFilter = itk::tube::CVTImageFilter< ImageType >;
   CVTImageFilter::Pointer cvtImage = CVTImageFilter::New();
   std::cout << "-------------cvtImage" << cvtImage << std::endl;
 
-  typedef itk::tube::ExtractTubePointsSpatialObjectFilter<
-    TubeSpatialObjectType > ExtractTubePointsSpatialObjectFilterType;
+  using ExtractTubePointsSpatialObjectFilterType = itk::tube::ExtractTubePointsSpatialObjectFilter<
+    TubeSpatialObjectType >;
   ExtractTubePointsSpatialObjectFilterType::Pointer etpsof =
     ExtractTubePointsSpatialObjectFilterType::New();
   std::cout << "-------------etpsof" << etpsof << std::endl;
 
-  typedef itk::tube::FFTGaussianDerivativeIFFTFilter< ImageType >
-    FFTGaussianDerivativeIFFTFilter;
+  using FFTGaussianDerivativeIFFTFilter = itk::tube::FFTGaussianDerivativeIFFTFilter< ImageType >;
   FFTGaussianDerivativeIFFTFilter::Pointer fgdif =
     FFTGaussianDerivativeIFFTFilter::New();
   std::cout << "-------------fgdif " << fgdif << std::endl;
 
-  typedef itk::tube::MinimumSpanningTreeVesselConnectivityFilter<
-    Dimension > VesselConnectivityFilterType;
+  using VesselConnectivityFilterType = itk::tube::MinimumSpanningTreeVesselConnectivityFilter<
+    Dimension >;
   VesselConnectivityFilterType::Pointer mstvcf =
     VesselConnectivityFilterType::New();
   std::cout << "-------------mstvcf " << mstvcf << std::endl;
 
-  typedef itk::tube::RidgeFFTFilter< ImageType > RidgeFFTFilterType;
+  using RidgeFFTFilterType = itk::tube::RidgeFFTFilter< ImageType >;
   RidgeFFTFilterType::Pointer rfif = RidgeFFTFilterType::New();
   std::cout << "-------------rfif " << rfif << std::endl;
 
-  typedef itk::tube::ReResampleImageFilter< float, 3 > ReResampleImageFilterType;
+  using ReResampleImageFilterType = itk::tube::ReResampleImageFilter< float, 3 >;
   ReResampleImageFilterType::Pointer rrif = ReResampleImageFilterType::New();
   std::cout << "-------------rrif " << rrif << std::endl;
 
@@ -122,10 +121,10 @@ int tubeRegistrationPrintTest( int itkNotUsed( argc ), char * itkNotUsed(
     ::New();
   std::cout << "-------------strgif" << strgif << std::endl;
 
-  typedef itk::FixedArray< float, 3 >            EigenValueArrayType;
-  typedef itk::Matrix< float, 3, 3 >             EigenVectorMatrixType;
-  typedef itk::Image< EigenValueArrayType, 3>    EigenValueImageType;
-  typedef itk::Image< EigenVectorMatrixType, 3>  EigenVectorImageType;
+  using EigenValueArrayType = itk::FixedArray< float, 3 >;
+  using EigenVectorMatrixType = itk::Matrix< float, 3, 3 >;
+  using EigenValueImageType = itk::Image< EigenValueArrayType, 3>;
+  using EigenVectorImageType = itk::Image< EigenVectorMatrixType, 3>;
 
   typedef itk::tube::StructureTensorRecursiveGaussianImageFilter<
     ImageType >::OutputImageType SymmetricSecondRankTensorImageType;

--- a/test/Segmentation/itktubePDFSegmenterParzenTest.cxx
+++ b/test/Segmentation/itktubePDFSegmenterParzenTest.cxx
@@ -43,26 +43,24 @@ int itktubePDFSegmenterParzenTest( int argc, char * argv[] )
   enum { Dimension = 2 };
 
   // Define the pixel type
-  typedef float PixelType;
+  using PixelType = float;
 
   // Declare the types of the images
-  typedef itk::Image<PixelType, Dimension>  ImageType;
+  using ImageType = itk::Image<PixelType, Dimension>;
 
   // Declare the reader and writer
-  typedef itk::ImageFileReader< ImageType > ReaderType;
-  typedef itk::ImageFileWriter< ImageType > WriterType;
+  using ReaderType = itk::ImageFileReader< ImageType >;
+  using WriterType = itk::ImageFileWriter< ImageType >;
 
-  typedef float                                  HistoPixelType;
-  typedef itk::Image<HistoPixelType, 4 >         HistoImageType;
-  typedef itk::ImageFileWriter< HistoImageType > HistoWriterType;
+  using HistoPixelType = float;
+  using HistoImageType = itk::Image<HistoPixelType, 4 >;
+  using HistoWriterType = itk::ImageFileWriter< HistoImageType >;
 
 
   // Declare the type for the Filter
-  typedef itk::tube::PDFSegmenterParzen< ImageType, ImageType >
-    FilterType;
+  using FilterType = itk::tube::PDFSegmenterParzen< ImageType, ImageType >;
 
-  typedef itk::tube::FeatureVectorGenerator< ImageType >
-    FeatureVectorGeneratorType;
+  using FeatureVectorGeneratorType = itk::tube::FeatureVectorGenerator< ImageType >;
 
   // Create the reader and writer
   ReaderType::Pointer reader = ReaderType::New();

--- a/test/Segmentation/itktubeRadiusExtractor2Test.cxx
+++ b/test/Segmentation/itktubeRadiusExtractor2Test.cxx
@@ -37,16 +37,16 @@ int itktubeRadiusExtractor2Test( int argc, char * argv[] )
     return EXIT_FAILURE;
     }
 
-  typedef itk::Image<float, 3>   ImageType;
+  using ImageType = itk::Image<float, 3>;
 
-  typedef itk::ImageFileReader< ImageType > ImageReaderType;
+  using ImageReaderType = itk::ImageFileReader< ImageType >;
   ImageReaderType::Pointer imReader = ImageReaderType::New();
   imReader->SetFileName( argv[1] );
   imReader->Update();
 
   ImageType::Pointer im = imReader->GetOutput();
 
-  typedef itk::tube::RadiusExtractor2<ImageType> RadiusOpType;
+  using RadiusOpType = itk::tube::RadiusExtractor2<ImageType>;
   RadiusOpType::Pointer radiusOp = RadiusOpType::New();
 
   radiusOp->SetInputImage( im );
@@ -102,12 +102,12 @@ int itktubeRadiusExtractor2Test( int argc, char * argv[] )
     returnStatus = EXIT_FAILURE;
     }
 
-  typedef itk::SpatialObjectReader<>                   ReaderType;
-  typedef itk::SpatialObject<>::ChildrenListType       ObjectListType;
-  typedef itk::GroupSpatialObject<>                    GroupType;
-  typedef itk::TubeSpatialObject<>                     TubeType;
-  typedef TubeType::TubePointListType                  TubePointListType;
-  typedef TubeType::TubePointType                      TubePointType;
+  using ReaderType = itk::SpatialObjectReader<>;
+  using ObjectListType = itk::SpatialObject<>::ChildrenListType;
+  using GroupType = itk::GroupSpatialObject<>;
+  using TubeType = itk::TubeSpatialObject<>;
+  using TubePointListType = TubeType::TubePointListType;
+  using TubePointType = TubeType::TubePointType;
 
   ReaderType::Pointer reader = ReaderType::New();
   reader->SetFileName( argv[2] );

--- a/test/Segmentation/itktubeRadiusExtractor2Test2.cxx
+++ b/test/Segmentation/itktubeRadiusExtractor2Test2.cxx
@@ -38,16 +38,16 @@ int itktubeRadiusExtractor2Test2( int argc, char * argv[] )
     return EXIT_FAILURE;
     }
 
-  typedef itk::Image<float, 3>   ImageType;
+  using ImageType = itk::Image<float, 3>;
 
-  typedef itk::ImageFileReader< ImageType > ImageReaderType;
+  using ImageReaderType = itk::ImageFileReader< ImageType >;
   ImageReaderType::Pointer imReader = ImageReaderType::New();
   imReader->SetFileName( argv[1] );
   imReader->Update();
 
   ImageType::Pointer im = imReader->GetOutput();
 
-  typedef itk::tube::RadiusExtractor2<ImageType> RadiusOpType;
+  using RadiusOpType = itk::tube::RadiusExtractor2<ImageType>;
   RadiusOpType::Pointer radiusOp = RadiusOpType::New();
 
   radiusOp->SetInputImage( im );
@@ -68,11 +68,11 @@ int itktubeRadiusExtractor2Test2( int argc, char * argv[] )
     returnStatus = EXIT_FAILURE;
     }
 
-  typedef itk::SpatialObjectReader<>                   ReaderType;
-  typedef itk::SpatialObject<>::ChildrenListType       ObjectListType;
-  typedef itk::GroupSpatialObject<>                    GroupType;
-  typedef itk::TubeSpatialObject<>                     TubeType;
-  typedef TubeType::TubePointListType                  TubePointListType;
+  using ReaderType = itk::SpatialObjectReader<>;
+  using ObjectListType = itk::SpatialObject<>::ChildrenListType;
+  using GroupType = itk::GroupSpatialObject<>;
+  using TubeType = itk::TubeSpatialObject<>;
+  using TubePointListType = TubeType::TubePointListType;
 
   ReaderType::Pointer reader = ReaderType::New();
   reader->SetFileName( argv[2] );

--- a/test/Segmentation/itktubeRidgeExtractorTest.cxx
+++ b/test/Segmentation/itktubeRidgeExtractorTest.cxx
@@ -37,9 +37,9 @@ int itktubeRidgeExtractorTest( int argc, char * argv[] )
     return EXIT_FAILURE;
     }
 
-  typedef itk::Image<float, 3>   ImageType;
+  using ImageType = itk::Image<float, 3>;
 
-  typedef itk::ImageFileReader< ImageType > ImageReaderType;
+  using ImageReaderType = itk::ImageFileReader< ImageType >;
   ImageReaderType::Pointer imReader = ImageReaderType::New();
   imReader->SetFileName( argv[1] );
   imReader->Update();
@@ -48,7 +48,7 @@ int itktubeRidgeExtractorTest( int argc, char * argv[] )
 
   ImageType::SizeType size = im->GetLargestPossibleRegion().GetSize();
 
-  typedef itk::tube::RidgeExtractor<ImageType> RidgeOpType;
+  using RidgeOpType = itk::tube::RidgeExtractor<ImageType>;
   RidgeOpType::Pointer ridgeOp = RidgeOpType::New();
 
   ridgeOp->SetInputImage( im );
@@ -191,7 +191,7 @@ int itktubeRidgeExtractorTest( int argc, char * argv[] )
     }
   std::cout << "...end" << std::endl;
 
-  typedef itk::ImageFileWriter<ImageType> ImageWriterType;
+  using ImageWriterType = itk::ImageFileWriter<ImageType>;
   ImageWriterType::Pointer imWriter = ImageWriterType::New();
   imWriter->SetFileName( argv[2] );
   imWriter->SetInput( imOut );

--- a/test/Segmentation/itktubeRidgeExtractorTest2.cxx
+++ b/test/Segmentation/itktubeRidgeExtractorTest2.cxx
@@ -37,16 +37,16 @@ int itktubeRidgeExtractorTest2( int argc, char * argv[] )
     return EXIT_FAILURE;
     }
 
-  typedef itk::Image<float, 3>   ImageType;
+  using ImageType = itk::Image<float, 3>;
 
-  typedef itk::ImageFileReader< ImageType > ImageReaderType;
+  using ImageReaderType = itk::ImageFileReader< ImageType >;
   ImageReaderType::Pointer imReader = ImageReaderType::New();
   imReader->SetFileName( argv[1] );
   imReader->Update();
 
   ImageType::Pointer im = imReader->GetOutput();
 
-  typedef itk::tube::RidgeExtractor<ImageType> RidgeOpType;
+  using RidgeOpType = itk::tube::RidgeExtractor<ImageType>;
   RidgeOpType::Pointer ridgeOp = RidgeOpType::New();
 
   //ridgeOp->SetDebug( true );
@@ -56,12 +56,12 @@ int itktubeRidgeExtractorTest2( int argc, char * argv[] )
   ridgeOp->SetDynamicScale( true );
   ridgeOp->ResetFailureCodeCounts();
 
-  typedef itk::SpatialObjectReader<>                   ReaderType;
-  typedef itk::SpatialObject<>::ChildrenListType       ObjectListType;
-  typedef itk::GroupSpatialObject<>                    GroupType;
-  typedef itk::TubeSpatialObject<>                     TubeType;
-  typedef TubeType::TubePointListType                  TubePointListType;
-  typedef TubeType::TubePointType                      TubePointType;
+  using ReaderType = itk::SpatialObjectReader<>;
+  using ObjectListType = itk::SpatialObject<>::ChildrenListType;
+  using GroupType = itk::GroupSpatialObject<>;
+  using TubeType = itk::TubeSpatialObject<>;
+  using TubePointListType = TubeType::TubePointListType;
+  using TubePointType = TubeType::TubePointType;
 
   ReaderType::Pointer reader = ReaderType::New();
   reader->SetFileName( argv[2] );

--- a/test/Segmentation/itktubeRidgeSeedFilterTest.cxx
+++ b/test/Segmentation/itktubeRidgeSeedFilterTest.cxx
@@ -39,24 +39,23 @@ int itktubeRidgeSeedFilterTest( int argc, char * argv[] )
   enum { Dimension = 2 };
 
   // Define the pixel type
-  typedef float PixelType;
+  using PixelType = float;
 
   // Declare the types of the images
-  typedef itk::Image<PixelType, Dimension>  ImageType;
+  using ImageType = itk::Image<PixelType, Dimension>;
 
   // Declare the reader and writer
-  typedef itk::ImageFileReader< ImageType > ReaderType;
+  using ReaderType = itk::ImageFileReader< ImageType >;
 
-  typedef itk::Image< unsigned char, Dimension >    LabelMapType;
-  typedef itk::ImageFileReader< LabelMapType >      LabelMapReaderType;
-  typedef itk::ImageFileWriter< LabelMapType >      LabelMapWriterType;
+  using LabelMapType = itk::Image< unsigned char, Dimension >;
+  using LabelMapReaderType = itk::ImageFileReader< LabelMapType >;
+  using LabelMapWriterType = itk::ImageFileWriter< LabelMapType >;
 
-  typedef itk::Image< float, Dimension >            FeatureImageType;
-  typedef itk::ImageFileWriter< FeatureImageType >  FeatureImageWriterType;
+  using FeatureImageType = itk::Image< float, Dimension >;
+  using FeatureImageWriterType = itk::ImageFileWriter< FeatureImageType >;
 
   // Declare the type for the Filter
-  typedef itk::tube::RidgeSeedFilter< ImageType, LabelMapType >
-    FilterType;
+  using FilterType = itk::tube::RidgeSeedFilter< ImageType, LabelMapType >;
 
   // Create the reader
   ReaderType::Pointer reader = ReaderType::New();

--- a/test/Segmentation/itktubeTubeExtractorTest.cxx
+++ b/test/Segmentation/itktubeTubeExtractorTest.cxx
@@ -37,27 +37,27 @@ int itktubeTubeExtractorTest( int argc, char * argv[] )
     return EXIT_FAILURE;
     }
 
-  typedef itk::Image<float, 3>   ImageType;
+  using ImageType = itk::Image<float, 3>;
 
-  typedef itk::ImageFileReader< ImageType > ImageReaderType;
+  using ImageReaderType = itk::ImageFileReader< ImageType >;
   ImageReaderType::Pointer imReader = ImageReaderType::New();
   imReader->SetFileName( argv[1] );
   imReader->Update();
 
   ImageType::Pointer im = imReader->GetOutput();
 
-  typedef itk::tube::TubeExtractor<ImageType> TubeOpType;
+  using TubeOpType = itk::tube::TubeExtractor<ImageType>;
   TubeOpType::Pointer tubeOp = TubeOpType::New();
 
   tubeOp->SetInputImage( im );
   tubeOp->SetRadiusInObjectSpace( 2.0 );
 
-  typedef itk::SpatialObjectReader<>                   ReaderType;
-  typedef itk::SpatialObject<>::ChildrenListType       ObjectListType;
-  typedef itk::GroupSpatialObject<>                    GroupType;
-  typedef itk::TubeSpatialObject<>                     TubeType;
-  typedef TubeType::TubePointListType                  TubePointListType;
-  typedef TubeType::TubePointType                      TubePointType;
+  using ReaderType = itk::SpatialObjectReader<>;
+  using ObjectListType = itk::SpatialObject<>::ChildrenListType;
+  using GroupType = itk::GroupSpatialObject<>;
+  using TubeType = itk::TubeSpatialObject<>;
+  using TubePointListType = TubeType::TubePointListType;
+  using TubePointType = TubeType::TubePointType;
 
   ReaderType::Pointer reader = ReaderType::New();
   reader->SetFileName( argv[2] );

--- a/test/Segmentation/tubeSegmentationPrintTest.cxx
+++ b/test/Segmentation/tubeSegmentationPrintTest.cxx
@@ -31,8 +31,8 @@ limitations under the License.
 int tubeSegmentationPrintTest( int itkNotUsed( argc ),
   char * itkNotUsed( argv )[] )
 {
-  typedef itk::Image< float, 2 >         ImageType;
-  typedef itk::Image< unsigned char, 2 > CharImageType;
+  using ImageType = itk::Image< float, 2 >;
+  using CharImageType = itk::Image< unsigned char, 2 >;
 
   itk::tube::PDFSegmenterParzen< ImageType, ImageType >::Pointer
     pdfSegmenterParzen = itk::tube::PDFSegmenterParzen< ImageType,

--- a/wasm/crop-image.cxx
+++ b/wasm/crop-image.cxx
@@ -68,7 +68,7 @@ public:
 
     const unsigned int Dimension = inputVolume.Get()->GetImageDimension();
 
-    typedef tube::CropImage< ImageType, ImageType > CropFilterType;
+    using CropFilterType = tube::CropImage< ImageType, ImageType >;
     typename CropFilterType::Pointer cropFilter = CropFilterType::New();
 
     cropFilter->SetInput( inputVolume.Get() );


### PR DESCRIPTION
Prefer C++11 type alias over typedef.

Follows the ITK convention adopted in:
https://review.source.kitware.com/%23/c/23103/

Changes done using the script contributed in:
https://github.com/InsightSoftwareConsortium/ITK/pull/160/commits/2c5d8d08fa468a9caf4f6616f027687880c684f2