### PR TITLE
ENH: Increase test timeout values to avoid failure reports

### DIFF
--- a/test/Filtering/CMakeLists.txt
+++ b/test/Filtering/CMakeLists.txt
@@ -120,7 +120,7 @@ itk_add_test(
       ${ITK_TEST_OUTPUT_DIR}/itktubeRidgeFFTFilterTest1_Curvature.mha
       ${ITK_TEST_OUTPUT_DIR}/itktubeRidgeFFTFilterTest1_Levelness.mha )
 set_tests_properties(itktubeRidgeFFTFilterTest1
-  PROPERTIES TIMEOUT 10)
+  PROPERTIES TIMEOUT 12)
 
 add_test( NAME itktubeSheetnessMeasureImageFilterTest
   COMMAND tubeFilteringTestDriver

--- a/test/Numerics/CMakeLists.txt
+++ b/test/Numerics/CMakeLists.txt
@@ -252,7 +252,7 @@ itk_add_test(
       ${ITK_TEST_OUTPUT_DIR}/itktubeNJetBasisFeatureVectorGeneratorTest_basis
       ${ITK_TEST_OUTPUT_DIR}/itktubeNJetBasisFeatureVectorGeneratorTest_feature )
 set_tests_properties(itktubeNJetBasisFeatureVectorGeneratorTest
-  PROPERTIES TIMEOUT 10)
+  PROPERTIES TIMEOUT 12)
 
 itk_add_test(
   NAME itktubeSingleValuedCostFunctionImageSourceTest


### PR DESCRIPTION
Increase test timeout values to avoid failure reports: increase them to 12 s from the current 10 s.
- `itktubeNJetBasisFeatureVectorGeneratorTest` has been timing out consistently at slightly over 10 s, e.g. https://open.cdash.org/viewTest.php?onlyfailed&buildid=10257878
- `itktubeRidgeFFTFilterTest1` has failed at least once at running below 10 s, e.g. https://open.cdash.org/tests/1944319150