### PR TITLE
STYLE: Use `hxx` extension for template class files consistently

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -17,7 +17,6 @@ configure        crlf=input
 *.h              whitespace=tab-in-indent,no-lf-at-eof  hooks.style=KWStyle,uncrustify
 *.cxx            whitespace=tab-in-indent,no-lf-at-eof  hooks.style=KWStyle,uncrustify
 *.hxx            whitespace=tab-in-indent,no-lf-at-eof  hooks.style=KWStyle,uncrustify
-*.txx            whitespace=tab-in-indent,no-lf-at-eof  hooks.style=KWStyle,uncrustify
 *.txt            whitespace=tab-in-indent,no-lf-at-eof
 *.cmake          whitespace=tab-in-indent,no-lf-at-eof
 

--- a/src/Filtering.cmake
+++ b/src/Filtering.cmake
@@ -65,7 +65,7 @@ set( TubeTK_Filtering_H_Files
   Filtering/tubeTubeMathFilters.h )
 
 set( TubeTK_Filtering_HXX_Files
-  Filtering/itkGeneralizedDistanceTransformImageFilter.txx
+  Filtering/itkGeneralizedDistanceTransformImageFilter.hxx
   Filtering/itkImageRegionSplitter.hxx
   Filtering/itktubeAnisotropicCoherenceEnhancingDiffusionImageFilter.hxx
   Filtering/itktubeAnisotropicDiffusionTensorFunction.hxx

--- a/src/Filtering/itkGeneralizedDistanceTransformImageFilter.h
+++ b/src/Filtering/itkGeneralizedDistanceTransformImageFilter.h
@@ -329,7 +329,7 @@ private:
 
 
 #ifndef ITK_MANUAL_INSTANTIATION
-#include "itkGeneralizedDistanceTransformImageFilter.txx"
+#include "itkGeneralizedDistanceTransformImageFilter.hxx"
 #endif
 
 #endif

--- a/src/Filtering/itkGeneralizedDistanceTransformImageFilter.hxx
+++ b/src/Filtering/itkGeneralizedDistanceTransformImageFilter.hxx
@@ -20,8 +20,8 @@ limitations under the License.
 
 =========================================================================*/
 
-#ifndef __itkGeneralizedDistanceTransformImageFilter_txx
-#define __itkGeneralizedDistanceTransformImageFilter_txx
+#ifndef itkGeneralizedDistanceTransformImageFilter_hxx
+#define itkGeneralizedDistanceTransformImageFilter_hxx
 
 #include <limits>
 


### PR DESCRIPTION
Use the `hxx` extension for template class files consistently: change the `txx` extension to `hxx`.

Follows the change in ITK:
https://github.com/InsightSoftwareConsortium/ITK/commit/13f99f81510fd76b0409b98dac6a4670436e007a

Filename extensions changed using the command:
```
find . -type f -name "*.txx" -exec bash -c 'git mv "$0" "${0%.txx}.hxx"' {} \;
```

Then made changes manually to the header file, `.gitattributes` and `Filtering.cmake` files.