### PR TITLE
Update override and virtual function designations."

### DIFF
--- a/.github/workflows/clang-format-linter.yml
+++ b/.github/workflows/clang-format-linter.yml
@@ -10,5 +10,3 @@ jobs:
     - uses: actions/checkout@v4
 
     - uses: InsightSoftwareConsortium/ITKClangFormatLinterAction@master
-       with:
-         itk-branch: master

--- a/include/itkTubeTK_fake_library_src.h
+++ b/include/itkTubeTK_fake_library_src.h
@@ -54,7 +54,8 @@ namespace itk
 namespace tube
 {
 
-int never_call_this_function(int multiplier)
+int
+never_call_this_function(int multiplier)
 {
   // silly function just to prevent having an empty file compiled.
   return 1010 * multiplier;

--- a/src/Common/tubeMacro.h
+++ b/src/Common/tubeMacro.h
@@ -114,7 +114,7 @@ limitations under the License.
 
 /** Return the name of a class. */
 #define tubeTypeMacro(classname) \
-  virtual const char * GetNameOfClass(void) const override { return #classname; }
+  const char * GetNameOfClass(void) const override { return #classname; }
 
 /** Return the name of a class. */
 #define tubeTypeMacroNoOverride(classname) \

--- a/src/Filtering/itktubeAnisotropicCoherenceEnhancingDiffusionImageFilter.h
+++ b/src/Filtering/itktubeAnisotropicCoherenceEnhancingDiffusionImageFilter.h
@@ -135,7 +135,7 @@ protected:
   PrintSelf(std::ostream & os, Indent indent) const override;
 
   /** Update diffusion tensor image */
-  void virtual UpdateDiffusionTensorImage(void) override;
+  void UpdateDiffusionTensorImage(void) override;
 
 private:
   // purposely not implemented

--- a/src/Filtering/itktubeAnisotropicCoherenceEnhancingDiffusionImageFilter.h
+++ b/src/Filtering/itktubeAnisotropicCoherenceEnhancingDiffusionImageFilter.h
@@ -135,7 +135,8 @@ protected:
   PrintSelf(std::ostream & os, Indent indent) const override;
 
   /** Update diffusion tensor image */
-  void UpdateDiffusionTensorImage(void) override;
+  void
+  UpdateDiffusionTensorImage(void) override;
 
 private:
   // purposely not implemented

--- a/src/Filtering/itktubeAnisotropicDiffusionTensorFunction.h
+++ b/src/Filtering/itktubeAnisotropicDiffusionTensorFunction.h
@@ -92,8 +92,7 @@ public:
   using ScalarDerivativeImageRegionType = ImageRegionIterator<ScalarDerivativeImageType>;
 
   /** Tensor derivative type alias. */
-  using TensorDerivativeType =
-    itk::Matrix<ScalarValueType, Self::ImageDimension, Self::ImageDimension>;
+  using TensorDerivativeType = itk::Matrix<ScalarValueType, Self::ImageDimension, Self::ImageDimension>;
   using TensorDerivativeImageType = itk::Image<TensorDerivativeType, 3>;
   using TensorDerivativeImageRegionType = ImageRegionIterator<TensorDerivativeImageType>;
 

--- a/src/Filtering/itktubeAnisotropicEdgeEnhancementDiffusionImageFilter.h
+++ b/src/Filtering/itktubeAnisotropicEdgeEnhancementDiffusionImageFilter.h
@@ -135,7 +135,7 @@ protected:
   PrintSelf(std::ostream & os, Indent indent) const override;
 
   /** Update diffusion tensor image */
-  void virtual UpdateDiffusionTensorImage(void) override;
+  void UpdateDiffusionTensorImage(void) override;
 
 private:
   // purposely not implemented

--- a/src/Filtering/itktubeAnisotropicEdgeEnhancementDiffusionImageFilter.h
+++ b/src/Filtering/itktubeAnisotropicEdgeEnhancementDiffusionImageFilter.h
@@ -135,7 +135,8 @@ protected:
   PrintSelf(std::ostream & os, Indent indent) const override;
 
   /** Update diffusion tensor image */
-  void UpdateDiffusionTensorImage(void) override;
+  void
+  UpdateDiffusionTensorImage(void) override;
 
 private:
   // purposely not implemented

--- a/src/Filtering/itktubeAnisotropicHybridDiffusionImageFilter.h
+++ b/src/Filtering/itktubeAnisotropicHybridDiffusionImageFilter.h
@@ -142,7 +142,8 @@ protected:
   PrintSelf(std::ostream & os, Indent indent) const override;
 
   /** Update diffusion tensor image */
-  void UpdateDiffusionTensorImage(void) override;
+  void
+  UpdateDiffusionTensorImage(void) override;
 
 private:
   // purposely not implemented

--- a/src/Filtering/itktubeAnisotropicHybridDiffusionImageFilter.h
+++ b/src/Filtering/itktubeAnisotropicHybridDiffusionImageFilter.h
@@ -142,7 +142,7 @@ protected:
   PrintSelf(std::ostream & os, Indent indent) const override;
 
   /** Update diffusion tensor image */
-  void virtual UpdateDiffusionTensorImage(void) override;
+  void UpdateDiffusionTensorImage(void) override;
 
 private:
   // purposely not implemented

--- a/src/Filtering/itktubeMinimumSpanningTreeVesselConnectivityFilter.hxx
+++ b/src/Filtering/itktubeMinimumSpanningTreeVesselConnectivityFilter.hxx
@@ -340,7 +340,8 @@ MinimumSpanningTreeVesselConnectivityFilter<ObjectDimension>::RunMinimumSpanning
 
   rootTube->GetModifiableObjectToParentTransform()->SetFixedParameters(
     inputRootTube->GetObjectToParentTransform()->GetFixedParameters());
-  rootTube->GetModifiableObjectToParentTransform()->SetParameters(inputRootTube->GetObjectToParentTransform()->GetParameters());
+  rootTube->GetModifiableObjectToParentTransform()->SetParameters(
+    inputRootTube->GetObjectToParentTransform()->GetParameters());
   rootTube->Update();
 
   rootTube->ComputeTangentsAndNormals();

--- a/src/Filtering/itktubeTubeSpatialObjectToDensityImageFilter.h
+++ b/src/Filtering/itktubeTubeSpatialObjectToDensityImageFilter.h
@@ -80,8 +80,7 @@ public:
   using SizeType = typename DensityImageType::SizeType;
   using SpacingType = typename DensityImageType::SpacingType;
 
-  using TubetoImageFilterType =
-    TubeSpatialObjectToImageFilter<Self::ImageDimension, DensityImageType>;
+  using TubetoImageFilterType = TubeSpatialObjectToImageFilter<Self::ImageDimension, DensityImageType>;
 
   using DanielssonFilterType = DanielssonDistanceMapImageFilter<DensityImageType, DensityImageType>;
 

--- a/src/MetaIO/itktubeMetaClassPDF.cxx
+++ b/src/MetaIO/itktubeMetaClassPDF.cxx
@@ -169,7 +169,7 @@ MetaClassPDF::PrintInfo(void) const
   if (!m_ObjectPDFWeight.empty())
   {
     std::cout << m_ObjectPDFWeight[0];
-    for (int i = 1; i < m_ObjectPDFWeight.size(); i++)
+    for (unsigned long i = 1; i < m_ObjectPDFWeight.size(); i++)
     {
       std::cout << ", " << m_ObjectPDFWeight[i];
     }

--- a/src/MetaIO/itktubeMetaClassPDF.h
+++ b/src/MetaIO/itktubeMetaClassPDF.h
@@ -85,16 +85,16 @@ public:
                double       _binSizeZ,
                float *      _elementData = NULL);
 
-  ~MetaClassPDF(void);
+  ~MetaClassPDF(void) override;
 
-  virtual void
-  PrintInfo(void) const;
+  void
+  PrintInfo(void) const override;
 
-  virtual void
-  CopyInfo(const MetaObject * _pdf);
+  void
+  CopyInfo(const MetaObject * _pdf) override;
 
-  virtual void
-  Clear(void);
+  void
+  Clear(void) override;
 
   virtual bool
   InitializeEssential(unsigned int             _nFeatures,
@@ -185,8 +185,8 @@ public:
   virtual bool
   CanRead(const char * _headerName = NULL) const;
 
-  virtual bool
-  Read(const char * _headerName = NULL);
+  bool
+  Read(const char * _headerName = NULL) override;
 
   virtual bool
   CanReadStream(METAIO_STREAM::ifstream * _stream) const;
@@ -194,21 +194,21 @@ public:
   virtual bool
   ReadStream(METAIO_STREAM::ifstream * _stream);
 
-  virtual bool
-  Write(const char * _headerName = NULL);
+  bool
+  Write(const char * _headerName = NULL) override;
 
   virtual bool
   WriteStream(METAIO_STREAM::ofstream * _stream);
 
 protected:
-  virtual void
-  M_SetupReadFields(void);
+  void
+  M_SetupReadFields(void) override;
 
-  virtual void
-  M_SetupWriteFields(void);
+  void
+  M_SetupWriteFields(void) override;
 
-  virtual bool
-  M_Read(void);
+  bool
+  M_Read(void) override;
 
   VectorIntType    m_ObjectId;
   VectorDoubleType m_ObjectPDFWeight;

--- a/src/MetaIO/itktubeMetaLDA.h
+++ b/src/MetaIO/itktubeMetaLDA.h
@@ -72,17 +72,17 @@ public:
           const ValueListType & _outputWhitenMeans,
           const ValueListType & _outputWhitenStdDevs);
 
-  ~MetaLDA(void);
+  ~MetaLDA(void) override;
 
-  virtual void
-  PrintInfo(void) const;
+  void
+  PrintInfo(void) const override;
 
   using MetaForm::CopyInfo;
   virtual void
   CopyInfo(const MetaLDA & lda);
 
-  virtual void
-  Clear(void);
+  void
+  Clear(void) override;
 
   bool
   InitializeEssential(unsigned int          _numberOfPCABasisToUseAsFeatures,
@@ -157,13 +157,13 @@ protected:
   M_Destroy(void);
 
   void
-  M_SetupReadFields(void);
+  M_SetupReadFields(void) override;
 
   void
-  M_SetupWriteFields(void);
+  M_SetupWriteFields(void) override;
 
   bool
-  M_Read(void);
+  M_Read(void) override;
 
   unsigned int m_NumberOfPCABasisToUseAsFeatures;
 

--- a/src/MetaIO/itktubeMetaNJetLDA.h
+++ b/src/MetaIO/itktubeMetaNJetLDA.h
@@ -77,17 +77,17 @@ public:
               const ValueListType &  _outputWhitenMeans,
               const ValueListType &  _outputWhitenStdDevs);
 
-  ~MetaNJetLDA(void);
+  ~MetaNJetLDA(void) override;
 
-  virtual void
-  PrintInfo(void) const;
+  void
+  PrintInfo(void) const override;
 
   using MetaLDA::CopyInfo;
   virtual void
   CopyInfo(const MetaNJetLDA & _lda);
 
-  virtual void
-  Clear(void);
+  void
+  Clear(void) override;
 
   bool
   InitializeEssential(const NJetScalesType & _zeroScales,
@@ -128,36 +128,36 @@ public:
   const NJetScalesType &
   GetRidgeScales(void) const;
 
-  virtual bool
-  CanRead(const char * headerName = NULL) const;
+  bool
+  CanRead(const char * headerName = NULL) const override;
 
-  virtual bool
-  Read(const char * headerName = NULL);
+  bool
+  Read(const char * headerName = NULL) override;
 
-  virtual bool
-  CanReadStream(METAIO_STREAM::ifstream * stream) const;
+  bool
+  CanReadStream(METAIO_STREAM::ifstream * stream) const override;
 
-  virtual bool
-  ReadStream(METAIO_STREAM::ifstream * stream);
+  bool
+  ReadStream(METAIO_STREAM::ifstream * stream) override;
 
-  virtual bool
-  Write(const char * headerName = NULL);
+  bool
+  Write(const char * headerName = NULL) override;
 
-  virtual bool
-  WriteStream(METAIO_STREAM::ofstream * stream);
+  bool
+  WriteStream(METAIO_STREAM::ofstream * stream) override;
 
 protected:
   void
   M_Destroy(void);
 
   void
-  M_SetupReadFields(void);
+  M_SetupReadFields(void) override;
 
   void
-  M_SetupWriteFields(void);
+  M_SetupWriteFields(void) override;
 
   bool
-  M_Read(void);
+  M_Read(void) override;
 
   NJetScalesType m_ZeroScales;
   NJetScalesType m_FirstScales;

--- a/src/MetaIO/itktubeMetaRidgeSeed.h
+++ b/src/MetaIO/itktubeMetaRidgeSeed.h
@@ -77,17 +77,17 @@ public:
                 const ValueListType &       _outputWhitenStdDevs,
                 const std::string &         _pdfFileName);
 
-  ~MetaRidgeSeed(void);
+  ~MetaRidgeSeed(void) override;
 
-  virtual void
-  PrintInfo(void) const;
+  void
+  PrintInfo(void) const override;
 
   using MetaLDA::CopyInfo;
   virtual void
   CopyInfo(const MetaRidgeSeed & _lda);
 
-  virtual void
-  Clear(void);
+  void
+  Clear(void) override;
 
   bool
   InitializeEssential(const RidgeSeedScalesType & _ridgeScales,
@@ -146,36 +146,36 @@ public:
   bool
   GetSkeletonize(void) const;
 
-  virtual bool
-  CanRead(const char * _headerName = NULL) const;
+  bool
+  CanRead(const char * _headerName = NULL) const override;
 
-  virtual bool
-  Read(const char * _headerName = NULL);
+  bool
+  Read(const char * _headerName = NULL) override;
 
-  virtual bool
-  CanReadStream(METAIO_STREAM::ifstream * _stream) const;
+  bool
+  CanReadStream(METAIO_STREAM::ifstream * _stream) const override;
 
-  virtual bool
-  ReadStream(METAIO_STREAM::ifstream * _stream);
+  bool
+  ReadStream(METAIO_STREAM::ifstream * _stream) override;
 
-  virtual bool
-  Write(const char * _headName = NULL);
+  bool
+  Write(const char * _headName = NULL) override;
 
-  virtual bool
-  WriteStream(METAIO_STREAM::ofstream * _stream);
+  bool
+  WriteStream(METAIO_STREAM::ofstream * _stream) override;
 
 protected:
   void
   M_Destroy(void);
 
   void
-  M_SetupReadFields(void);
+  M_SetupReadFields(void) override;
 
   void
-  M_SetupWriteFields(void);
+  M_SetupWriteFields(void) override;
 
   bool
-  M_Read(void);
+  M_Read(void) override;
 
   bool m_UseIntensityOnly;
   bool m_UseFeatureMath;

--- a/src/MetaIO/itktubeMetaTubeExtractor.h
+++ b/src/MetaIO/itktubeMetaTubeExtractor.h
@@ -64,10 +64,10 @@ public:
 
   MetaTubeExtractor(const MetaTubeExtractor & _metaTubeExtractor);
 
-  ~MetaTubeExtractor(void);
+  ~MetaTubeExtractor(void) override;
 
-  virtual void
-  PrintInfo(void) const;
+  void
+  PrintInfo(void) const override;
 
   void
   SetGeneralProperties(double _dataMin, double _dataMax, const VectorType & _tubeColor);
@@ -153,8 +153,8 @@ public:
   virtual void
   CopyInfo(const MetaTubeExtractor & _tubeExtractor);
 
-  virtual void
-  Clear(void);
+  void
+  Clear(void) override;
 
   bool
   InitializeEssential(void);
@@ -180,13 +180,13 @@ protected:
   M_Destroy(void);
 
   void
-  M_SetupReadFields(void);
+  M_SetupReadFields(void) override;
 
   void
-  M_SetupWriteFields(void);
+  M_SetupWriteFields(void) override;
 
   bool
-  M_Read(void);
+  M_Read(void) override;
 
   double     m_DataMin;
   double     m_DataMax;

--- a/src/Numerics/tubeBrentOptimizer1D.h
+++ b/src/Numerics/tubeBrentOptimizer1D.h
@@ -56,7 +56,7 @@ public:
   BrentOptimizer1D(ValueFunctionType::Pointer funcVal, DerivativeFunctionType::Pointer funcDeriv);
 
   /** Destructor. */
-  ~BrentOptimizer1D(void);
+  ~BrentOptimizer1D(void) override;
 
   tubeGetMacro(Epsilon, double);
 

--- a/src/Numerics/tubeGoldenMeanOptimizer1D.h
+++ b/src/Numerics/tubeGoldenMeanOptimizer1D.h
@@ -55,7 +55,7 @@ public:
   GoldenMeanOptimizer1D(ValueFunctionType::Pointer funcVal);
 
   /** Destructor. */
-  ~GoldenMeanOptimizer1D(void);
+  ~GoldenMeanOptimizer1D(void) override;
 
   void
   Use(ValueFunctionType::Pointer funcVal);

--- a/src/Numerics/tubeOptimizer1D.h
+++ b/src/Numerics/tubeOptimizer1D.h
@@ -69,7 +69,7 @@ public:
   Optimizer1D(ValueFunctionType::Pointer funcVal, DerivativeFunctionType::Pointer funcDeriv);
 
   /** Destructor. */
-  virtual ~Optimizer1D(void);
+  ~Optimizer1D(void) override;
 
   tubeGetMacro(MaxIterations, unsigned int);
 

--- a/src/Numerics/tubeOptimizerND.h
+++ b/src/Numerics/tubeOptimizerND.h
@@ -63,7 +63,7 @@ public:
               Optimizer1D::Pointer            optimizer1D);
 
   /** Destructor. */
-  virtual ~OptimizerND(void);
+  ~OptimizerND(void) override;
 
   tubeGetMacro(MaxIterations, unsigned int);
 

--- a/src/Numerics/tubeParabolicFitOptimizer1D.h
+++ b/src/Numerics/tubeParabolicFitOptimizer1D.h
@@ -55,7 +55,7 @@ public:
   ParabolicFitOptimizer1D(ValueFunctionType::Pointer funcVal);
 
   /** Destructor. */
-  ~ParabolicFitOptimizer1D(void);
+  ~ParabolicFitOptimizer1D(void) override;
 
   void
   Use(ValueFunctionType::Pointer funcVal);

--- a/src/Numerics/tubeSpline1D.h
+++ b/src/Numerics/tubeSpline1D.h
@@ -77,7 +77,7 @@ public:
   Spline1D(ValueFunctionType::Pointer funcVal, Optimizer1D::Pointer optimizer1D);
 
   /** Destructor. */
-  virtual ~Spline1D(void);
+  ~Spline1D(void) override;
 
   /** Returns the characteristics of spline evaluations near data bounds
    * ( xMin and xMax ). If true, values beyond edges ( xMin and xMax ) are set

--- a/src/Numerics/tubeSplineApproximation1D.h
+++ b/src/Numerics/tubeSplineApproximation1D.h
@@ -56,7 +56,7 @@ public:
   SplineApproximation1D(ValueFunctionType::Pointer funcVal, Optimizer1D::Pointer optimizer1D);
 
   /** Destructor. */
-  virtual ~SplineApproximation1D(void);
+  ~SplineApproximation1D(void) override;
 
   double
   DataValue(const VectorType & y, double x) override;

--- a/src/Numerics/tubeSplineND.h
+++ b/src/Numerics/tubeSplineND.h
@@ -84,7 +84,7 @@ public:
            Optimizer1D::Pointer       optimizer1D);
 
   /** Destructor. */
-  virtual ~SplineND(void);
+  ~SplineND(void) override;
 
   /** Returns the characteristics of spline evaluations near data bounds
    *   ( xMin and xMax ). If true, values beyond edges ( xMin and xMax ) are

--- a/src/ObjectDocuments/itktubeBlobSpatialObjectDocument.h
+++ b/src/ObjectDocuments/itktubeBlobSpatialObjectDocument.h
@@ -58,7 +58,7 @@ protected:
   BlobSpatialObjectDocument(void) { this->SetObjectType("Blob"); }
 
   /** Destructor. */
-  virtual ~BlobSpatialObjectDocument(void) {}
+  ~BlobSpatialObjectDocument(void) override {}
 
 private:
   // Copy constructor not implemented.

--- a/src/ObjectDocuments/itktubeDocument.h
+++ b/src/ObjectDocuments/itktubeDocument.h
@@ -62,18 +62,18 @@ public:
   itkSetStringMacro(Comment);
 
   /** Copy the information from the specified data object. */
-  virtual void
+  void
   CopyInformation(const DataObject * itkNotUsed(data)) override
   {}
 
   /** Update the output information. */
-  virtual void
+  void
   UpdateOutputInformation(void) override
   {}
 
   /** Verify that the requested region is within the largest possible region,
       but note that this object does not use region information. */
-  virtual bool
+  bool
   VerifyRequestedRegion(void) override
   {
     return true;
@@ -81,7 +81,7 @@ public:
 
   /** Determine whether the requested region is outside of the buffered region,
       but note that this object does not use region information. */
-  virtual bool
+  bool
   RequestedRegionIsOutsideOfTheBufferedRegion(void) override
   {
     return false;
@@ -89,13 +89,13 @@ public:
 
   /** Set the requested region to match the requested region of the specified
       data object, but note that this object does not use region information. */
-  virtual void
+  void
   SetRequestedRegion(const DataObject * itkNotUsed(data)) override
   {}
 
   /** Set the requested region to the largest possible region, but note that
       this object does not use region information. */
-  virtual void
+  void
   SetRequestedRegionToLargestPossibleRegion(void) override
   {}
 
@@ -104,10 +104,10 @@ protected:
   Document(void) {}
 
   /** Destructor. */
-  virtual ~Document(void) {}
+  ~Document(void) override {}
 
   /** Print information about the object. */
-  virtual void
+  void
   PrintSelf(std::ostream & os, Indent indent) const override
   {
     this->Superclass::PrintSelf(os, indent);

--- a/src/ObjectDocuments/itktubeImageDocument.h
+++ b/src/ObjectDocuments/itktubeImageDocument.h
@@ -57,7 +57,7 @@ protected:
   ImageDocument(void) { this->SetObjectType("Image"); }
 
   /** Destructor. */
-  virtual ~ImageDocument(void) {}
+  ~ImageDocument(void) override {}
 
 private:
   // Copy constructor not implemented.

--- a/src/ObjectDocuments/itktubeObjectDocument.h
+++ b/src/ObjectDocuments/itktubeObjectDocument.h
@@ -89,13 +89,13 @@ protected:
   ObjectDocument(void) { this->SetObjectType("Object"); }
 
   /** Destructor. */
-  virtual ~ObjectDocument(void) {}
+  ~ObjectDocument(void) override {}
 
   /** Set the object type. */
   itkSetMacro(ObjectType, std::string);
 
   /** Print information about the object. */
-  virtual void
+  void
   PrintSelf(std::ostream & os, Indent indent) const override
   {
     Superclass::PrintSelf(os, indent);

--- a/src/ObjectDocuments/itktubeSpatialObjectDocument.h
+++ b/src/ObjectDocuments/itktubeSpatialObjectDocument.h
@@ -58,7 +58,7 @@ protected:
   SpatialObjectDocument(void) { this->SetObjectType("SpatialObject"); }
 
   /** Destructor. */
-  virtual ~SpatialObjectDocument(void) {}
+  ~SpatialObjectDocument(void) override {}
 
 private:
   // Copy constructor not implemented.

--- a/src/ObjectDocuments/tubeMetaDocument.h
+++ b/src/ObjectDocuments/tubeMetaDocument.h
@@ -52,7 +52,7 @@ public:
   MetaDocument(void);
 
   /**  Destructor. */
-  virtual ~MetaDocument(void);
+  ~MetaDocument(void) override;
 
   /** Return the name of this class. */
   tubeTypeMacro(MetaDocument);
@@ -119,7 +119,7 @@ protected:
   WriteFields(void);
 
   /** Print information about this object. */
-  virtual void
+  void
   PrintSelf(std::ostream & os, Indent indent) const override;
 
   std::ifstream m_ReadStream;

--- a/src/ObjectDocuments/tubeMetaObjectDocument.h
+++ b/src/ObjectDocuments/tubeMetaObjectDocument.h
@@ -55,7 +55,7 @@ public:
   MetaObjectDocument(void);
 
   /** Destructor. */
-  virtual ~MetaObjectDocument(void);
+  ~MetaObjectDocument(void) override;
 
   /** Return the name of this class. */
   tubeTypeMacro(MetaObjectDocument);
@@ -79,7 +79,7 @@ public:
   AddObjectDocument(ObjectDocumentType::Pointer objectDocument);
 
   /** Clear all the information. */
-  virtual void
+  void
   Clear(void) override;
 
 protected:
@@ -90,7 +90,7 @@ protected:
   tubeSetMacro(NumberOfObjectDocuments, int);
 
   /** Read the fields. */
-  virtual bool
+  bool
   ReadFields(void) override;
 
   /** Initialize the read fields for objects. */
@@ -102,19 +102,19 @@ protected:
   SetupObjectWriteFields(unsigned int index);
 
   /** Initialize the read fields. */
-  virtual void
+  void
   SetupReadFields(void) override;
 
   /** Initialize the write fields. */
-  virtual void
+  void
   SetupWriteFields(void) override;
 
   /** Write the fields. */
-  virtual bool
+  bool
   WriteFields(void) override;
 
   /** Print information about this object. */
-  virtual void
+  void
   PrintSelf(std::ostream & os, Indent indent) const override;
 
 private:

--- a/src/ObjectDocuments/tubeOptionList.h
+++ b/src/ObjectDocuments/tubeOptionList.h
@@ -90,7 +90,7 @@ public:
   OptionList(void);
 
   /** Destructor. */
-  virtual ~OptionList(void);
+  ~OptionList(void) override;
 
   /** Return the name of this class. */
   tubeTypeMacro(OptionList);
@@ -166,7 +166,7 @@ protected:
   GetOptionMap(void);
 
   /** Print information about this object. */
-  virtual void
+  void
   PrintSelf(std::ostream & os, Indent indent) const override;
 
 private:

--- a/src/Registration/itkImageToImageRegistrationMethod.h
+++ b/src/Registration/itkImageToImageRegistrationMethod.h
@@ -59,8 +59,7 @@ public:
   //
   static constexpr unsigned int ImageDimension = TImage::ImageDimension;
 
-  using TransformType =
-    Transform<double, Self::ImageDimension, Self::ImageDimension>;
+  using TransformType = Transform<double, Self::ImageDimension, Self::ImageDimension>;
 
   using TransformOutputType = DataObjectDecorator<TransformType>;
 

--- a/src/Registration/itkRigidImageToImageRegistrationMethod.h
+++ b/src/Registration/itkRigidImageToImageRegistrationMethod.h
@@ -51,8 +51,7 @@ public:
   // Overrides the superclass' TransformType typedef
   // We must use MatrixOffsetTransformBase since no itk rigid transform is
   //   templated over ImageDimension.
-  using RigidTransformType =
-    MatrixOffsetTransformBase<double, Self::ImageDimension, Self::ImageDimension>;
+  using RigidTransformType = MatrixOffsetTransformBase<double, Self::ImageDimension, Self::ImageDimension>;
   using TransformType = RigidTransformType;
 
   //

--- a/src/Registration/itktubeRigidSpatialObjectToImageRegistrationMethod.h
+++ b/src/Registration/itktubeRigidSpatialObjectToImageRegistrationMethod.h
@@ -60,8 +60,7 @@ public:
   // Overrides the superclass' TransformType typedef
   // We must use MatrixOffsetTransformBase since no itk rigid transform is
   //   templated over ImageDimension.
-  using RigidTransformType =
-    MatrixOffsetTransformBase<double, Self::ImageDimension, Self::ImageDimension>;
+  using RigidTransformType = MatrixOffsetTransformBase<double, Self::ImageDimension, Self::ImageDimension>;
   using TransformType = RigidTransformType;
 
   //


### PR DESCRIPTION
- **ENH: Revert Uses with "itk-branch: master" clang-format linter"**
- **STYLE: Use override statements for C++11**
- **ENH: Use matching types for comparision.**
- **STYLE: Enforce ITK clang-format style.**
